### PR TITLE
Fix module path of download_progress and create dir correctly.

### DIFF
--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -612,8 +612,13 @@ def check_presence_download(filename, backup_url):
     """Check if file is present otherwise download."""
     import os
     if not os.path.exists(filename):
-        from ..readwrite import download_progress
-        os.makedirs(filename)
+        from .readwrite import download_progress
+        dr = os.path.dirname(filename)
+        try:
+            os.makedirs(dr)
+        except FileExistsError:
+            pass # ignore if dir already exists
+
         from urllib.request import urlretrieve
         urlretrieve(backup_url, filename, reporthook=download_progress)
 


### PR DESCRIPTION
`sc.datasets.paul15_raw()` fails with `attempted relative import beyond top-level package` error due to the wrong module path in `sc.utils.check_presence_download `. 

Simply run `sc.datasets.paul15_raw()` or `sc.datasets.paul15()` to reproduce.