### PR TITLE
Add PHATE integration

### DIFF
--- a/docs/references.rst
+++ b/docs/references.rst
@@ -91,6 +91,10 @@ References
    *Visualizing data using t-SNE*,
    `JMLR <http://www.jmlr.org/papers/v9/vandermaaten08a.html>`_.
 
+.. [Moon17] Moon *et al.* (2017),
+   *PHATE: A Dimensionality Reduction Method for Visualizing Trajectory Structures in High-Dimensional Biological Data*,
+   `BioRxiv <http://biorxiv.org/content/early/2017/03/24/120378>`_.
+
 .. [Satija15] Satija *et al.* (2015),
    *Spatial reconstruction of single-cell gene expression data*,
    `Nature Biotechnology <https://doi.org/10.1038/nbt.3192>`_.

--- a/requires.txt
+++ b/requires.txt
@@ -11,4 +11,3 @@ networkx
 natsort
 joblib
 numba
-phate

--- a/requires.txt
+++ b/requires.txt
@@ -11,3 +11,4 @@ networkx
 natsort
 joblib
 numba
+phate

--- a/scanpy/api/pl.py
+++ b/scanpy/api/pl.py
@@ -6,6 +6,7 @@ from ..plotting.tools import pca, pca_loadings, pca_scatter, pca_variance_ratio
 from ..plotting.tools import diffmap
 from ..plotting.tools import draw_graph
 from ..plotting.tools import tsne
+from ..plotting.tools import phate
 from ..plotting.tools import umap
 from ..plotting.tools.paga import paga, paga_adjacency, paga_compare, paga_path, paga_scatter
 from ..plotting.tools import dpt, dpt_scatter, dpt_groups_pseudotime, dpt_timeseries

--- a/scanpy/api/tl.py
+++ b/scanpy/api/tl.py
@@ -14,3 +14,5 @@ from ..tools.top_genes import correlation_matrix, ROC_AUC_analysis
 from ..tools.score_genes import score_genes, score_genes_cell_cycle
 
 from ..tools.pypairs import cyclone, sandbag
+
+from ..tools.phate import run_phate, PHATE

--- a/scanpy/api/tl.py
+++ b/scanpy/api/tl.py
@@ -15,4 +15,4 @@ from ..tools.score_genes import score_genes, score_genes_cell_cycle
 
 from ..tools.pypairs import cyclone, sandbag
 
-from ..tools.phate import run_phate, PHATE
+from ..tools.phate import phate

--- a/scanpy/plotting/tools/__init__.py
+++ b/scanpy/plotting/tools/__init__.py
@@ -457,7 +457,7 @@ def tsne(
         string `"ann1,ann2,..."`.
     use_raw : `bool`, optional (default: `True`)
         Use `raw` attribute of `adata` if present.
-    {{edges_arrows}}
+    {edges_arrows}
     sort_order : `bool`, optional (default: `True`)
         For continuous annotations used as color parameter, plot data points
         with higher values on top of others.
@@ -608,6 +608,122 @@ def umap(
         save=save,
         ax=ax)
     if show == False: return axs
+
+
+@doc_params(edges_arrows=doc_edges_arrows)
+def phate(
+        adata,
+        color=None,
+        use_raw=True,
+        edges=False,
+        edges_width=0.1,
+        edges_color='grey',
+        arrows=False,
+        arrows_kwds=None,
+        sort_order=True,
+        alpha=None,
+        groups=None,
+        legend_loc='right margin',
+        legend_fontsize=None,
+        legend_fontweight=None,
+        color_map=None,
+        palette=None,
+        right_margin=None,
+        size=None,
+        title=None,
+        show=None,
+        save=None, ax=None):
+    """Scatter plot in PHATE basis.
+
+    Parameters
+    ----------
+    adata : :class:`~scanpy.api.AnnData`
+        Annotated data matrix.
+    color : string or list of strings, optional (default: None)
+        Keys for observation/cell annotation either as list `["ann1", "ann2"]` or
+        string `"ann1,ann2,..."`.
+    use_raw : `bool`, optional (default: `True`)
+        Use `raw` attribute of `adata` if present.
+    {edges_arrows}
+    sort_order : `bool`, optional (default: `True`)
+        For continuous annotations used as color parameter, plot data points
+        with higher values on top of others.
+    groups : str, optional (default: all groups)
+        Restrict to a few categories in categorical observation annotation.
+    legend_loc : str, optional (default: 'right margin')
+         Location of legend, either 'on data', 'right margin' or valid keywords
+         for matplotlib.legend.
+    legend_fontsize : int (default: None)
+         Legend font size.
+    color_map : str (default: `matplotlib.rcParams['image.cmap']`)
+         String denoting matplotlib color map.
+    palette : list of str (default: None)
+         Colors to use for plotting groups (categorical annotation).
+    right_margin : float or list of floats (default: None)
+         Adjust the width of the space right of each plotting panel.
+    size : float (default: None)
+         Point size.
+    title : str, optional (default: None)
+         Provide title for panels either as `["title1", "title2", ...]` or
+         `"title1,title2,..."`.
+    show : bool, optional (default: None)
+         Show the plot, do not return axis.
+    save : `bool` or `str`, optional (default: `None`)
+        If `True` or a `str`, save the figure. A string is appended to the
+        default filename. Infer the filetype if ending on {{'.pdf', '.png', '.svg'}}.
+    ax : matplotlib.Axes
+         A matplotlib axes object.
+
+    Returns
+    -------
+    If `show==False`, a list of `matplotlib.Axis` objects. Every second element
+    corresponds to the 'right margin' drawing area for color bars and legends.
+
+    Examples
+    --------
+    >>> import scanpy.api as sc
+    >>> import phate
+    >>> data, branches = phate.tree.gen_dla(n_dim=100,
+                                            n_branch=20,
+                                            branch_length=100)
+    >>> data.shape
+    (2000, 100)
+    >>> adata = sc.AnnData(data)
+    >>> adata.obs['branches'] = branches
+    >>> sc.tl.phate(adata, k=5, a=20, t=150)
+    >>> adata.obsm['X_phate'].shape
+    (2000, 2)
+    >>> sc.pl.phate(adata,
+                    color='branches',
+                    color_map='tab20')
+    """
+    basis = 'phate'
+    axs = scatter(
+        adata,
+        basis=basis,
+        color=color,
+        use_raw=use_raw,
+        sort_order=sort_order,
+        alpha=alpha,
+        groups=groups,
+        legend_loc=legend_loc,
+        legend_fontsize=legend_fontsize,
+        legend_fontweight=legend_fontweight,
+        color_map=color_map,
+        palette=palette,
+        right_margin=right_margin,
+        size=size,
+        title=title,
+        show=False,
+        save=False,
+        ax=ax)
+    if edges:
+        utils.plot_edges(axs, adata, basis, edges_width, edges_color)
+    if arrows:
+        utils.plot_arrows(axs, adata, basis, arrows_kwds)
+    utils.savefig_or_show(basis, show=show, save=save)
+    if show == False:
+        return axs
 
 
 # ------------------------------------------------------------------------------

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -1,0 +1,293 @@
+"""Embed high-dimensional data using PHATE
+"""
+
+
+def PHATE(
+        n_components=2,
+        k=15,
+        a=10,
+        alpha_decay=None,
+        n_landmark=2000,
+        t='auto',
+        potential_method='log',
+        n_pca=100,
+        knn_dist='euclidean',
+        mds_dist='euclidean',
+        mds='metric',
+        n_jobs=1,
+        random_state=None,
+        verbose=True):
+    """PHATE operator which performs dimensionality reduction.
+
+    Potential of Heat-diffusion for Affinity-based Trajectory Embedding
+    (PHATE). Embeds high dimensional single-cell data into two or three
+    dimensions for visualization of biological progressions as described
+    in [Moon17]_.
+
+    PHATE operator is used with standard `sklearn` estimator methods:
+    `fit(X)`, `transform(X)` and `fit_transform(X)`. Read more in the
+    `PHATE Documentation <https://phate.readthedocs.io/>`_.
+
+    Parameters
+    ----------
+
+    n_components : int, optional, default: 2
+        number of dimensions in which the data will be embedded
+
+    k : int, optional, default: 15
+        number of nearest neighbors on which to build kernel
+
+    a : int, optional, default: None
+        sets decay rate of kernel tails.
+        If None, alpha decaying kernel is not used
+
+    alpha_decay : boolean, default: None
+        forces the use of alpha decaying kernel
+        If None, alpha decaying kernel is used for small inputs
+        (n_samples < n_landmark) and not used otherwise
+
+    n_landmark : int, optional, default: 2000
+        number of landmarks to use in fast PHATE
+
+    t : int, optional, default: 'auto'
+        power to which the diffusion operator is powered
+        sets the level of diffusion
+
+    potential_method : string, optional, default: 'log'
+        choose from ['log', 'sqrt']
+        which transformation of the diffusional operator is used
+        to compute the diffusion potential
+
+    n_pca : int, optional, default: 100
+        Number of principal components to use for calculating
+        neighborhoods. For extremely large datasets, using
+        n_pca < 20 allows neighborhoods to be calculated in
+        log(n_samples) time.
+
+    knn_dist : string, optional, default: 'euclidean'
+        recommended values: 'euclidean' and 'cosine'
+        Any metric from `scipy.spatial.distance` can be used
+        distance metric for building kNN graph
+
+    mds_dist : string, optional, default: 'euclidean'
+        recommended values: 'euclidean' and 'cosine'
+        Any metric from `scipy.spatial.distance` can be used
+        distance metric for MDS
+
+    mds : string, optional, default: 'metric'
+        choose from ['classic', 'metric', 'nonmetric']
+        which MDS algorithm is used for dimensionality reduction
+
+    n_jobs : integer, optional, default: 1
+        The number of jobs to use for the computation.
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging.
+        For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for
+        n_jobs = -2, all CPUs but one are used
+
+    random_state : integer or `numpy.RandomState`, optional
+        The generator used to initialize SMACOF (metric, nonmetric) MDS
+        If an integer is given, it fixes the seed
+        Defaults to the global `numpy` random number generator
+
+    verbose : boolean, optional
+        If true, print status messages
+
+    Attributes
+    ----------
+
+    X : array-like, shape=[n_samples, n_dimensions]
+
+    embedding : array-like, shape=[n_samples, n_components]
+        Stores the position of the dataset in the embedding space
+
+    diff_op : array-like, shape=[n_samples, n_samples] or [n_landmarks, n_landmarks]
+        The diffusion operator fit on the input data
+
+    diff_potential : array-like, shape=[n_samples, n_samples]
+        Precomputed diffusion potential
+
+    landmark_transitions : array-like, shape=[n_samples, n_landmarks]
+        Transition matrix between input data and landmarks,
+        if `n_landmark` is set, otherwise `None`
+
+    Examples
+    --------
+    >>> import scanpy.api as sc
+    >>> import matplotlib.pyplot as plt
+    >>> from anndata import AnnData
+    >>> import phate
+    >>> tree_data, tree_clusters = phate.tree.gen_dla(n_dim=100,
+                                                      n_branch=20,
+                                                      branch_length=100)
+    >>> tree_data.shape
+    (2000, 100)
+    >>> adata = AnnData(tree_data)
+    >>> phate_operator = sc.tl.PHATE(k=5, a=20, t=100)
+    >>> tree_phate = phate_operator.fit_transform(adata)
+    >>> tree_phate.shape
+    (2000, 2)
+    >>> plt.scatter(tree_phate[:,0], tree_phate[:,1], c=tree_clusters)
+    >>> plt.show()
+    """
+    try:
+        import phate as ph
+    except ImportError:
+        raise ImportError('You need to install the package `phate`: please run'
+                          ' `pip install - -user phate` in a terminal.')
+
+    return ph.PHATE(
+        n_components=n_components,
+        k=k,
+        a=a,
+        alpha_decay=alpha_decay,
+        n_landmark=n_landmark,
+        t=t,
+        potential_method=potential_method,
+        n_pca=n_pca,
+        knn_dist=knn_dist,
+        mds_dist=mds_dist,
+        mds=mds,
+        n_jobs=n_jobs,
+        random_state=random_state,
+        verbose=verbose,
+    )
+
+
+def run_phate(
+        adata,
+        n_components=2,
+        k=15,
+        a=10,
+        alpha_decay=None,
+        n_landmark=2000,
+        t='auto',
+        potential_method='log',
+        n_pca=100,
+        knn_dist='euclidean',
+        mds_dist='euclidean',
+        mds='metric',
+        n_jobs=1,
+        random_state=None,
+        verbose=True):
+    """Runs PHATE dimensionality reduction.
+
+    Embeds high dimensional single-cell data into two or three dimensions for
+    visualization of biological progressions. Potential of Heat-diffusion for
+    Affinity-based Trajectory Embedding (PHATE) [Moon17]_
+
+    Parameters
+    ----------
+    data : AnnData or array-like [n_samples, n_dimensions]
+        input data with `n_samples` samples and `n_dimensions`
+        dimensions. Accepted data types: `numpy.ndarray`,
+        `scipy.sparse.spmatrix`, `pd.DataFrame`, `anndata.AnnData`
+
+    n_components : int, optional, default: 2
+        number of dimensions in which the data will be embedded
+
+    k : int, optional, default: 15
+        number of nearest neighbors on which to build kernel
+
+    a : int, optional, default: None
+        sets decay rate of kernel tails.
+        If None, alpha decaying kernel is not used
+
+    alpha_decay : boolean, default: None
+        forces the use of alpha decaying kernel
+        If None, alpha decaying kernel is used for small inputs
+        (n_samples < n_landmark) and not used otherwise
+
+    n_landmark : int, optional, default: 2000
+        number of landmarks to use in fast PHATE
+
+    t : int, optional, default: 'auto'
+        power to which the diffusion operator is powered
+        sets the level of diffusion
+
+    potential_method : string, optional, default: 'log'
+        choose from ['log', 'sqrt']
+        which transformation of the diffusional operator is used
+        to compute the diffusion potential
+
+    n_pca : int, optional, default: 100
+        Number of principal components to use for calculating
+        neighborhoods. For extremely large datasets, using
+        n_pca < 20 allows neighborhoods to be calculated in
+        log(n_samples) time.
+
+    knn_dist : string, optional, default: 'euclidean'
+        recommended values: 'euclidean' and 'cosine'
+        Any metric from `scipy.spatial.distance` can be used
+        distance metric for building kNN graph
+
+    mds_dist : string, optional, default: 'euclidean'
+        recommended values: 'euclidean' and 'cosine'
+        Any metric from `scipy.spatial.distance` can be used
+        distance metric for MDS
+
+    mds : string, optional, default: 'metric'
+        choose from ['classic', 'metric', 'nonmetric']
+        which MDS algorithm is used for dimensionality reduction
+
+    n_jobs : integer, optional, default: 1
+        The number of jobs to use for the computation.
+        If -1 all CPUs are used. If 1 is given, no parallel computing code is
+        used at all, which is useful for debugging.
+        For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for
+        n_jobs = -2, all CPUs but one are used
+
+    random_state : integer or `numpy.RandomState`, optional
+        The generator used to initialize SMACOF (metric, nonmetric) MDS
+        If an integer is given, it fixes the seed
+        Defaults to the global `numpy` random number generator
+
+    verbose : boolean, optional
+        If true, print status messages
+
+    Returns
+    -------
+
+    embedding : array-like, shape=[n_samples, n_components]
+        Stores the position of the dataset in the embedding space
+
+    Examples
+    --------
+    >>> import scanpy.api as sc
+    >>> import matplotlib.pyplot as plt
+    >>> from anndata import AnnData
+    >>> import phate
+    >>> tree_data, tree_clusters = phate.tree.gen_dla(n_dim=100,
+                                                      n_branch=20,
+                                                      branch_length=100)
+    >>> tree_data.shape
+    (2000, 100)
+    >>> adata = AnnData(tree_data)
+    >>> tree_phate = sc.tl.run_phate(adata, k=5, a=20, t=150)
+    >>> tree_phate.shape
+    (2000, 2)
+    >>> plt.scatter(tree_phate[:,0], tree_phate[:,1], c=tree_clusters)
+    >>> plt.show()
+    """
+    try:
+        import phate as ph
+    except ImportError:
+        raise ImportError(
+            'You need to install the package `phate`: please run `pip install --user phate` in a terminal.')
+
+    return ph.PHATE(
+        n_components=n_components,
+        k=k,
+        a=a,
+        alpha_decay=alpha_decay,
+        n_landmark=n_landmark,
+        t=t,
+        potential_method=potential_method,
+        n_pca=n_pca,
+        knn_dist=knn_dist,
+        mds_dist=mds_dist,
+        mds=mds,
+        n_jobs=n_jobs,
+        random_state=random_state,
+        verbose=verbose,
+    ).fit_transform(adata)

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -5,158 +5,11 @@ try:
 except ImportError:
     pass
 
-
-def PHATE(
-        n_components=2,
-        k=15,
-        a=10,
-        alpha_decay=None,
-        n_landmark=2000,
-        t='auto',
-        potential_method='log',
-        n_pca=100,
-        knn_dist='euclidean',
-        mds_dist='euclidean',
-        mds='metric',
-        n_jobs=1,
-        random_state=None,
-        verbose=True):
-    """PHATE operator which performs dimensionality reduction.
-
-    Potential of Heat-diffusion for Affinity-based Trajectory Embedding
-    (PHATE). Embeds high dimensional single-cell data into two or three
-    dimensions for visualization of biological progressions as described
-    in [Moon17]_.
-
-    PHATE operator is used with standard `sklearn` estimator methods:
-    `fit(X)`, `transform(X)` and `fit_transform(X)`. Read more in the
-    `PHATE Documentation <https://phate.readthedocs.io/>`_.
-
-    Parameters
-    ----------
-
-    n_components : int, optional, default: 2
-        number of dimensions in which the data will be embedded
-
-    k : int, optional, default: 15
-        number of nearest neighbors on which to build kernel
-
-    a : int, optional, default: None
-        sets decay rate of kernel tails.
-        If None, alpha decaying kernel is not used
-
-    alpha_decay : boolean, default: None
-        forces the use of alpha decaying kernel
-        If None, alpha decaying kernel is used for small inputs
-        (n_samples < n_landmark) and not used otherwise
-
-    n_landmark : int, optional, default: 2000
-        number of landmarks to use in fast PHATE
-
-    t : int, optional, default: 'auto'
-        power to which the diffusion operator is powered
-        sets the level of diffusion
-
-    potential_method : string, optional, default: 'log'
-        choose from ['log', 'sqrt']
-        which transformation of the diffusional operator is used
-        to compute the diffusion potential
-
-    n_pca : int, optional, default: 100
-        Number of principal components to use for calculating
-        neighborhoods. For extremely large datasets, using
-        n_pca < 20 allows neighborhoods to be calculated in
-        log(n_samples) time.
-
-    knn_dist : string, optional, default: 'euclidean'
-        recommended values: 'euclidean' and 'cosine'
-        Any metric from `scipy.spatial.distance` can be used
-        distance metric for building kNN graph
-
-    mds_dist : string, optional, default: 'euclidean'
-        recommended values: 'euclidean' and 'cosine'
-        Any metric from `scipy.spatial.distance` can be used
-        distance metric for MDS
-
-    mds : string, optional, default: 'metric'
-        choose from ['classic', 'metric', 'nonmetric']
-        which MDS algorithm is used for dimensionality reduction
-
-    n_jobs : integer, optional, default: 1
-        The number of jobs to use for the computation.
-        If -1 all CPUs are used. If 1 is given, no parallel computing code is
-        used at all, which is useful for debugging.
-        For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for
-        n_jobs = -2, all CPUs but one are used
-
-    random_state : integer or `numpy.RandomState`, optional
-        The generator used to initialize SMACOF (metric, nonmetric) MDS
-        If an integer is given, it fixes the seed
-        Defaults to the global `numpy` random number generator
-
-    verbose : boolean, optional
-        If true, print status messages
-
-    Attributes
-    ----------
-
-    X : array-like, shape=[n_samples, n_dimensions]
-
-    embedding : array-like, shape=[n_samples, n_components]
-        Stores the position of the dataset in the embedding space
-
-    diff_op : array-like, shape=[n_samples, n_samples] or [n_landmarks, n_landmarks]
-        The diffusion operator fit on the input data
-
-    diff_potential : array-like, shape=[n_samples, n_samples]
-        Precomputed diffusion potential
-
-    landmark_transitions : array-like, shape=[n_samples, n_landmarks]
-        Transition matrix between input data and landmarks,
-        if `n_landmark` is set, otherwise `None`
-
-    Examples
-    --------
-    >>> import scanpy.api as sc
-    >>> import matplotlib.pyplot as plt
-    >>> from anndata import AnnData
-    >>> import phate
-    >>> tree_data, tree_clusters = phate.tree.gen_dla(n_dim=100,
-                                                      n_branch=20,
-                                                      branch_length=100)
-    >>> tree_data.shape
-    (2000, 100)
-    >>> adata = AnnData(tree_data)
-    >>> phate_operator = sc.tl.PHATE(k=5, a=20, t=100)
-    >>> tree_phate = phate_operator.fit_transform(adata)
-    >>> tree_phate.shape
-    (2000, 2)
-    >>> plt.scatter(tree_phate[:,0], tree_phate[:,1], c=tree_clusters)
-    >>> plt.show()
-    """
-    try:
-        return ph.PHATE(
-            n_components=n_components,
-            k=k,
-            a=a,
-            alpha_decay=alpha_decay,
-            n_landmark=n_landmark,
-            t=t,
-            potential_method=potential_method,
-            n_pca=n_pca,
-            knn_dist=knn_dist,
-            mds_dist=mds_dist,
-            mds=mds,
-            n_jobs=n_jobs,
-            random_state=random_state,
-            verbose=verbose,
-        )
-    except NameError:
-        raise ImportError('You need to install the package `phate`: please run'
-                          ' `pip install --user phate` in a terminal.')
+from .. import settings
+from .. import logging as logg
 
 
-def run_phate(
+def phate(
         adata,
         n_components=2,
         k=15,
@@ -169,110 +22,116 @@ def run_phate(
         knn_dist='euclidean',
         mds_dist='euclidean',
         mds='metric',
-        n_jobs=1,
+        n_jobs=None,
         random_state=None,
-        verbose=True):
-    """Runs PHATE dimensionality reduction.
+        verbose=None,
+        copy=False):
+    """Run PHATE dimensionality reduction.
 
-    Embeds high dimensional single-cell data into two or three dimensions for
-    visualization of biological progressions. Potential of Heat-diffusion for
-    Affinity-based Trajectory Embedding (PHATE) [Moon17]_
+    Potential of Heat-diffusion for Affinity-based Trajectory Embedding (PHATE)
+    embeds high dimensional single-cell data into two or three dimensions for
+    visualization of biological progressions. [Moon17]_
+
+    Read more in the `PHATE Documentation <https://phate.readthedocs.io/>`_.
 
     Parameters
     ----------
-    data : AnnData or array-like [n_samples, n_dimensions]
-        input data with `n_samples` samples and `n_dimensions`
-        dimensions. Accepted data types: `numpy.ndarray`,
-        `scipy.sparse.spmatrix`, `pd.DataFrame`, `anndata.AnnData`
+    adata : :class:`~scanpy.api.AnnData`
+        Annotated data matrix.
 
-    n_components : int, optional, default: 2
+    n_components : `int`, optional (default: 2)
         number of dimensions in which the data will be embedded
 
-    k : int, optional, default: 15
+    k : `int`, optional (default: 15)
         number of nearest neighbors on which to build kernel
 
-    a : int, optional, default: None
+    a : `int`, optional (default: `None`)
         sets decay rate of kernel tails.
         If None, alpha decaying kernel is not used
 
-    alpha_decay : boolean, default: None
+    alpha_decay : `bool` or `None` (default: `None`)
         forces the use of alpha decaying kernel
         If None, alpha decaying kernel is used for small inputs
         (n_samples < n_landmark) and not used otherwise
 
-    n_landmark : int, optional, default: 2000
+    n_landmark : `int`, optional (default: 2000)
         number of landmarks to use in fast PHATE
 
-    t : int, optional, default: 'auto'
+    t : `int` or 'auto', optional (default: 'auto')
         power to which the diffusion operator is powered
         sets the level of diffusion
 
-    potential_method : string, optional, default: 'log'
-        choose from ['log', 'sqrt']
-        which transformation of the diffusional operator is used
+    potential_method : {'log', 'sqrt'}, optional (default: 'log')
+        Selects which transformation of the diffusional operator is used
         to compute the diffusion potential
 
-    n_pca : int, optional, default: 100
+    n_pca : `int`, optional (default: 100)
         Number of principal components to use for calculating
         neighborhoods. For extremely large datasets, using
         n_pca < 20 allows neighborhoods to be calculated in
         log(n_samples) time.
 
-    knn_dist : string, optional, default: 'euclidean'
+    knn_dist : string, optional (default: 'euclidean')
         recommended values: 'euclidean' and 'cosine'
         Any metric from `scipy.spatial.distance` can be used
         distance metric for building kNN graph
 
-    mds_dist : string, optional, default: 'euclidean'
+    mds_dist : string, optional (default: 'euclidean')
         recommended values: 'euclidean' and 'cosine'
         Any metric from `scipy.spatial.distance` can be used
         distance metric for MDS
 
-    mds : string, optional, default: 'metric'
-        choose from ['classic', 'metric', 'nonmetric']
-        which MDS algorithm is used for dimensionality reduction
+    mds : {'classic', 'metric', 'nonmetric'}, optional (default: 'metric')
+        Selects which MDS algorithm is used for dimensionality reduction
 
-    n_jobs : integer, optional, default: 1
+    n_jobs : `int` or `None`, optional (default: `sc.settings.n_jobs`)
         The number of jobs to use for the computation.
+        If `None`, `sc.settings.n_jobs` is used.
         If -1 all CPUs are used. If 1 is given, no parallel computing code is
         used at all, which is useful for debugging.
         For n_jobs below -1, (n_cpus + 1 + n_jobs) are used. Thus for
         n_jobs = -2, all CPUs but one are used
 
-    random_state : integer or `numpy.RandomState`, optional
-        The generator used to initialize SMACOF (metric, nonmetric) MDS
-        If an integer is given, it fixes the seed
-        Defaults to the global `numpy` random number generator
+    random_state : `int`, `numpy.RandomState` or `None`, optional (default: `None`)
+        Random seed. Defaults to the global `numpy` random number generator
 
-    verbose : boolean, optional
-        If true, print status messages
+    verbose : `bool`, `int` or `None`, optional (default: `sc.settings.verbosity`)
+        If `True` or an integer `>= 2`, print status messages.
+        If `None`, `sc.settings.verbosity` is used.
+
+    copy : `bool` (default: `False`)
+        Return a copy instead of writing to `adata`.
 
     Returns
     -------
+    Depending on `copy`, returns or updates `adata` with the following fields.
 
-    embedding : array-like, shape=[n_samples, n_components]
-        Stores the position of the dataset in the embedding space
+    X_phate : `np.ndarray`, (`adata.obs`, shape=[n_samples, n_components], dtype `float`)
+        PHATE coordinates of data.
 
     Examples
     --------
     >>> import scanpy.api as sc
-    >>> import matplotlib.pyplot as plt
-    >>> from anndata import AnnData
     >>> import phate
     >>> tree_data, tree_clusters = phate.tree.gen_dla(n_dim=100,
                                                       n_branch=20,
                                                       branch_length=100)
     >>> tree_data.shape
     (2000, 100)
-    >>> adata = AnnData(tree_data)
-    >>> tree_phate = sc.tl.run_phate(adata, k=5, a=20, t=150)
-    >>> tree_phate.shape
+    >>> adata = sc.AnnData(tree_data)
+    >>> sc.tl.phate(adata, k=5, a=20, t=150)
+    >>> adata.obsm['X_phate'].shape
     (2000, 2)
-    >>> plt.scatter(tree_phate[:,0], tree_phate[:,1], c=tree_clusters)
-    >>> plt.show()
+    >>> sc.pl.phate(adata)
     """
+    logg.info('computing PHATE', r=True)
+    adata = adata.copy() if copy else adata
+    verbose = settings.verbosity if verbose is None else verbose
+    if isinstance(verbose, int):
+        verbose = verbose >= 2
+    n_jobs = settings.n_jobs if n_jobs is None else n_jobs
     try:
-        return ph.PHATE(
+        X_phate = ph.PHATE(
             n_components=n_components,
             k=k,
             a=a,
@@ -292,3 +151,10 @@ def run_phate(
         raise ImportError(
             'You need to install the package `phate`: please run `pip install '
             '--user phate` in a terminal.')
+    logg.info('    finished', time=True,
+              end=' ' if settings.verbosity > 2 else '\n')
+    # update AnnData instance
+    adata.obsm['X_phate'] = X_phate  # annotate samples with tSNE coordinates
+    logg.hint('added\n'
+              '    \'X_phate\', PHATE coordinates (adata.obsm)')
+    return adata if copy else None

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -32,7 +32,10 @@ def phate(
     embeds high dimensional single-cell data into two or three dimensions for
     visualization of biological progressions. [Moon17]_
 
-    Read more in the `PHATE Documentation <https://phate.readthedocs.io/>`_.
+    For more informaton and access to the object-oriented interface,
+    read the `PHATE Documentation <https://phate.readthedocs.io/>`_.
+    For help, tutorials, bug reports, and R/MATLAB implementations,
+    visit the `PHATE GitHub <https://github.com/KrishnaswamyLab/PHATE/>`_.
 
     Parameters
     ----------

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -32,7 +32,7 @@ def phate(
     embeds high dimensional single-cell data into two or three dimensions for
     visualization of biological progressions. [Moon17]_
 
-    For more informaton and access to the object-oriented interface,
+    For more information and access to the object-oriented interface,
     read the `PHATE Documentation <https://phate.readthedocs.io/>`_.
     For help, tutorials, bug reports, and R/MATLAB implementations,
     visit the `PHATE GitHub <https://github.com/KrishnaswamyLab/PHATE/>`_.

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -3,7 +3,6 @@
 try:
     import phate as ph
 except ImportError:
-    raise
     pass
 
 

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -1,5 +1,10 @@
 """Embed high-dimensional data using PHATE
 """
+try:
+    import phate as ph
+except ImportError:
+    raise
+    pass
 
 
 def PHATE(
@@ -131,27 +136,25 @@ def PHATE(
     >>> plt.show()
     """
     try:
-        import phate as ph
-    except ImportError:
+        return ph.PHATE(
+            n_components=n_components,
+            k=k,
+            a=a,
+            alpha_decay=alpha_decay,
+            n_landmark=n_landmark,
+            t=t,
+            potential_method=potential_method,
+            n_pca=n_pca,
+            knn_dist=knn_dist,
+            mds_dist=mds_dist,
+            mds=mds,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            verbose=verbose,
+        )
+    except NameError:
         raise ImportError('You need to install the package `phate`: please run'
-                          ' `pip install - -user phate` in a terminal.')
-
-    return ph.PHATE(
-        n_components=n_components,
-        k=k,
-        a=a,
-        alpha_decay=alpha_decay,
-        n_landmark=n_landmark,
-        t=t,
-        potential_method=potential_method,
-        n_pca=n_pca,
-        knn_dist=knn_dist,
-        mds_dist=mds_dist,
-        mds=mds,
-        n_jobs=n_jobs,
-        random_state=random_state,
-        verbose=verbose,
-    )
+                          ' `pip install --user phate` in a terminal.')
 
 
 def run_phate(
@@ -270,24 +273,23 @@ def run_phate(
     >>> plt.show()
     """
     try:
-        import phate as ph
-    except ImportError:
+        return ph.PHATE(
+            n_components=n_components,
+            k=k,
+            a=a,
+            alpha_decay=alpha_decay,
+            n_landmark=n_landmark,
+            t=t,
+            potential_method=potential_method,
+            n_pca=n_pca,
+            knn_dist=knn_dist,
+            mds_dist=mds_dist,
+            mds=mds,
+            n_jobs=n_jobs,
+            random_state=random_state,
+            verbose=verbose,
+        ).fit_transform(adata)
+    except NameError:
         raise ImportError(
-            'You need to install the package `phate`: please run `pip install --user phate` in a terminal.')
-
-    return ph.PHATE(
-        n_components=n_components,
-        k=k,
-        a=a,
-        alpha_decay=alpha_decay,
-        n_landmark=n_landmark,
-        t=t,
-        potential_method=potential_method,
-        n_pca=n_pca,
-        knn_dist=knn_dist,
-        mds_dist=mds_dist,
-        mds=mds,
-        n_jobs=n_jobs,
-        random_state=random_state,
-        verbose=verbose,
-    ).fit_transform(adata)
+            'You need to install the package `phate`: please run `pip install '
+            '--user phate` in a terminal.')


### PR DESCRIPTION
Hi! I've added two possible APIs for PHATE: I imagine you'll only want to include one of them. 

The first, `sc.tl.PHATE`, is an object-oriented interface that matches `phate.PHATE`, which looks like an `sklearn` estimator class. The second is a functional interface which is equivalent to running `phate.PHATE().fit_transform(data)`. The second is more simple, but less powerful as any changes in parameters will require the entire operator to be recomputed, where the object-oriented interface allows partial recomputation.

Please let me know which you prefer (or if you would like to include both!) If we only include the functional version I would probably rename it to `phate` rather than `run_phate`.