### PR TITLE
Add MAGIC API

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -52,6 +52,7 @@ For visual quality control, also see :func:`~scanpy.api.pl.highest_expr_gens` an
    :toctree: .
 
    pp.dca
+   pp.magic
 
 **Neighbors**
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -152,6 +152,10 @@ References
    *Multicore t-SNE*,
    `GitHub <https://github.com/DmitryUlyanov/Multicore-TSNE>`__.
 
+.. [vanDijk18] Van Dijk D *et al.* (2018),
+   *Recovering Gene Interactions from Single-Cell Data Using Data Diffusion*,
+   `Cell <https://www.cell.com/cell/abstract/S0092-8674(18)30724-4>`__.
+
 .. [Weinreb17] Weinreb *et al.* (2016),
    *SPRING: a kinetic interface for visualizing high dimensional single-cell expression data*,
    `bioRxiv <https://doi.org/10.1101/090332>`__.

--- a/scanpy/api/pp.py
+++ b/scanpy/api/pp.py
@@ -1,6 +1,7 @@
 from ..preprocessing.recipes import recipe_zheng17, recipe_weinreb17, recipe_seurat
 from ..preprocessing.simple import filter_cells, filter_genes, filter_genes_dispersion
-from ..preprocessing.simple import log1p, pca, normalize_per_cell, regress_out, scale, subsample, downsample_counts
+from ..preprocessing.simple import log1p, sqrt, pca, normalize_per_cell, regress_out, scale, subsample, downsample_counts
 from ..preprocessing.mnn_correct import mnn_correct
 from ..preprocessing.dca import dca
+from ..preprocessing.magic import magic
 from ..neighbors import neighbors

--- a/scanpy/preprocessing/magic.py
+++ b/scanpy/preprocessing/magic.py
@@ -1,0 +1,137 @@
+"""Denoise high-dimensional data using MAGIC
+"""
+
+import numbers
+import numpy as np
+
+from .. import settings
+from .. import logging as logg
+
+
+def magic(adata,
+          name_list=None,
+          k=10,
+          a=15,
+          t='auto',
+          n_pca=100,
+          knn_dist='euclidean',
+          random_state=None,
+          n_jobs=None,
+          verbose=False,
+          copy=False,
+          **kwargs):
+    """Markov Affinity-based Graph Imputation of Cells (MAGIC) API [vanDijk18]_.
+
+    MAGIC is an algorithm for denoising and transcript recover of single cells
+    applied to single-cell sequencing data. MAGIC builds a graph from the data
+    and uses diffusion to smooth out noise and recover the data manifold.
+
+    More information and bug reports
+    `here <https://github.com/KrishnaswamyLab/MAGIC>`__. For help, visit
+    <https://krishnaswamylab.org/get-help>.
+
+    Parameters
+    ----------
+    adata : :class:`~scanpy.api.AnnData`
+        An anndata file with `.raw` attribute representing raw counts.
+    name_list : `list`, `'all_genes'`, or `'pca_only'`, optional (default: `'all_genes'`)
+        Denoised genes to return. Default is all genes, but this
+        may require a large amount of memory if the input data is sparse.
+    k : int, optional, default: 10
+        number of nearest neighbors on which to build kernel
+    a : int, optional, default: 15
+        sets decay rate of kernel tails.
+        If None, alpha decaying kernel is not used
+    t : int, optional, default: 'auto'
+        power to which the diffusion operator is powered.
+        This sets the level of diffusion. If 'auto', t is selected
+        according to the Procrustes disparity of the diffused data
+    n_pca : int, optional, default: 100
+        Number of principal components to use for calculating
+        neighborhoods. For extremely large datasets, using
+        n_pca < 20 allows neighborhoods to be calculated in
+        roughly log(n_samples) time.
+    knn_dist : string, optional, default: 'euclidean'
+        recommended values: 'euclidean', 'cosine', 'precomputed'
+        Any metric from `scipy.spatial.distance` can be used
+        distance metric for building kNN graph. If 'precomputed',
+        `data` should be an n_samples x n_samples distance or
+        affinity matrix
+    random_state : `int`, `numpy.RandomState` or `None`, optional (default: `None`)
+        Random seed. Defaults to the global `numpy` random number generator
+    n_jobs : `int` or None, optional. Default: None
+        Number of threads to use in training. All cores are used by default.
+    verbose : `bool`, `int` or `None`, optional (default: `sc.settings.verbosity`)
+        If `True` or an integer `>= 2`, print status messages.
+        If `None`, `sc.settings.verbosity` is used.
+    copy : `bool`, optional. Default: `False`.
+        If true, a copy of anndata is returned.
+    kwargs : additional arguments to `magic.MAGIC`
+
+    Returns
+    -------
+    If `copy` is true, AnnData object is returned.
+
+    If `subset_genes` is not `all_genes`, PCA on MAGIC values of cells are stored in
+    `adata.obsm['X_magic']` and `adata.X` is not modified.
+
+    The raw counts are stored in `.raw` attribute of AnnData object.
+
+    Examples
+    --------
+    >>> import scanpy.api as sc
+    >>> import magic
+    >>> adata = sc.datasets.paul15()
+    >>> sc.pp.normalize_per_cell(adata)
+    >>> sc.pp.sqrt(adata)  # or sc.pp.log1p(adata)
+    >>> sc.pp.magic(adata, name_list=['Mpo', 'Klf1', 'Ifitm1'], k=5)
+    >>> adata.obsm['X_magic'].shape
+    (2730, 3)
+    >>> sc.pp.magic(adata, name_list='pca_only', k=5)
+    >>> adata.obsm['X_magic'].shape
+    (2730, 100)
+    >>> sc.pp.magic(adata, name_list='all_genes', k=5)
+    >>> adata.X.shape
+    (2730, 3451)
+    """
+
+    try:
+        from magic import MAGIC
+    except ImportError:
+        raise ImportError(
+            'Please install magic package via `pip install --user '
+            'git+git://github.com/KrishnaswamyLab/MAGIC.git#subdirectory=python`')
+
+    logg.info('computing PHATE', r=True)
+    adata = adata.copy() if copy else adata
+    verbose = settings.verbosity if verbose is None else verbose
+    if isinstance(verbose, int):
+        verbose = verbose >= 2
+    n_jobs = settings.n_jobs if n_jobs is None else n_jobs
+
+    X_magic = MAGIC(k=k,
+                    a=a,
+                    t=t,
+                    n_pca=n_pca,
+                    knn_dist=knn_dist,
+                    random_state=random_state,
+                    n_jobs=n_jobs,
+                    verbose=verbose,
+                    **kwargs).fit_transform(adata,
+                                            genes=name_list)
+    logg.info('    finished', time=True,
+              end=' ' if settings.verbosity > 2 else '\n')
+    # update AnnData instance
+    adata.raw = adata
+    if X_magic.shape[1] != adata.X.shape[1]:
+        adata.obsm["X_magic"] = X_magic
+        if name_list == "pca_only":
+            logg.hint('added\n'
+                      '    \'X_magic\', PCA on MAGIC coordinates (adata.obsm)')
+        else:
+            logg.hint('added\n'
+                      '    \'X_magic\', MAGIC smoothed gene values (adata.obsm)')
+    else:
+        adata.X = X_magic
+    if copy:
+        return adata

--- a/scanpy/preprocessing/simple.py
+++ b/scanpy/preprocessing/simple.py
@@ -437,6 +437,39 @@ def log1p(data, copy=False, chunked=False, chunk_size=None):
         return X.log1p()
 
 
+def sqrt(data, copy=False, chunked=False, chunk_size=None):
+    """Square root the data matrix.
+
+    Computes `X = sqrt(X)`.
+
+    Parameters
+    ----------
+    data : :class:`~scanpy.api.AnnData`, `np.ndarray`, `sp.sparse`
+        The (annotated) data matrix of shape `n_obs` × `n_vars`. Rows correspond
+        to cells and columns to genes.
+    copy : `bool`, optional (default: `False`)
+        If an :class:`~scanpy.api.AnnData` is passed, determines whether a copy
+        is returned.
+
+    Returns
+    -------
+    Returns or updates `data`, depending on `copy`.
+    """
+    if isinstance(data, AnnData):
+        adata = data.copy() if copy else data
+        if chunked:
+            for chunk, start, end in adata.chunked_X(chunk_size):
+                adata.X[start:end] = sqrt(chunk)
+        else:
+            adata.X = sqrt(data.X)
+        return adata if copy else None
+    X = data  # proceed with data matrix
+    if not issparse(X):
+        return np.sqrt(X)
+    else:
+        return X.sqrt()
+
+
 def pca(data, n_comps=None, zero_center=True, svd_solver='auto', random_state=0,
         return_info=False, dtype='float32', copy=False, chunked=False, chunk_size=None):
     """Principal component analysis [Pedregosa11]_.

--- a/scanpy/tools/phate.py
+++ b/scanpy/tools/phate.py
@@ -8,12 +8,11 @@ from .. import logging as logg
 def phate(
         adata,
         n_components=2,
-        k=15,
-        a=10,
-        alpha_decay=None,
+        k=5,
+        a=15,
         n_landmark=2000,
         t='auto',
-        potential_method='log',
+        gamma=1,
         n_pca=100,
         knn_dist='euclidean',
         mds_dist='euclidean',
@@ -21,7 +20,8 @@ def phate(
         n_jobs=None,
         random_state=None,
         verbose=None,
-        copy=False):
+        copy=False,
+        **kwargs):
     """PHATE [Moon17]_.
 
     Potential of Heat-diffusion for Affinity-based Trajectory Embedding (PHATE)
@@ -29,9 +29,10 @@ def phate(
     visualization of biological progressions.
 
     For more information and access to the object-oriented interface, read the
-    `PHATE documentation <https://phate.readthedocs.io/>`__.  For help,
+    `PHATE documentation <https://phate.readthedocs.io/>`__.  For
     tutorials, bug reports, and R/MATLAB implementations, visit the `PHATE
-    GitHub page <https://github.com/KrishnaswamyLab/PHATE/>`__.
+    GitHub page <https://github.com/KrishnaswamyLab/PHATE/>`__. For help
+    using PHATE, visit <https://krishnaswamylab.org/get-help>.
 
     Parameters
     ----------
@@ -39,23 +40,22 @@ def phate(
         Annotated data matrix.
     n_components : `int`, optional (default: 2)
         number of dimensions in which the data will be embedded
-    k : `int`, optional (default: 15)
+    k : `int`, optional (default: 5)
         number of nearest neighbors on which to build kernel
-    a : `int`, optional (default: `None`)
+    a : `int`, optional (default: 15)
         sets decay rate of kernel tails.
         If None, alpha decaying kernel is not used
-    alpha_decay : `bool` or `None` (default: `None`)
-        forces the use of alpha decaying kernel
-        If None, alpha decaying kernel is used for small inputs
-        (n_samples < n_landmark) and not used otherwise
     n_landmark : `int`, optional (default: 2000)
         number of landmarks to use in fast PHATE
     t : `int` or 'auto', optional (default: 'auto')
         power to which the diffusion operator is powered
-        sets the level of diffusion
-    potential_method : {'log', 'sqrt'}, optional (default: 'log')
-        Selects which transformation of the diffusional operator is used
-        to compute the diffusion potential
+        sets the level of diffusion. If 'auto', t is selected
+        according to the knee point in the Von Neumann Entropy of
+        the diffusion operator
+    gamma : float, optional, default: 1
+        Informational distance constant between -1 and 1.
+        `gamma=1` gives the PHATE log potential, `gamma=0` gives
+        a square root potential.
     n_pca : `int`, optional (default: 100)
         Number of principal components to use for calculating
         neighborhoods. For extremely large datasets, using
@@ -85,6 +85,7 @@ def phate(
         If `None`, `sc.settings.verbosity` is used.
     copy : `bool` (default: `False`)
         Return a copy instead of writing to `adata`.
+    kwargs : additional arguments to `phate.PHATE`
 
     Returns
     -------
@@ -124,10 +125,9 @@ def phate(
         n_components=n_components,
         k=k,
         a=a,
-        alpha_decay=alpha_decay,
         n_landmark=n_landmark,
         t=t,
-        potential_method=potential_method,
+        gamma=gamma,
         n_pca=n_pca,
         knn_dist=knn_dist,
         mds_dist=mds_dist,
@@ -135,11 +135,12 @@ def phate(
         n_jobs=n_jobs,
         random_state=random_state,
         verbose=verbose,
+        **kwargs
     ).fit_transform(adata)
     logg.info('    finished', time=True,
               end=' ' if settings.verbosity > 2 else '\n')
     # update AnnData instance
-    adata.obsm['X_phate'] = X_phate  # annotate samples with tSNE coordinates
+    adata.obsm['X_phate'] = X_phate  # annotate samples with PHATE coordinates
     logg.hint('added\n'
               '    \'X_phate\', PHATE coordinates (adata.obsm)')
     return adata if copy else None


### PR DESCRIPTION
MAGIC API modelled off the DCA API. A couple of comments:

- I changed `threads` to `n_jobs` to match `sc.tl` API
- I use `sc.settings.verbosity` rather than `False` for `verbose` default
- I updated the PHATE API while I was here
- I'm open to suggestions on how to handle `name_list`.

Re: `name_list`: MAGIC accepts both gene names and column indices. I've set it up currently to return to adata.obsm['X_magic'] if genes are specified as the number of columns is reduced from the original data, and to adata.X if all genes are returned. However, adata.obsm['X_magic'] now has no information about the order of the genes, unless I return it from MAGIC as a `pandas.DataFrame`, or as an AnnData object in its own right. What do you think?

P.S. MAGIC handling `genes` on AnnData input is currently on the dev branch, but will be merged to master once we settle on an API.