### PR TITLE
Do not use paga in draw_graph, if use_paga is False

### DIFF
--- a/scanpy/tools/draw_graph.py
+++ b/scanpy/tools/draw_graph.py
@@ -89,7 +89,7 @@ def draw_graph(
         if proceed:
             init_coords = adata.obsm[key_added]
             ig_layout = g.layout(layout, seed=init_coords.tolist(), **kwds)
-        elif 'paga' in adata.uns and 'pos' in adata.uns['paga']:
+        elif 'paga' in adata.uns and 'pos' in adata.uns['paga'] and use_paga:
             groups = adata.obs[adata.uns['paga']['groups']]
             all_pos = adata.uns['paga']['pos']
             if use_paga == 'global':


### PR DESCRIPTION
This fixes the `UnboundLocalError: local variable 'ig_layout' referenced before assignment` exception that happens in following scenario:

```
sc.tl.louvain(adata)
sc.tl.paga(adata)
sc.pl.paga(adata)
sc.tl.draw_graph(adata)
```

Since there is no else statement for use_paga check, ig_layout is not defined.