### PR TITLE
Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
this makes it easy to have a basic code style in place without configuring individual editors: http://editorconfig.org

my PyCharm and your [Emacs](https://github.com/editorconfig/editorconfig-emacs#readme) both support it (Emacs with that plugin). if you don’t want to install the plugin, it’s at least useful for me when i switch machines (or future contributors)