### PR TITLE
added highest expressed genes QC

### DIFF
--- a/scanpy/api/pl.py
+++ b/scanpy/api/pl.py
@@ -19,3 +19,5 @@ from ..plotting import palettes
 
 from ..plotting.utils import matrix
 from ..plotting.utils import timeseries, timeseries_subplot, timeseries_as_heatmap
+
+from ..plotting.qc import highest_expr_genes

--- a/scanpy/plotting/anndata.py
+++ b/scanpy/plotting/anndata.py
@@ -440,7 +440,7 @@ def _scatter_obs(
         if mask_remaining.sum() > 0:
             data = [Y[mask_remaining, 0], Y[mask_remaining, 1]]
             if projection == '3d': data.append(Y[mask_remaining, 2])
-            axs[ikey].scatter(*data, marker='.', c='grey', s=size,
+            axs[ikey].scatter(*data, marker='.', c='lightgrey', s=size,
                                     edgecolors='none', zorder=-1)
         legend = None
         if legend_loc.startswith('on data'):

--- a/scanpy/plotting/qc.py
+++ b/scanpy/plotting/qc.py
@@ -1,0 +1,57 @@
+import seaborn as sns
+from matplotlib import pyplot as plt
+import pandas as pd
+from . import utils
+from ..preprocessing.simple import normalize_per_cell
+
+
+def highest_expr_genes(adata, n_top=30, save=None, show=None, ax=None, **kwargs):
+    """
+    Computes, for each gene, the fraction of counts assigned
+    to that gene within a cell. The n_top genes with the highest
+    mean fraction over all cells are plotted as boxplots.
+
+    This plot is similar to the `scater` package function
+    `plotQC(type = "highest-expression")`.
+    See (https://bioconductor.org/packages/devel/bioc/vignettes/scater/inst/doc/vignette-qc.html)
+
+    Parameters
+    ----------
+    adata : :class:`~scanpy.api.AnnData`
+        Annotated data matrix.
+    n_top : int, optional (default:30)
+        Number of top
+    save : `bool` or `str`, optional (default: `None`)
+        If `True` or a `str`, save the figure. A string is appended to the
+        default filename. Infer the filetype if ending on {{'.pdf', '.png', '.svg'}}.
+    show : bool, optional (default: None)
+        Show the plot, do not return axis.
+    ax : `matplotlib.Axes`
+         A `matplotlib.Axes` object.
+    **kwargs : keyword arguments
+        Are passed to `seaborn.boxplot`.
+
+    Returns
+    -------
+    A `matplotlib.Axes` object
+
+    """
+    # compute the percentage of each gene per cell
+    dat = normalize_per_cell(adata, counts_per_cell_after=100, copy=True)
+
+    # identify the genes with the highest mean
+    dat.var['mean_percent'] = dat.X.mean(axis=0).A1
+
+    top = dat.var.sort_values('mean_percent', ascending=False).index[:n_top]
+
+    dat = dat[:, top]
+    dat = pd.DataFrame(dat.X.todense(), index=dat.obs_names, columns=dat.var_names)
+    if not ax:
+        # figsize is hardcoded to produce a tall image. To change the fig size,
+        # a matplotlib.Axes object needs to be passed.
+        height = (n_top * 0.2) + 1.5
+        fig, ax = plt.subplots(figsize=(5, height))
+    sns.boxplot(data=dat, orient='h', ax=ax, fliersize=1, **kwargs)
+    ax.set_xlabel("% of total counts")
+    utils.savefig_or_show('highest_expression', show=show, save=save)
+    return ax

--- a/scanpy/plotting/tools/__init__.py
+++ b/scanpy/plotting/tools/__init__.py
@@ -1018,7 +1018,8 @@ def louvain(
     utils.savefig_or_show('louvain_' + basis, show=show, save=save)
 
 
-def rank_genes_groups(adata, groups=None, n_genes=20, gene_symbols=None, key=None, fontsize=8, show=None, save=None, ext=None):
+def rank_genes_groups(adata, groups=None, n_genes=20, gene_symbols=None, key=None, fontsize=8,
+                      show=None, save=None, panels_per_row=5, ax=None):
     """Plot ranking of genes.
 
     Parameters
@@ -1036,6 +1037,8 @@ def rank_genes_groups(adata, groups=None, n_genes=20, gene_symbols=None, key=Non
         Fontsize for gene names.
     show : `bool`, optional (default: `None`)
         Show the plot, do not return axis.
+    panels_per_row: `int`, optional (default: 5)
+        Number of panels shown per row.
     save : `bool` or `str`, optional (default: `None`)
         If `True` or a `str`, save the figure. A string is appended to the
         default filename. Infer the filetype if ending on {{'.pdf', '.png', '.svg'}}.
@@ -1051,12 +1054,9 @@ def rank_genes_groups(adata, groups=None, n_genes=20, gene_symbols=None, key=Non
     # one panel for each group
     n_panels = len(group_names)
     # set up the figure
-    if n_panels <= 5:
-        n_panels_y = 1
-        n_panels_x = n_panels
-    else:
-        n_panels_y = 2
-        n_panels_x = int(n_panels/2+0.5)
+    n_panels_x = panels_per_row
+    n_panels_y = np.ceil(len(group_names) / n_panels_x).astype(int)
+
     from matplotlib import gridspec
     fig = pl.figure(figsize=(n_panels_x * rcParams['figure.figsize'][0],
                              n_panels_y * rcParams['figure.figsize'][1]))
@@ -1189,7 +1189,7 @@ def rank_genes_groups_violin(
                     + str(adata.uns[key]['params']['groupby'])
                     + '_' + group_name)
         utils.savefig_or_show(writekey, show=show, save=save)
-
+        return _ax
 
 def sim(adata, tmax_realization=None, as_heatmap=False, shuffle=False,
         show=None, save=None):


### PR DESCRIPTION
This PR adds the option to make an image like the following:

```python
sc.pl.highest_expr_genes(adata, n_top=40)
```
<img src="https://user-images.githubusercontent.com/4964309/41143405-6ac1acd8-6af9-11e8-8a9f-6fc6c7d9846a.png" width="450px">


This plot is similar to the one produced by `scater` function `plotQC` and is useful to identify highly expressed genes in a sample.

To keep the code tidy I added the new plot on  `scanpy/plotting/qc.py` I imagine that other QC plots can be added in the future. Possible future improvements can plot multiple panels by splitting the data using batch for example.

Additionally, this PR:

 * Changes the *grey* dot color of `_scatter_obs` to *ligh_grey*. This results in a better contrast of colors. E.g.:
```python
sc.pl.umap(bdata, color='batch', groups=['PBMC'])
```
<img src="https://user-images.githubusercontent.com/4964309/41143661-6341e17a-6afa-11e8-98e1-e48bd9c1a3d3.png" width="350px">

 * Added option to select the number of panels for `rank_genes_groups`. Without this option, if there are too many louvain groups, then the image is too wide. With the new parameter, it is easy to select how many panels per row should be plotted.