### PR TITLE
Fix weight assignment in igraph constructor

### DIFF
--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -43,6 +43,8 @@ def get_igraph_from_adjacency(adjacency, directed=None):
     import igraph as ig
     sources, targets = adjacency.nonzero()
     weights = adjacency[sources, targets]
+    if isinstance(weights, np.matrix):
+        weights = weights.A1
     # if len(weights) > 0: weights = np.array(weights)
     # else:
     #     # hack for empty graph


### PR DESCRIPTION
`sc.utils.get_igraph_from_adjacency` does not assign edge weights correctly, because `adjacency[sources, targets]` is an np.matrix and python-igraph thinks that it's not iterable, so it broadcasts matrix to every edge:

```python
import scanpy.api as sc

adata = sc.datasets.paul15_raw()
adata = adata[:100]
sc.tl.draw_graph(adata)

g = sc.utils.get_igraph_from_adjacency(adata.uns['data_graph_norm_weights'])
g.es['weight'][:10]
```
Output:

```
[matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32),
 matrix([[0.05460853 , 0.022233006, 0.022029877, ..., 0.03527954 ,
          0.02314072 , 0.05000015 ]], dtype=float32)]
```

Accordingly, edge-weighted graph layouts are also not working. `sc.tl.draw_graph(adata, layout='fr', weights='weight')` call throws `ValueError: iterable must yield numbers.`

Actually I realized that when I try to stream a graph from scanpy to Gephi using `GephiGraphStreamer` class from igraph. Now, that works, too.

