### PR TITLE
[WIP] Allow weighted network for louvain clustering

### DIFF
--- a/scanpy/tests/clustering.py
+++ b/scanpy/tests/clustering.py
@@ -1,0 +1,19 @@
+import pytest
+import scanpy.api as sc
+
+@pytest.fixture
+def adata_neighbors():
+    adata = sc.read('./data/pbmc3k_raw.h5ad',
+                    backup_url='http://falexwolf.de/data/pbmc3k_raw.h5ad')
+    sc.pp.filter_genes(adata, min_cells=1)
+    sc.pp.normalize_per_cell(adata)
+    sc.pp.log1p(adata)
+    sc.pp.pca(adata)
+    sc.pp.neighbors(adata)
+    return adata
+
+def test_nofail(adata_neighbors): 
+    sc.tl.louvain(adata_neighbors)
+    sc.tl.louvain(adata_neighbors, use_weights=True)
+    sc.tl.louvain(adata_neighbors, use_weights=True, flavor="igraph")
+    sc.tl.louvain(adata_neighbors, flavor="igraph")

--- a/scanpy/tests/clustering.py
+++ b/scanpy/tests/clustering.py
@@ -21,5 +21,4 @@ def test_nofail(adata_neighbors):
 def test_partition_type(adata_neighbors):
     import louvain
     sc.tl.louvain(adata_neighbors, partition_type=louvain.RBERVertexPartition)
-    # Fails due to passing a resolution parameter
-    # sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)
+    sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)

--- a/scanpy/tests/clustering.py
+++ b/scanpy/tests/clustering.py
@@ -17,3 +17,9 @@ def test_nofail(adata_neighbors):
     sc.tl.louvain(adata_neighbors, use_weights=True)
     sc.tl.louvain(adata_neighbors, use_weights=True, flavor="igraph")
     sc.tl.louvain(adata_neighbors, flavor="igraph")
+
+def test_partition_type(adata_neighbors):
+    import louvain
+    sc.tl.louvain(adata_neighbors, partition_type=louvain.RBERVertexPartition)
+    # Fails due to passing a resolution parameter
+    # sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)

--- a/scanpy/tools/louvain.py
+++ b/scanpy/tools/louvain.py
@@ -17,6 +17,7 @@ def louvain(
         directed=True,
         use_weights=False,
         partition_type=None,
+        partition_kwargs={},
         copy=False):
     """Cluster cells into subgroups [Blondel08]_ [Levine15]_ [Traag17]_.
 
@@ -52,6 +53,9 @@ def louvain(
     partition_type : `~louvain.MutableVertexPartition`, optional (default: `None`)
         Type of partition to use. Only a valid argument if `flavor` is 
         `'vtraag'`.
+    partition_kwargs : `dict`, optional
+        Key word arguments to pass to partitioning, if `vtraag` method is 
+        being used.
     copy : `bool` (default: `False`)
         Copy adata or modify it inplace.
 
@@ -103,14 +107,16 @@ def louvain(
             weights = None
         if flavor == 'vtraag':
             import louvain
-            if resolution is None: resolution = 1
             if partition_type is None:
                 partition_type = louvain.RBConfigurationVertexPartition
+            if resolution is not None:
+                partition_kwargs["resolution_parameter"] = resolution
+            if use_weights:
+                partition_kwargs["weights"] = weights
             logg.info('    using the "louvain" package of Traag (2017)')
             louvain.set_rng_seed(random_state)
             part = louvain.find_partition(g, partition_type,
-                                            resolution_parameter=resolution,
-                                            weights=weights)
+                                          **partition_kwargs)
             # adata.uns['louvain_quality'] = part.quality()
         elif flavor == 'igraph':
             part = g.community_multilevel(weights=weights)

--- a/scanpy/tools/louvain.py
+++ b/scanpy/tools/louvain.py
@@ -17,7 +17,7 @@ def louvain(
         directed=True,
         use_weights=False,
         partition_type=None,
-        partition_kwargs={},
+        partition_kwargs=None,
         copy=False):
     """Cluster cells into subgroups [Blondel08]_ [Levine15]_ [Traag17]_.
 
@@ -53,7 +53,7 @@ def louvain(
     partition_type : `~louvain.MutableVertexPartition`, optional (default: `None`)
         Type of partition to use. Only a valid argument if `flavor` is 
         `'vtraag'`.
-    partition_kwargs : `dict`, optional
+    partition_kwargs : `dict`, optional (default: `None`)
         Key word arguments to pass to partitioning, if `vtraag` method is 
         being used.
     copy : `bool` (default: `False`)
@@ -107,6 +107,8 @@ def louvain(
             weights = None
         if flavor == 'vtraag':
             import louvain
+            if partition_kwargs is None:
+                partition_kwargs = {}
             if partition_type is None:
                 partition_type = louvain.RBConfigurationVertexPartition
             if resolution is not None:

--- a/scanpy/tools/louvain.py
+++ b/scanpy/tools/louvain.py
@@ -45,7 +45,7 @@ def louvain(
         `adata.uns['neighbors']['connectivities']`.
     flavor : {'vtraag', 'igraph'}
         Choose between to packages for computing the clustering. 'vtraag' is
-        much more powerful.
+        much more powerful, and the default.
     use_weights : `bool`, optional (default: `False`)
         Use weights from knn graph.
     copy : `bool` (default: `False`)

--- a/scanpy/tools/louvain.py
+++ b/scanpy/tools/louvain.py
@@ -90,13 +90,13 @@ def louvain(
             directed = False
         if not directed: logg.m('    using the undirected graph', v=4)
         g = utils.get_igraph_from_adjacency(adjacency, directed=directed)
+        if use_weights:
+            weights = np.array(g.es["weight"]).astype(np.float64)
+        else:
+            weights = None
         if flavor == 'vtraag':
             import louvain
             if resolution is None: resolution = 1
-            if use_weights:
-                weights = np.array(g.es["weight"]).astype(np.float64)
-            else:
-                weights = None
             try:
                 logg.info('    using the "louvain" package of Traag (2017)')
                 louvain.set_rng_seed(random_state)
@@ -115,7 +115,7 @@ def louvain(
                                               resolution_parameter=resolution,
                                               weights=weights)
         elif flavor == 'igraph':
-            part = g.community_multilevel()
+            part = g.community_multilevel(weights=weights)
         groups = np.array(part.membership)
     elif flavor == 'taynaud':
         # this is deprecated

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     license='BSD',
     install_requires=requires,
     extras_require=dict(
-        louvain=['python-igraph', 'louvain'],
+        louvain=['python-igraph', 'louvain>=0.6'],
         doc=['sphinx', 'sphinx_rtd_theme', 'sphinx_autodoc_typehints'],
         test=['pytest'],
     ),


### PR DESCRIPTION
Previously discussed in #240

A few things left to discuss:

## Tests

These are pretty simple, "this doesn't intrinsically throw an error" type tests. Should the tests cover more than that? Should they be more thorough is checking arguments won't throw errors? I'm open to suggestions on other things that could be checked.

Also, is there a place they'd be more appropriate?

## Allowing storage of multiple network representations 

I think this would also be a pretty simple addition, but wanted to check again before implementing it. I'm thinking of adding a `use_network` argument which would allow key access to network stored in the AnnData object – similar to the `use_rep` argument. @LuckyMD mentioned there might be some storage concerns here, though I think the user is ultimately responsible for size in this case.

The value added here is different representations are useful for different analysis, and it'd be useful to not have to have two objects when the rest of the data would be shared.

## Allow more choice of partition method for `louvain-igraph` package

I'm not too fussed on this one. It's just that `"RBConfiguration"` is hard coded when other methods are available, and I'm not aware of a reason it would be the best choice.