### PR TITLE
Fix NoneType check in plotting/anndata.py

### DIFF
--- a/scanpy/plotting/anndata.py
+++ b/scanpy/plotting/anndata.py
@@ -514,7 +514,7 @@ def clustermap(
     >>> adata = sc.datasets.krumsiek11()
     >>> sc.pl.clustermap(adata, obs_keys='cell_type')
     """
-    if not isinstance(obs_keys, (str, None)):
+    if not isinstance(obs_keys, (str, type(None))):
         raise ValueError('Currently, only a single key is supported.')
     sanitize_anndata(adata)
     X = adata.raw.X if use_raw and adata.raw is not None else adata.X


### PR DESCRIPTION
`clustermap` raises an exception when an `obs_keys` argument is not provided, because None is not a type.