### PR TITLE
Fix PYTHON_VERSION in travis installer

### DIFF
--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -20,7 +20,7 @@ export PATH=/home/travis/miniconda3/bin:$PATH
 conda update --yes conda
 popd
 
-conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip pytest \
+conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip pytest hdf5 \
       numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numba scikit-learn statsmodels
 
 source activate testenv

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -11,7 +11,7 @@ ls -l
 echo
 if [[ ! -f miniconda.sh ]]
    then
-   wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
+   wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
        -O miniconda.sh
    fi
 chmod +x miniconda.sh && ./miniconda.sh -b

--- a/.travis_install.sh
+++ b/.travis_install.sh
@@ -20,7 +20,7 @@ export PATH=/home/travis/miniconda3/bin:$PATH
 conda update --yes conda
 popd
 
-conda create -n testenv --yes python=$PYTHON_VERSION pip pytest \
+conda create -n testenv --yes python=$TRAVIS_PYTHON_VERSION pip pytest \
       numpy=$NUMPY_VERSION scipy=$SCIPY_VERSION numba scikit-learn statsmodels
 
 source activate testenv


### PR DESCRIPTION
PYTHON_VERSION variable is empty, so we actually pass `python=` in `conda create` so Travis always tests scanpy with latest Python in Conda distribution. Therefore Python 3.5 is actually never tested. Furthermore, conda switched to python 3.7, so now all test are run on Python 3.7. This is also the reason of weird HDF error message we get in tests.