### PR TITLE
Prevent error when no third point is found

### DIFF
--- a/scanpy/tools/dpt.py
+++ b/scanpy/tools/dpt.py
@@ -327,6 +327,8 @@ class DPT(Neighbors):
             # find the third point on the segment that has maximal
             # added distance from the two tip points
             dseg = Dseg[tips[0]] + Dseg[tips[1]]
+            if not np.isfinite(dseg).any():
+                continue
             # add this point to tips, it's a third tip, we store it at the first
             # position in an array called tips3
             third_tip = np.argmax(dseg)


### PR DESCRIPTION
Else `argmax([])` is called later, which doesn’t make sense. This happens because `Dseg[tips[0]] + Dseg[tips[1]]` are all `inf` for some datasets. Is that simply a consequence of my data or is that a bug?

This PR assumes the former and results in such segments being skipped. In case of my data, this means that I end up with a single DPT group instead of multiple ones.