### PR TITLE
Update PyPI badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-|Docs| |PyPI| |Build Status|
+|PyPI| |Docs| |Build Status|
 
+.. |PyPI| image:: https://img.shields.io/pypi/v/scanpy.svg
+    :target: https://pypi.org/project/scanpy
 .. |Docs| image:: https://readthedocs.org/projects/scanpy/badge/?version=latest
    :target: https://scanpy.readthedocs.io
-.. |PyPI| image:: https://badge.fury.io/py/scanpy.svg
-    :target: https://pypi.python.org/pypi/scanpy
 .. |Build Status| image:: https://travis-ci.org/theislab/scanpy.svg?branch=master
    :target: https://travis-ci.org/theislab/scanpy
 ..


### PR DESCRIPTION
The new one is smaller, because it doesn’t say “package”. It’s also blue which shows it’s not a build status