### PR TITLE
np.int64 won't work on 32-bit numpy. Use the more general np.integer instead.

### DIFF
--- a/scanpy/data_structs/data_graph.py
+++ b/scanpy/data_structs/data_graph.py
@@ -102,7 +102,7 @@ class OnFlySymMatrix():
         self.restrict_array = restrict_array  # restrict the array to a subset
 
     def __getitem__(self, index):
-        if isinstance(index, int) or isinstance(index, np.int64):
+        if isinstance(index, int) or isinstance(index, np.integer):
             if self.restrict_array is None:
                 glob_index = index
             else:


### PR DESCRIPTION
In my test, even we check `if isinstance(index, int) or isinstance(index, np.int64) or isinstance(index, np.int32):`, it still doesn't work on my 32-bit numpy and an _TypeErorr_ will be raised. Anyway, _isinstance(index, np.integer)_ works well and is a better choice.
Reference: [http://stackoverflow.com/questions/37726830/how-to-determine-if-a-number-is-any-type-of-int-core-or-numpy-signed-or-not](url)