### PR TITLE
regress_out multiprocessing

### DIFF
--- a/scanpy/preprocessing/simple.py
+++ b/scanpy/preprocessing/simple.py
@@ -703,29 +703,32 @@ def regress_out(adata, keys, n_jobs=None, copy=False):
         The annotated data matrix.
     keys : `str` or list of `str`
         Keys for observation annotation on which to regress on.
-    n_jobs : `int` or `None`, optional (default: `None`)
-        Number of jobs for parallel computation. Currently has no effect.
+    n_jobs : `int` or `None`, optional. If None is given, then the n_jobs seting is used (default: `None`)
+        Number of jobs for parallel computation.
     copy : `bool`, optional (default: `False`)
         If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
         is returned.
 
     Returns
     -------
-    Depening on `copy` returns or updates `adata` with the corrected data matrix.
+    Depending on `copy` returns or updates `adata` with the corrected data matrix.
     """
     logg.info('regressing out', keys, r=True)
     if issparse(adata.X):
         logg.info('    sparse input is densified and may '
                   'lead to high memory use')
     adata = adata.copy() if copy else adata
-    if isinstance(keys, str): keys = [keys]
+    if isinstance(keys, str):
+        keys = [keys]
+
     if issparse(adata.X):
         adata.X = adata.X.toarray()
-    if n_jobs is not None:
-        logg.warn('Parallelization is currently broke, will be restored soon. Running on 1 core.')
+
     n_jobs = sett.n_jobs if n_jobs is None else n_jobs
+
     # regress on a single categorical variable
     sanitize_anndata(adata)
+    variable_is_categorical = False
     if keys[0] in adata.obs_keys() and is_categorical_dtype(adata.obs[keys[0]]):
         if len(keys) > 1:
             raise ValueError(
@@ -738,52 +741,78 @@ def regress_out(adata, keys, n_jobs=None, copy=False):
             mask = (category == adata.obs[keys[0]]).values
             for ix, x in enumerate(adata.X.T):
                 regressors[mask, ix] = x[mask].mean()
+        variable_is_categorical = True
     # regress on one or several ordinal variables
     else:
-        regressors = np.array(
-            [adata.obs[key].values if key in adata.obs_keys()
-             else adata[:, key].X for key in keys]).T
-    regressors = np.c_[np.ones(adata.X.shape[0]), regressors]
+        # create data frame with selected keys (if given)
+        if keys:
+            regressors = adata.obs[keys]
+        else:
+            regressors = adata.obs.copy()
+
+        # add column of ones at index 0 (first column)
+        regressors.insert(0, 'ones', 1.0)
+
     len_chunk = np.ceil(min(1000, adata.X.shape[1]) / n_jobs).astype(int)
     n_chunks = np.ceil(adata.X.shape[1] / len_chunk).astype(int)
-    chunks = [np.arange(start, min(start + len_chunk, adata.X.shape[1]))
-              for start in range(0, n_chunks * len_chunk, len_chunk)]
 
+    tasks = []
+    # split the adata.X matrix by columns in chunks of size n_chunk (the last chunk could be of smaller
+    # size than the others)
+    chunk_list = np.array_split(adata.X, n_chunks, axis=1)
+    if variable_is_categorical:
+        regressors_chunk = np.array_split(regressors, n_chunks, axis=1)
+    for idx, data_chunk in enumerate(chunk_list):
+        # each task is a tuple of a data_chunk eg. (adata.X[:,0:100]) and
+        # the regressors. This data will be passed to each of the jobs.
+        if variable_is_categorical:
+            regres = regressors_chunk[idx]
+        else:
+            regres = regressors
+        tasks.append(tuple((data_chunk, regres, variable_is_categorical)))
+
+    if n_jobs > 1 and n_chunks > 1:
+        import multiprocessing
+        pool = multiprocessing.Pool(n_jobs)
+        res = pool.map_async(_regress_out_chunk, tasks).get(9999999)
+        pool.close()
+
+    else:
+        res = list(map(_regress_out_chunk, tasks))
+
+    # res is a list of vectors (each corresponding to a regressed gene column).
+    # The transpose is needed to get the matrix in the shape needed
+    adata.X = np.vstack(res).T.astype(adata.X.dtype)
+    logg.info('    finished', t=True)
+    return adata if copy else None
+
+
+def _regress_out_chunk(data):
+    # data is a tuple containing the selected columns from adata.X
+    # and the regressors dataFrame
+    data_chunk = data[0]
+    regressors = data[1]
+    variable_is_categorical = data[2]
+
+    responses_chunk_list = []
     import statsmodels.api as sm
     from statsmodels.tools.sm_exceptions import PerfectSeparationError
 
-    def _regress_out(col_index, responses, regressors):
+    for col_index in range(data_chunk.shape[1]):
+        if variable_is_categorical:
+            regres = np.c_[np.ones(regressors.shape[0]), regressors[:, col_index]]
+        else:
+            regres = regressors
         try:
-            if regressors.shape[1] - 1 == responses.shape[1]:
-                regressors_view = np.c_[regressors[:, 0], regressors[:, col_index + 1]]
-            else:
-                regressors_view = regressors
-            result = sm.GLM(responses[:, col_index],
-                            regressors_view, family=sm.families.Gaussian()).fit()
+            result = sm.GLM(data_chunk[:, col_index], regres, family=sm.families.Gaussian()).fit()
             new_column = result.resid_response
         except PerfectSeparationError:  # this emulates R's behavior
             logg.warn('Encountered PerfectSeparationError, setting to 0 as in R.')
-            new_column = np.zeros(responses.shape[0])
-        return new_column
+            new_column = np.zeros(data_chunk.shape[0])
 
-    def _regress_out_chunk(chunk, responses, regressors):
-        chunk_array = np.zeros((responses.shape[0], chunk.size),
-                               dtype=responses.dtype)
-        for i, col_index in enumerate(chunk):
-            chunk_array[:, i] = _regress_out(col_index, responses, regressors)
-        return chunk_array
+        responses_chunk_list.append(new_column)
 
-    for chunk in chunks:
-        # why did this break after migrating to dataframes?
-        # result_lst = Parallel(n_jobs=n_jobs)(
-        #     delayed(_regress_out)(
-        #         col_index, adata.X, regressors) for col_index in chunk)
-        result_lst = [_regress_out(
-            col_index, adata.X, regressors) for col_index in chunk]
-        for i_column, column in enumerate(chunk):
-            adata.X[:, column] = result_lst[i_column]
-    logg.info('    finished', t=True)
-    return adata if copy else None
+    return np.vstack(responses_chunk_list)
 
 
 def scale(data, zero_center=True, max_value=None, copy=False):

--- a/scanpy/tests/preprocessing.py
+++ b/scanpy/tests/preprocessing.py
@@ -39,30 +39,18 @@ def test_recipe_plotting():
     sc.pp.recipe_zheng17(adata.copy(), plot=True)
 
 
-def test_regress_out_minimal():
-    adata = AnnData(np.array([[1, 0], [3, 0], [5, 6]]))
-    sc.pp.normalize_per_cell(adata, counts_per_cell_after=1, key_n_counts='n_counts2')
-    adata.obs['percent_mito'] = [0.1, 0.2, 0.05]
-    adata.obs['n_counts'] = adata.X.sum(axis=1)
-
-    single = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=1, copy=True)
-    assert adata.X.shape == single.shape
-
-    multi = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=2, copy=True)
-
-    np.testing.assert_array_equal(single.X, multi.X)
-
-
-def test_regress_out_large():
+def test_regress_out_ordinal():
     from scipy.sparse import random
     adata = AnnData(random(5000, 2000, density=0.6, format='csr'))
     adata.obs['percent_mito'] = np.random.rand(adata.X.shape[0])
     adata.obs['n_counts'] = adata.X.sum(axis=1)
 
+    # results using only one processor
     single = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=1, copy=True)
     assert adata.X.shape == single.X.shape
 
-    multi = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=32, copy=True)
+    # results using 8 processors
+    multi = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=8, copy=True)
 
     np.testing.assert_array_equal(single.X, multi.X)
 
@@ -74,5 +62,5 @@ def test_regress_out_categorical():
     # create a categorical column
     adata.obs['batch'] = pd.Categorical(np.random.randint(1, 10, size=adata.X.shape[0]))
 
-    multi = sc.pp.regress_out(adata, keys='batch', n_jobs=32, copy=True)
+    multi = sc.pp.regress_out(adata, keys='batch', n_jobs=8, copy=True)
     assert adata.X.shape == multi.X.shape

--- a/scanpy/tests/preprocessing.py
+++ b/scanpy/tests/preprocessing.py
@@ -30,9 +30,49 @@ def test_normalize_per_cell():
     assert adata.X.sum(axis=1).tolist() == adata_sparse.X.sum(
         axis=1).A1.tolist()
 
+
 def test_recipe_plotting():
     sc.settings.autoshow = False
     adata = AnnData(np.random.randint(0, 1000, (1000, 1000)))
     # These shouldn't throw an error
     sc.pp.recipe_seurat(adata.copy(), plot=True)
     sc.pp.recipe_zheng17(adata.copy(), plot=True)
+
+
+def test_regress_out_minimal():
+    adata = AnnData(np.array([[1, 0], [3, 0], [5, 6]]))
+    sc.pp.normalize_per_cell(adata, counts_per_cell_after=1, key_n_counts='n_counts2')
+    adata.obs['percent_mito'] = [0.1, 0.2, 0.05]
+    adata.obs['n_counts'] = adata.X.sum(axis=1)
+
+    single = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=1, copy=True)
+    assert adata.X.shape == single.shape
+
+    multi = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=2, copy=True)
+
+    np.testing.assert_array_equal(single.X, multi.X)
+
+
+def test_regress_out_large():
+    from scipy.sparse import random
+    adata = AnnData(random(5000, 2000, density=0.6, format='csr'))
+    adata.obs['percent_mito'] = np.random.rand(adata.X.shape[0])
+    adata.obs['n_counts'] = adata.X.sum(axis=1)
+
+    single = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=1, copy=True)
+    assert adata.X.shape == single.X.shape
+
+    multi = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=32, copy=True)
+
+    np.testing.assert_array_equal(single.X, multi.X)
+
+
+def test_regress_out_categorical():
+    from scipy.sparse import random
+    import pandas as pd
+    adata = AnnData(random(2500, 1000, density=0.6, format='csr'))
+    # create a categorical column
+    adata.obs['batch'] = pd.Categorical(np.random.randint(1, 10, size=adata.X.shape[0]))
+
+    multi = sc.pp.regress_out(adata, keys='batch', n_jobs=32, copy=True)
+    assert adata.X.shape == multi.X.shape


### PR DESCRIPTION
This PR adds multiprocessing to the pp.regress_out function. 

Here some benchmarks:

```python
import numpy as np
import pandas as pd
import scanpy.api as sc
from anndata import AnnData
from scipy.sparse import random

# create a matrix with 20.000 cells with 3000 genes
adata = AnnData(random(20000, 3000, density=0.6, format='csr'))
```
**Benchmark using ordinal variables**
```python
# create a categorical column and run regress out using 
# the categorical column
adata.obs['batch'] = pd.Categorical(np.random.randint(1, 4, size=adata.X.shape[0]))
%timeit res = sc.pp.regress_out(adata, keys='batch', n_jobs=20, copy=True)
```
> 8.44 s ± 292 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```python
# import previous version of the function (which I saved in the file simple_old.py)
from scanpy.preprocessing.simple_old import regress_out_old
%timeit res_old = regress_out_old(adata, keys='batch', n_jobs=1, copy=True)
```
> 1min 5s ± 4.45 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

**Compare that the previous and the new output are the same**
```python
np.array_equal(res.X, res_old.X)
```
> True

**Benchmark using ordinal variables**
```python
adata.obs['percent_mito'] = np.random.rand(adata.X.shape[0])
adata.obs['n_counts'] = adata.X.sum(axis=1)

%timeit res2 = sc.pp.regress_out(adata, keys=['n_counts', 'percent_mito'], n_jobs=32, copy=True)
```
> 4.99 s ± 501 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

```python
%timeit res2_old = regress_out_old(adata, keys=['n_counts', 'percent_mito'], n_jobs=1, copy=True)
```
> 41.2 s ± 7.79 s per loop (mean ± std. dev. of 7 runs, 1 loop each)

```python
np.array_equal(res2.X, res2_old.X)
```
> True
