### PR TITLE
Fix sc.write() for files without extensions

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -507,7 +507,7 @@ def is_valid_filename(filename, return_ext=False):
     # cases for gzipped/bzipped text files
     if len(ext) == 2 and ext[0][1:] in text_exts and ext[1][1:] in ('gz', 'bz2'):
         return ext[0][1:] if return_ext else True
-    elif ext[-1][1:] in avail_exts:
+    elif ext and ext[-1][1:] in avail_exts:
         return ext[-1][1:] if return_ext else True
     elif ''.join(ext) == '.soft.gz':
         return 'soft.gz' if return_ext else True


### PR DESCRIPTION
`sc.write('filewithoutextension', adata)` is broken right now. I noticed it via a related report in DCA (https://github.com/theislab/dca/issues/13). Filenames without extension should fallback to final else and return False, but now IndexError exception is raised since `ext[-1]` is invalid for empty list.