### PR TITLE
Added visualizations for variables ordered by observations. E.g. marker genes ordered by cluster

### DIFF
--- a/scanpy/api/pl.py
+++ b/scanpy/api/pl.py
@@ -1,4 +1,4 @@
-from ..plotting.anndata import scatter, violin, ranking, clustermap
+from ..plotting.anndata import scatter, violin, ranking, clustermap, heatmap
 
 from ..plotting.preprocessing import filter_genes_dispersion
 

--- a/scanpy/plotting/anndata.py
+++ b/scanpy/plotting/anndata.py
@@ -831,8 +831,9 @@ def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categor
 
     height = 12
     width = len(var_names) * 0.3 + 2
+    ax_frac2width = 0.010 * width
     fig, axs = pl.subplots(nrows=1, ncols=3, sharey=False,
-                           figsize=(width, height), gridspec_kw={'width_ratios': [0.5, 10, 0.5]})
+                           figsize=(width, height), gridspec_kw={'width_ratios': [ax_frac2width, width, ax_frac2width]})
     groupby_ax = axs[0]
     heatmap_ax = axs[1]
     heatmap_cbar_ax = axs[2]
@@ -868,5 +869,5 @@ def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categor
     sns.heatmap(obs_tidy, yticklabels='none', ax=heatmap_ax, cbar_ax=heatmap_cbar_ax, **kwargs)
     heatmap_ax.set_yticklabels([])
     heatmap_ax.set_ylabel('')
-    pl.subplots_adjust(wspace=0.05, hspace=0.01)
+    pl.subplots_adjust(wspace=0.02, hspace=0.01)
     return axs

--- a/scanpy/plotting/anndata.py
+++ b/scanpy/plotting/anndata.py
@@ -764,7 +764,8 @@ def clustermap(
     else: return g
 
 
-def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categories=7, **kwargs):
+def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categories=7,
+            show=None, save=None, **kwargs):
     """Plot a heatmap of the expression values of `var_names`. If groupby is given, the heatmap
     is ordered by the respective group. For example, a list of marker genes
     can be plotted, ordered by clustering. If the groupby observation is not categorical
@@ -788,7 +789,12 @@ def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categor
     num_categories : `int`, optional (default: `7`)
         Only used if groupby observation is not categorical. This value determines
         the number of groups into which the groupby observation should be subdivided.
-   **kwargs : keyword arguments
+    show : bool, optional (default: `None`)
+         Show the plot.
+    save : `bool` or `str`, optional (default: `None`)
+        If `True` or a `str`, save the figure. A string is appended to the
+        default filename. Infer the filetype if ending on {{'.pdf', '.png', '.svg'}}.
+    **kwargs : keyword arguments
         Are passed to `seaborn.heatmap`.
 
     Returns
@@ -870,4 +876,6 @@ def heatmap(adata, var_names, groupby=None, use_raw=True, log=False, num_categor
     heatmap_ax.set_yticklabels([])
     heatmap_ax.set_ylabel('')
     pl.subplots_adjust(wspace=0.02, hspace=0.01)
+    utils.savefig_or_show('heatmap', show=show, save=save)
+
     return axs

--- a/scanpy/preprocessing/simple.py
+++ b/scanpy/preprocessing/simple.py
@@ -407,7 +407,7 @@ def filter_genes_fano_deprecated(X, Ecutoff, Vcutoff):
 def log1p(data, copy=False, chunked=False, chunk_size=None):
     """Logarithmize the data matrix.
 
-    Computes `X = log(X + 1)`, where `log` denotes the natural logrithm.
+    Computes `X = log(X + 1)`, where `log` denotes the natural logarithm.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adds extra functionality to `pl.violin` adding the option produce stacked violin plots for each `key` passed. The new optional boolean argument `stripplot` was added to add/remove the stripplot on top of the violin plots. An example image is:

![image](https://user-images.githubusercontent.com/4964309/41411458-3e105336-6fdd-11e8-8e18-07e49fe7c8d1.png)

Similarly, I added `pl.heatmap` that plots variables ordered by an observation as follows:

![image](https://user-images.githubusercontent.com/4964309/41411511-6996f334-6fdd-11e8-93ff-176b89743d83.png)

An example notebook using these visualizations is [here](https://gist.github.com/fidelram/2289b7a8d6da055fb058ac9a79ed485c)
