### PR TITLE
Fix for `recipe_*(adata, plot=True)`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "3.6"
 install: source .travis_install.sh
+env:
+  - MPLBACKEND=Agg
 script:
   - pytest
   - python setup.py check --restructuredtext --strict

--- a/scanpy/preprocessing/recipes.py
+++ b/scanpy/preprocessing/recipes.py
@@ -51,7 +51,7 @@ def recipe_seurat(adata, log=True, plot=False, copy=False):
         adata.X, min_mean=0.0125, max_mean=3, min_disp=0.5, log=not log)
     if plot:
         from .. import plotting as pl  # should not import at the top of the file
-        pl.filter_genes_dispersion(filter_result, log=not log)
+        pl.preprocessing.filter_genes_dispersion(filter_result, log=not log)
     adata._inplace_subset_var(filter_result.gene_subset)  # filter genes
     if log: pp.log1p(adata)
     pp.scale(adata, max_value=10)
@@ -105,7 +105,7 @@ def recipe_zheng17(adata, n_top_genes=1000, log=True, plot=False, copy=False):
         adata.X, flavor='cell_ranger', n_top_genes=n_top_genes, log=False)
     if plot:
         from .. import plotting as pl  # should not import at the top of the file
-        pl.filter_genes_dispersion(filter_result, log=True)
+        pl.preprocessing.filter_genes_dispersion(filter_result, log=True)
     # actually filter the genes, the following is the inplace version of
     #     adata = adata[:, filter_result.gene_subset]
     adata._inplace_subset_var(filter_result.gene_subset)  # filter genes

--- a/scanpy/tests/preprocessing.py
+++ b/scanpy/tests/preprocessing.py
@@ -29,3 +29,10 @@ def test_normalize_per_cell():
     sc.pp.normalize_per_cell(adata_sparse)
     assert adata.X.sum(axis=1).tolist() == adata_sparse.X.sum(
         axis=1).A1.tolist()
+
+def test_recipe_plotting():
+    sc.settings.autoshow = False
+    adata = AnnData(np.random.randint(0, 1000, (1000, 1000)))
+    # These shouldn't throw an error
+    sc.pp.recipe_seurat(adata.copy(), plot=True)
+    sc.pp.recipe_zheng17(adata.copy(), plot=True)


### PR DESCRIPTION
Fixes #153

Fixed usage of `plot=True` for `recipe_zheng17` and `recipe_seurat`. A test was added under `tests/preprocessing.py` which just checks that no error is thrown.

Style wise, I just went with changing the fewest lines of code. The test isn't exactly stateless since I've got to deactivate interactive plotting, but I wasn't sure how you'd like to handle that. Lemme know if you'd like any changes.