### PR TITLE
Added intersphinx, easier types in docs

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -13,40 +13,40 @@ in ``sc.tl``, e.g.::
 
     sc.tl.louvain(adata, **tool_params)  # cluster cells using Louvain clustering
 
-where ``adata`` is an :class:`~scanpy.api.AnnData` object. Each of these calls adds annotation to an expression matrix *X*, which stores *n_obs* observations of *n_vars* gene expression variables. For each tool, there is at least one associated plotting function in ``sc.pl``, which retrieves and plots the added annotation::
+where ``adata`` is an :class:`~anndata.AnnData` object. Each of these calls adds annotation to an expression matrix *X*, which stores *n_obs* observations of *n_vars* gene expression variables. For each tool, there is at least one associated plotting function in ``sc.pl``, which retrieves and plots the added annotation::
 
     sc.pl.louvain(adata, **plotting_params)
 
 If you pass ``show=False``, a `matplotlib.Axes <https://matplotlib.org/api/axes_api.html>`_ instance is returned and you have all of matplotlib's detailed configuration possibilities.
 
-To facilitate writing memory-efficient pipelines, by default, Scanpy tools operate *inplace* on ``adata`` and return ``None`` - this also allows to easily transition to `out-of-memory pipelines <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`_. If you want to return a copy of the :class:`~scanpy.api.AnnData` object and leave the passed ``adata`` unchanged, pass ``copy=True``.
+To facilitate writing memory-efficient pipelines, by default, Scanpy tools operate *inplace* on ``adata`` and return ``None`` - this also allows to easily transition to `out-of-memory pipelines <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`_. If you want to return a copy of the :class:`~anndata.AnnData` object and leave the passed ``adata`` unchanged, pass ``copy=True``.
 
     
 AnnData
 ^^^^^^^
 
 Scanpy is based on `anndata <http://anndata.readthedocs.io>`_, which provides
-the :class:`~scanpy.api.AnnData` class.
+the :class:`~anndata.AnnData` class.
 
 .. raw:: html
 
     <img src="http://falexwolf.de/img/scanpy/anndata.svg" style="width: 300px">
 
-At the most basic level, an :class:`~scanpy.api.AnnData` object ``adata`` stores
+At the most basic level, an :class:`~anndata.AnnData` object ``adata`` stores
 a data matrix (``adata.X``), dataframe-like annotation of observations
 (``adata.obs``) and variables (``adata.var``) and unstructured dict-like
 annotation (``adata.uns``). Values can be retrieved and appended via
 ``adata.obs['key1']`` and ``adata.var['key2']``. Names of observations and
 variables can be accessed via ``adata.obs_names`` and ``adata.var_names``,
-respectively. :class:`~scanpy.api.AnnData` objects can be sliced like
+respectively. :class:`~anndata.AnnData` objects can be sliced like
 dataframes, for example, ``adata_subset = adata[:, list_of_gene_names]``.
 For more, see this `blog post <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`_.
          
-To read a data file to an :class:`~scanpy.api.AnnData` object, call::
+To read a data file to an :class:`~anndata.AnnData` object, call::
 
     adata = sc.read(filename)
 
-to initialize an :class:`~scanpy.api.AnnData` object. Possibly add further annotation using, e.g., ``pd.read_csv``::
+to initialize an :class:`~anndata.AnnData` object. Possibly add further annotation using, e.g., ``pd.read_csv``::
 
     import pandas as pd 
     anno = pd.read_csv(filename_sample_annotation)

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -111,8 +111,8 @@ Further changes are
 
 ... and through `anndata v0.5 <http://anndata.readthedocs.io>`_
 
-1. inform about duplicates in :class:`~scanpy.api.AnnData.var_names` and resolve them using :func:`~scanpy.api.AnnData.var_names_make_unique`
-2. by default, generate unique observation names in :func:`~scanpy.api.AnnData.concatenate`
+1. inform about duplicates in :class:`~anndata.AnnData.var_names` and resolve them using :func:`~anndata.AnnData.var_names_make_unique`
+2. by default, generate unique observation names in :func:`~anndata.AnnData.concatenate`
 3. automatically remove unused categories after slicing
 4. read/write `.loom` files using loompy 2
 
@@ -132,14 +132,14 @@ Further changes are
 
 ... and through `anndata v0.4 <http://anndata.readthedocs.io>`_
 
-1. towards a common file format for exchanging :class:`~scanpy.api.AnnData` with
+1. towards a common file format for exchanging :class:`~anndata.AnnData` with
    packages such as Seurat and SCDE by reading and writing `.loom
    <http://loompy.org>`_ files
-2. :class:`~scanpy.api.AnnData`
+2. :class:`~anndata.AnnData`
    provides scalability beyond dataset sizes that fit into memory: see this
    `blog post
    <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`_
-3. :class:`~scanpy.api.AnnData` has a :class:`~scanpy.api.AnnData.raw` attribute
+3. :class:`~anndata.AnnData` has a :class:`~anndata.AnnData.raw` attribute
    that simplifies storing the data matrix when you consider it "raw": see the
    `clustering tutorial
    <https://github.com/theislab/scanpy_usage/tree/master/170505_seurat>`_
@@ -152,8 +152,8 @@ Further changes are
 
 **November 16, 2017**: version 0.3
 
-1. :class:`~scanpy.api.AnnData` can be `concatenated <https://scanpy.readthedocs.io/en/latest/api/scanpy.api.AnnData.html>`_
-2. :class:`~scanpy.api.AnnData` is available as a `separate package <https://pypi.python.org/pypi/anndata/>`_
+1. :class:`~anndata.AnnData` can be `concatenated <https://scanpy.readthedocs.io/en/latest/api/anndata.AnnData.html>`_
+2. :class:`~anndata.AnnData` is available as a `separate package <https://pypi.python.org/pypi/anndata/>`_
 3. results of approximate graph abstraction (AGA) are `simplified <https://github.com/theislab/graph_abstraction>`_
 
 

--- a/docs/requires.txt
+++ b/docs/requires.txt
@@ -1,6 +1,4 @@
-# numpydoc 0.8.0 doesn't render parameters properly and formats attributes like parameters
-# we want neither of this
-numpydoc==0.7.0
+sphinx-autodoc-typehints
 # same as ../requires.txt, but omitting the c++ packages
 anndata>=0.5.8
 matplotlib>=2.2

--- a/scanpy/api/__init__.py
+++ b/scanpy/api/__init__.py
@@ -191,12 +191,7 @@ Read other formats using functions borrowed from `anndata
 Classes
 -------
 
-:class:`~scanpy.api.AnnData` is borrowed from `anndata <http://anndata.readthedocs.io>`_.
-
-.. autosummary::
-   :toctree: .
-
-   AnnData
+:class:`~anndata.AnnData` is from `anndata <http://anndata.readthedocs.io>`_.
 
 Represent data as a neighborhood structure, usually a knn graph.
 

--- a/scanpy/datasets/__init__.py
+++ b/scanpy/datasets/__init__.py
@@ -25,7 +25,7 @@ def blobs(n_variables=11, n_centers=5, cluster_std=1.0, n_observations=640):
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix containing a observation annotation 'blobs' that
         indicates cluster identity.
     """
@@ -69,7 +69,7 @@ def krumsiek11():
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     """
     filename = os.path.dirname(__file__) + '/krumsiek11.txt'
@@ -95,7 +95,7 @@ def moignard15():
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     """
     filename = 'data/moignard15/nbt.3154-S3.xlsx'
@@ -130,7 +130,7 @@ def paul15():
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     """
     logg.warn('In Scanpy 0.*, this returned logarithmized data. '
@@ -181,7 +181,7 @@ def toggleswitch():
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     """
     filename = os.path.dirname(__file__) + '/toggleswitch.txt'

--- a/scanpy/exporting.py
+++ b/scanpy/exporting.py
@@ -23,7 +23,7 @@ def spring_project(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix: `adata.uns['neighbors_distances']` needs to
         be present.
     project_dir : `str`

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -36,7 +36,7 @@ def neighbors(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     n_neighbors : `int`, optional (default: 15)
         The size of local neighborhood (in terms of number of neighboring data
@@ -499,7 +499,7 @@ class Neighbors():
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         An annotated data matrix.
 
     Attributes

--- a/scanpy/plotting/anndata.py
+++ b/scanpy/plotting/anndata.py
@@ -52,7 +52,7 @@ def scatter(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     x : `str` or `None`
         x coordinate.
@@ -359,11 +359,11 @@ def violin(adata, keys, groupby=None, log=False, use_raw=True, jitter=True,
            xlabel='', rotation=None, save=None, ax=None, **kwargs):
     """Violin plot [Waskom16]_.
 
-    Wraps `seaborn.violinplot` for :class:`~scanpy.api.AnnData`.
+    Wraps `seaborn.violinplot` for :class:`~anndata.AnnData`.
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     keys : `str` or list of `str`
         Keys for accessing variables of `.var_names` or fields of `.obs`.
@@ -469,11 +469,11 @@ def clustermap(
         adata, obs_keys=None, use_raw=True, show=None, save=None, **kwargs):
     """Hierarchically-clustered heatmap [Waskom16]_.
 
-    Wraps `seaborn.clustermap <https://seaborn.pydata.org/generated/seaborn.clustermap.html>`_ for :class:`~scanpy.api.AnnData`.
+    Wraps `seaborn.clustermap <https://seaborn.pydata.org/generated/seaborn.clustermap.html>`_ for :class:`~anndata.AnnData`.
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     obs_keys : `str`
         Categorical annotation to plot with a different color map.

--- a/scanpy/plotting/tools/__init__.py
+++ b/scanpy/plotting/tools/__init__.py
@@ -33,7 +33,7 @@ def pca(adata, **params):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     color : string or list of strings, optional (default: None)
         Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
@@ -101,7 +101,7 @@ def pca_scatter(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     layout : {'fr', 'drl', ...}, optional (default: last computed)
         One of the `draw_graph` layouts, see sc.tl.draw_graph. By default,
@@ -176,7 +176,7 @@ def pca_loadings(adata, components=None, show=None, save=None):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     components : str or list of integers, optional
         For example, ``'1,2,3'`` means ``[1, 2, 3]``, first, second, third
@@ -232,7 +232,7 @@ def diffmap(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     color : string or list of strings, optional (default: None)
         Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
@@ -340,7 +340,7 @@ def draw_graph(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     edges : `bool`, optional (default: `False`)
         Show edges.
@@ -450,7 +450,7 @@ def tsne(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     color : string or list of strings, optional (default: None)
         Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
@@ -536,7 +536,7 @@ def umap(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     color : string or list of strings, optional (default: None)
         Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
@@ -633,7 +633,7 @@ def dpt(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     basis : {`'diffmap'`, `'pca'`, `'tsne'`, `'draw_graph_...'`}
         Choose the basis in which to plot.
@@ -830,7 +830,7 @@ def louvain(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     basis : {`'diffmap'`, `'pca'`, `'tsne'`, `'draw_graph_...'`}
         Choose the basis in which to plot.
@@ -895,7 +895,7 @@ def rank_genes_groups(adata, groups=None, n_genes=20, fontsize=8, show=None, sav
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     groups : `str` or `list` of `str`
         The groups for which to show the gene ranking.
@@ -969,7 +969,7 @@ def rank_genes_groups_violin(adata, groups=None, n_genes=20,
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     groups : list of `str`, optional (default: `None`)
         List of group names.

--- a/scanpy/plotting/tools/paga.py
+++ b/scanpy/plotting/tools/paga.py
@@ -113,7 +113,7 @@ def paga_scatter(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     color : string or list of strings, optional (default: None)
         Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
@@ -216,7 +216,7 @@ def paga(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     solid_edges : `str`, optional (default: 'paga_confidence')
         Key for `.uns['paga']` that specifies the matrix that stores the edges
@@ -647,7 +647,7 @@ def paga_path(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         An annotated data matrix.
     nodes : list of group names or their category indices
         A path through nodes of the abstracted graph, that is, names or indices

--- a/scanpy/plotting/top_genes_visual.py
+++ b/scanpy/plotting/top_genes_visual.py
@@ -22,7 +22,7 @@ def correlation_matrix(adata,groupby=None ,group=None, corr_matrix=None, annotat
 
             Parameters
             ----------
-            adata : :class:`~scanpy.api.AnnData`
+            adata : :class:`~anndata.AnnData`
                 Annotated data matrix.
             groupby : `str`, optional (default: None)
                 If specified, searches data_annotation for correlation_matrix+groupby+str(group)
@@ -77,7 +77,7 @@ def exploratory_rank_analysis(adata, groupby, x='inflation', y='mean', groups='a
 
                 Parameters
                 ----------
-                adata : :class:`~scanpy.api.AnnData`
+                adata : :class:`~anndata.AnnData`
                     Annotated data matrix.
                 groupby : `str`
                     The key of the sample grouping to consider.
@@ -400,7 +400,7 @@ def top_ranked_group_analysis(adata, groupby, groupid, n=100, special_markers=No
 
                 Parameters
                 ----------
-                adata : :class:`~scanpy.api.AnnData`
+                adata : :class:`~anndata.AnnData`
                     Annotated data matrix.
                 groupby : `str`
                     The key of the sample grouping to consider.
@@ -574,7 +574,7 @@ def scatter(adata, groupby, groupid, x,y, n=100, special_markers=None,
 
                 Parameters
                 ----------
-                adata : :class:`~scanpy.api.AnnData`
+                adata : :class:`~anndata.AnnData`
                     Annotated data matrix.
                 groupby : `str`
                     The key of the sample grouping to consider.
@@ -771,7 +771,7 @@ def ROC_AUC_analysis(adata,groupby,group,n_genes=100, special_markers=None, colo
 
         Parameters
         ----------
-        adata : :class:`~scanpy.api.AnnData`
+        adata : :class:`~anndata.AnnData`
             Annotated data matrix.
         groupby : `str`
             The key of the sample grouping to consider.

--- a/scanpy/preprocessing/recipes.py
+++ b/scanpy/preprocessing/recipes.py
@@ -14,7 +14,7 @@ def recipe_weinreb17(adata, log=True, mean_threshold=0.01, cv_threshold=2,
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     copy : bool (default: False)
         Return a copy if true.
@@ -81,7 +81,7 @@ def recipe_zheng17(adata, n_top_genes=1000, log=True, plot=False, copy=False):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     n_top_genes : `int`, optional (default: 1000)
         Number of genes to keep.

--- a/scanpy/preprocessing/simple.py
+++ b/scanpy/preprocessing/simple.py
@@ -10,14 +10,23 @@ from scipy.sparse import issparse
 from sklearn.utils import sparsefuncs
 from pandas.api.types import is_categorical_dtype
 from anndata import AnnData
+
+from typing import Union, Optional, Tuple
+
 from .. import settings as sett
 from .. import logging as logg
 
 N_PCS = 50  # default number of PCs
 
 
-def filter_cells(data, min_counts=None, min_genes=None, max_counts=None,
-                 max_genes=None, copy=False):
+def filter_cells(
+    data: Union[AnnData, np.ndarray, sp.sparse.spmatrix],
+    min_counts: Optional[int] = None,
+    min_genes: Optional[int] = None,
+    max_counts: Optional[int] = None,
+    max_genes: Optional[int] = None,
+    copy: bool = False,
+) -> Union[AnnData, Tuple[np.ndarray, np.ndarray]]:
     """Filter cell outliers based on counts and numbers of genes expressed.
 
     For instance, only keep cells with at least `min_counts` counts or
@@ -29,24 +38,24 @@ def filter_cells(data, min_counts=None, min_genes=None, max_counts=None,
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.spmatrix`
+    data :
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
-    min_counts : `int`, optional (default: `None`)
+    min_counts :
         Minimum number of counts required for a cell to pass filtering.
-    min_genes : `int`, optional (default: `None`)
+    min_genes :
         Minimum number of genes expressed required for a cell to pass filtering.
-    max_counts : `int`, optional (default: `None`)
+    max_counts :
         Maximum number of counts required for a cell to pass filtering.
-    max_genes : `int`, optional (default: `None`)
+    max_genes :
         Maximum number of genes expressed required for a cell to pass filtering.
-    copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+    copy :
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
     -------
-    If `data` is an :class:`~scanpy.api.AnnData`, filters the object and adds\
+    If `data` is an :class:`~anndata.AnnData`, filters the object and adds\
     either `n_genes` or `n_counts` to `adata.obs`. Otherwise a tuple
 
     cell_subset : `np.ndarray`
@@ -137,7 +146,7 @@ def filter_genes(data, min_counts=None, min_cells=None, max_counts=None,
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.spmatrix`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.spmatrix`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     min_counts : `int`, optional (default: `None`)
@@ -149,12 +158,12 @@ def filter_genes(data, min_counts=None, min_cells=None, max_counts=None,
     max_cells : `int`, optional (default: `None`)
         Maximum number of cells expressed required for a cell to pass filtering.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
     -------
-    If `data` is an :class:`~scanpy.api.AnnData`, filters the object and adds\
+    If `data` is an :class:`~anndata.AnnData`, filters the object and adds\
     either `n_cells` or `n_counts` to `adata.var`. Otherwise a tuple
 
     gene_subset : `np.ndarray`
@@ -233,7 +242,7 @@ def filter_genes_dispersion(data,
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     flavor : {'seurat', 'cell_ranger'}, optional (default: 'seurat')
@@ -257,7 +266,7 @@ def filter_genes_dispersion(data,
     log : `bool`, optional (default: `True`)
         Use the logarithm of the mean to variance ratio.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -407,11 +416,11 @@ def log1p(data, copy=False):
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -438,7 +447,7 @@ def pca(data, n_comps=None, zero_center=True, svd_solver='auto', random_state=0,
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     n_comps : `int`, optional (default: 50)
@@ -455,12 +464,12 @@ def pca(data, n_comps=None, zero_center=True, svd_solver='auto', random_state=0,
     random_state : `int`, optional (default: 0)
         Change to use different intial states for the optimization.
     return_info : `bool` or `None`, optional (default: `None`)
-        Only relevant when not passing an :class:`~scanpy.api.AnnData`: see
+        Only relevant when not passing an :class:`~anndata.AnnData`: see
         "Returns".
     dtype : `str` (default: 'float32')
         Numpy data type string to which to convert the result.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -536,7 +545,7 @@ def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None,
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     counts_per_cell_after : `float` or `None`, optional (default: `None`)
@@ -548,7 +557,7 @@ def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None,
         Name of the field in `adata.obs` where the total counts per cell are
         stored.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -661,14 +670,14 @@ def regress_out(adata, keys, n_jobs=None, copy=False):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         The annotated data matrix.
     keys : `str` or list of `str`
         Keys for observation annotation on which to regress on.
     n_jobs : `int` or `None`, optional (default: `None`)
         Number of jobs for parallel computation. Currently has no effect.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -753,7 +762,7 @@ def scale(data, zero_center=True, max_value=None, copy=False):
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     zero_center : `bool`, optional (default: `True`)
@@ -762,7 +771,7 @@ def scale(data, zero_center=True, max_value=None, copy=False):
     max_value : `float` or `None`, optional (default: `None`)
         Clip (truncate) to this value after scaling. If `None`, do not clip.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
@@ -803,7 +812,7 @@ def subsample(data, fraction, random_state=0, copy=False):
 
     Parameters
     ----------
-    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+    data : :class:`~anndata.AnnData`, `np.ndarray`, `sp.sparse`
         The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
         to cells and columns to genes.
     fraction : float in [0, 1]
@@ -811,13 +820,13 @@ def subsample(data, fraction, random_state=0, copy=False):
     random_state : `int` or `None`, optional (default: 0)
         Random seed to change subsampling.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
     -------
     Returns `X[obs_indices], obs_indices` if data is array-like, otherwise
-    subsamples the passed :class:`~scanpy.api.AnnData` (`copy == False`) or
+    subsamples the passed :class:`~anndata.AnnData` (`copy == False`) or
     returns a subsampled copy of it (`copy == True`).
     """
     if fraction > 1 or fraction < 0:
@@ -845,7 +854,7 @@ def downsample_counts(adata, target_counts=20000, random_state=0, copy=False):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     target_counts : `int` (default: 20,000)
         Target number of counts for downsampling. Cells with more counts than
@@ -853,7 +862,7 @@ def downsample_counts(adata, target_counts=20000, random_state=0, copy=False):
     random_state : `int` or `None`, optional (default: 0)
         Random seed to change subsampling.
     copy : `bool`, optional (default: `False`)
-        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -26,7 +26,7 @@ avail_exts = {'anndata', 'csv', 'xlsx',
 
 def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
          first_column_names=False, backup_url=None, cache=False):
-    """Read file and return :class:`~scanpy.api.AnnData` object.
+    """Read file and return :class:`~anndata.AnnData` object.
 
     To speed up reading, consider passing `cache=True`, which creates an hdf5
     cache file.
@@ -39,7 +39,7 @@ def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
         sc.settings.file_format_data`.  This is the same behavior as in
         `sc.read(filename, ...)`.
     backed : {`False`, `True`, 'r', 'r+'}, optional (default: `False`)
-        Load :class:`~scanpy.api.AnnData` in `backed` mode instead of fully
+        Load :class:`~anndata.AnnData` in `backed` mode instead of fully
         loading it into memory (`memory` mode). Only applies to `.h5ad` files.
         `True` and 'r' are equivalent. If you want to modify backed attributes
         of the AnnData object, you need to choose 'r+'.
@@ -63,7 +63,7 @@ def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
     """
     filename = str(filename)  # allow passing pathlib.Path objects
     if is_valid_filename(filename):
@@ -95,7 +95,7 @@ def read_10x_h5(filename, genome='mm10'):
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix, where obsevations/cells are named by their
         barcode and variables/genes by gene name. The data matrix is stored in
         `adata.X`, cell names in `adata.obs_names` and gene names in
@@ -133,7 +133,7 @@ def read_10x_h5(filename, genome='mm10'):
 
 
 def write(filename, adata, ext=None, compression='gzip', compression_opts=None):
-    """Write :class:`~scanpy.api.AnnData` objects to file.
+    """Write :class:`~anndata.AnnData` objects to file.
 
     Parameters
     ----------
@@ -142,7 +142,7 @@ def write(filename, adata, ext=None, compression='gzip', compression_opts=None):
         generating a filename via `sc.settings.writedir + filename +
         sc.settings.file_format_data`.  This is the same behavior as in
         :func:`~scanpy.api.read`.
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     ext : {`None`, `'h5'`, `'csv'`, `'txt'`, `'npz'`} (default: `None`)
         File extension from wich to infer file format. If `None`, defaults to

--- a/scanpy/tools/diffmap.py
+++ b/scanpy/tools/diffmap.py
@@ -12,7 +12,7 @@ def diffmap(adata, n_comps=15, copy=False):
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     n_comps : `int`, optional (default: 15)
         The number of dimensions of the representation.

--- a/scanpy/tools/dpt.py
+++ b/scanpy/tools/dpt.py
@@ -32,7 +32,7 @@ def dpt(adata, n_branchings=0, n_dcs=10, min_group_size=0.01,
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     n_branchings : `int`, optional (default: 0)
         Number of branchings to detect.

--- a/scanpy/tools/draw_graph.py
+++ b/scanpy/tools/draw_graph.py
@@ -33,7 +33,7 @@ def draw_graph(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     layout : `str`, optional (default: 'fr')
         Any valid `igraph layout

--- a/scanpy/tools/louvain.py
+++ b/scanpy/tools/louvain.py
@@ -27,7 +27,7 @@ def louvain(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         The annotated data matrix.
     resolution : `float` or `None`, optional (default: 1)
         For the default flavor ('vtraag'), you can provide a resolution (higher

--- a/scanpy/tools/paga.py
+++ b/scanpy/tools/paga.py
@@ -25,7 +25,7 @@ def paga(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     groups : categorical annotation of observations or 'louvain_groups', optional (default: 'louvain_groups')
         Criterion to determine the resulting partitions of the single-cell

--- a/scanpy/tools/rank_genes_groups.py
+++ b/scanpy/tools/rank_genes_groups.py
@@ -27,7 +27,7 @@ def rank_genes_groups(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     groupby : `str`
         The key of the observations grouping to consider.

--- a/scanpy/tools/score_genes.py
+++ b/scanpy/tools/score_genes.py
@@ -28,7 +28,7 @@ def score_genes(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         The annotated data matrix.
     gene_list : iterable
         The list of gene names used for score calculation.
@@ -118,7 +118,7 @@ def score_genes_cell_cycle(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         The annotated data matrix.
     s_genes : `list`
         List of genes associated with S phase.

--- a/scanpy/tools/sim.py
+++ b/scanpy/tools/sim.py
@@ -62,7 +62,7 @@ def sim(model,
 
     Returns
     -------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
 
     Examples

--- a/scanpy/tools/top_genes.py
+++ b/scanpy/tools/top_genes.py
@@ -17,7 +17,7 @@ def correlation_matrix(adata, name_list=None, groupby=None, group=None, n_genes=
 
         Parameters
         ----------
-        adata : :class:`~scanpy.api.AnnData`
+        adata : :class:`~anndata.AnnData`
             Annotated data matrix.
         name_list : list, optional (default: None)
             Takes a list of genes for which to calculate the correlation matrix
@@ -114,7 +114,7 @@ def ROC_AUC_analysis(adata,groupby,group=None, n_genes=100):
 
             Parameters
             ----------
-            adata : :class:`~scanpy.api.AnnData`
+            adata : :class:`~anndata.AnnData`
                 Annotated data matrix.
             groupby : `str`
                 The key of the sample grouping to consider.

--- a/scanpy/tools/tsne.py
+++ b/scanpy/tools/tsne.py
@@ -28,7 +28,7 @@ def tsne(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     {doc_n_pcs}
     {use_rep}

--- a/scanpy/tools/umap.py
+++ b/scanpy/tools/umap.py
@@ -27,7 +27,7 @@ def umap(
 
     Parameters
     ----------
-    adata : :class:`~scanpy.api.AnnData`
+    adata : :class:`~anndata.AnnData`
         Annotated data matrix.
     min_dist : `float`, optional (default: 0.5)
         The effective minimum distance between embedded points. Smaller values
@@ -55,9 +55,9 @@ def umap(
     init : `string` or `np.array`, optional (default: 'spectral')
         How to initialize the low dimensional embedding.
         Options are:
-            * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
-            * 'random': assign initial embedding positions at random.
-            * A numpy array of initial embedding positions.
+        * 'spectral': use a spectral embedding of the fuzzy 1-skeleton
+        * 'random': assign initial embedding positions at random.
+        * A numpy array of initial embedding positions.
     random_state : `int`, `RandomState` or `None`, optional (default: `None`)
         If `int`, `random_state` is the seed used by the random number generator;
         If `RandomState`, `random_state` is the random number generator;


### PR DESCRIPTION
As example for the change I [simplified scanpy.preprocessing.simple.filter_cells](https://github.com/theislab/scanpy/pull/119/commits/ae85520fcd16abbb1fb9748cf0b03fb35ce858b6#diff-1aa47c128676c77be1123acc601efd9eL19). Also I fixed a few docs problems.

The new format is now custom, so if you dislike the grey headers, that’s easy.

Before | After
----------|----------
![before](https://user-images.githubusercontent.com/291575/38499002-c6f9dda0-3bf5-11e8-8a76-07a423b366d3.png) | ![after](https://user-images.githubusercontent.com/291575/38512702-79d3ca24-3c1b-11e8-84af-87f033d5008e.png)