### PR TITLE
Speed up log1p

### DIFF
--- a/scanpy/preprocessing/simple.py
+++ b/scanpy/preprocessing/simple.py
@@ -404,7 +404,7 @@ def filter_genes_fano_deprecated(X, Ecutoff, Vcutoff):
     return gene_subset
 
 
-def log1p(data, copy=False, chunked=False, chunk_size=None):
+def log1p(data, copy=False):
     """Logarithmize the data matrix.
 
     Computes `X = log(X + 1)`, where `log` denotes the natural logarithm.
@@ -422,19 +422,20 @@ def log1p(data, copy=False, chunked=False, chunk_size=None):
     -------
     Returns or updates `data`, depending on `copy`.
     """
+    if copy:
+        data = data.copy()
+    
     if isinstance(data, AnnData):
-        adata = data.copy() if copy else data
-        if chunked:
-            for chunk, start, end in adata.chunked_X(chunk_size):
-                adata.X[start:end] = log1p(chunk)
+        if issparse(data.X):
+            np.log1p(data.X.data, out=data.X.data)
         else:
-            adata.X = log1p(data.X)
-        return adata if copy else None
-    X = data  # proceed with data matrix
-    if not issparse(X):
-        return np.log1p(X)
+            np.log1p(data.X, out=data.X)
+    elif issparse(data):
+        np.log1p(data.data, out=data.data)
     else:
-        return X.log1p()
+        np.log1p(data, out=data)
+
+    return data if copy else None
 
 
 def pca(data, n_comps=None, zero_center=True, svd_solver='auto', random_state=0,


### PR DESCRIPTION
We noticed some performance issues with `scanpy.api.pp.log1p` and I think these changes will make it faster and more memory efficient. The `out` argument of `np.log1p` can be used to modify data in-place, conserving memory (this does require special-casing for sparse matrices, unfortunately). Because it's a ufunc, it's quite fast and efficient.

With those changes I removed the `chunked` and `chunk_size` arguments for this function, because I don't think they would actually help performance. In fact I found that using `chunked=True` was extremely slow, possibly because of having so many function calls. The only advantage I can imagine there is if you used parallelization on the chunks, but until that's implemented I think the option should be removed.