### PR TITLE
 Allow gz and bz2 extensions for text formats

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -5,6 +5,7 @@ import os
 import sys
 import numpy as np
 import time
+from pathlib import Path
 from anndata import AnnData, read_loom, \
     read_csv, read_excel, read_text, read_hdf, read_mtx
 from anndata import read as read_h5ad
@@ -12,10 +13,12 @@ from anndata import read as read_h5ad
 from . import settings
 from . import logging as logg
 
-avail_exts = {'anndata', 'csv', 'xlsx',
-              'txt', 'tsv', 'tab', 'data',  # these four are all equivalent
+# .gz and .bz2 suffixes are also allowed for text formats
+text_exts = {'csv',
+             'tsv', 'tab', 'data', 'txt'} # these four are all equivalent
+avail_exts = {'anndata', 'xlsx',
               'h5', 'h5ad',
-              'soft.gz', 'txt.gz', 'mtx'}
+              'soft.gz', 'mtx'} | text_exts
 """Available file formats for reading data. """
 
 
@@ -503,12 +506,20 @@ def check_datafile_present_and_download(filename, backup_url=None):
 
 def is_valid_filename(filename, return_ext=False):
     """Check whether the argument is a filename."""
-    for ext in avail_exts:
-        if filename.endswith('.' + ext):
-            return ext if return_ext else True
-    if return_ext:
-        raise ValueError('"{}" does not end on a valid extension.\n'
-                         'Please, provide one of the available extensions.\n{}'
-                         .format(filename, avail_exts))
+    pt = Path(filename)
+    ext = pt.suffixes
+
+    # cases for gzipped/bzipped text files
+    if len(ext) == 2 and ext[0][1:] in text_exts and ext[1][1:] in ('gz', 'bz2'):
+        return ext[0][1:] if return_ext else True
+    elif len(ext) == 1 and ext[0][1:] in avail_exts:
+        return ext[0][1:] if return_ext else True
+    elif pt.suffix == '.soft.gz':
+        return 'soft.gz' if return_ext else True
     else:
-        return False
+        if return_ext:
+            raise ValueError('"{}" does not end on a valid extension.\n'
+                             'Please, provide one of the available extensions.\n{}'
+                             .format(filename, avail_exts))
+        else:
+            return False

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -517,7 +517,8 @@ def is_valid_filename(filename, return_ext=False):
     else:
         if return_ext:
             raise ValueError('"{}" does not end on a valid extension.\n'
-                             'Please, provide one of the available extensions.\n{}'
+                             'Please, provide one of the available extensions.\n{}\n'
+                             'Text files with .gz and .bz2 extensions are also supported.'
                              .format(filename, avail_exts))
         else:
             return False

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -353,7 +353,7 @@ def _read_softgz(filename):
                 for k in subset_ids:
                     samples_info[k] = subset_description
         # Next line is the column headers (sample id's)
-        sample_names = file.readline().split("\t")
+        sample_names = file.readline().strip().split("\t")
         # The column indices that contain gene expression data
         I = [i for i, x in enumerate(sample_names) if x.startswith("GSM")]
         # Restrict the column headers to those that we keep

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -338,12 +338,11 @@ def _read_softgz(filename):
     """
     filename = str(filename)  # allow passing pathlib.Path objects
     import gzip
-    with gzip.open(filename) as file:
+    with gzip.open(filename, mode='rt') as file:
         # The header part of the file contains information about the
         # samples. Read that information first.
         samples_info = {}
         for line in file:
-            line = line.decode("utf-8")
             if line.startswith("!dataset_table_begin"):
                 break
             elif line.startswith("!subset_description"):
@@ -354,7 +353,7 @@ def _read_softgz(filename):
                 for k in subset_ids:
                     samples_info[k] = subset_description
         # Next line is the column headers (sample id's)
-        sample_names = file.readline().decode("utf-8").split("\t")
+        sample_names = file.readline().split("\t")
         # The column indices that contain gene expression data
         I = [i for i, x in enumerate(sample_names) if x.startswith("GSM")]
         # Restrict the column headers to those that we keep
@@ -365,7 +364,6 @@ def _read_softgz(filename):
         # identifiers
         gene_names, X = [], []
         for line in file:
-            line = line.decode("utf-8")
             # This is what signals the end of the gene expression data
             # section in the file
             if line.startswith("!dataset_table_end"):
@@ -504,15 +502,14 @@ def check_datafile_present_and_download(filename, backup_url=None):
 
 def is_valid_filename(filename, return_ext=False):
     """Check whether the argument is a filename."""
-    pt = Path(filename)
-    ext = pt.suffixes
+    ext = Path(filename).suffixes
 
     # cases for gzipped/bzipped text files
     if len(ext) == 2 and ext[0][1:] in text_exts and ext[1][1:] in ('gz', 'bz2'):
         return ext[0][1:] if return_ext else True
     elif len(ext) == 1 and ext[0][1:] in avail_exts:
         return ext[0][1:] if return_ext else True
-    elif pt.suffix == '.soft.gz':
+    elif ''.join(ext) == '.soft.gz':
         return 'soft.gz' if return_ext else True
     else:
         if return_ext:

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -309,8 +309,6 @@ def _read(filename, backed=False, sheet=None, ext=None, delimiter=None,
             adata = read_text(filename, delimiter, first_column_names)
         elif ext == 'soft.gz':
             adata = _read_softgz(filename)
-        elif ext == 'txt.gz':
-            sys.exit('TODO: implement similar to read_softgz')
         else:
             raise ValueError('Unkown extension {}.'.format(ext))
         if cache:


### PR DESCRIPTION
Support for .gz and .bz2 compression. Uses https://github.com/theislab/anndata/pull/22 and fixes https://github.com/theislab/dca/issues/7.