### PR TITLE
P-values added to t-tests and wilcoxon test

### DIFF
--- a/scanpy/tools/rank_genes_groups.py
+++ b/scanpy/tools/rank_genes_groups.py
@@ -167,6 +167,7 @@ def rank_genes_groups(
             mean_rest[mean_rest == 0] = 1e-9  # set 0s to small value
             foldchanges = (means[igroup] + 1e-9) / mean_rest
             scores[np.isnan(scores)] = 0
+            #Get p-values
             denominator_dof = (np.square(vars[igroup]) / (np.square(ns_group)*(ns_group-1))) + (
                 (np.square(var_rest) / (np.square(ns_rest) * (ns_rest - 1))))
             denominator_dof[np.flatnonzero(denominator_dof == 0)] = np.nan
@@ -244,8 +245,6 @@ def rank_genes_groups(
 
             # Loop over all genes
             for gene_idx in range(n_genes):
-                # if gene_idx % 20 == 0:
-                #     print('Group {}, Gene regressions:{:.2%}'.format(current_group, gene_idx / n_genes))
                 scores[gene_idx], pvals[gene_idx] = ranksums(X1[:,gene_idx],X2[:,gene_idx])
 
             mean_rest[mean_rest == 0] = 1e-9  # set 0s to small value
@@ -279,18 +278,10 @@ def rank_genes_groups(
             dtype=[(rn, 'float32') for rn in groups_order_save])
         adata.uns[key_added]['pvals'] = np.rec.fromarrays(
             [n for n in rankings_gene_pvals],
-            dtype=[(rn, 'float32') for rn in groups_order_save])
+            dtype=[(rn, 'float64') for rn in groups_order_save])
         adata.uns[key_added]['pvals_adj'] = np.rec.fromarrays(
             [n for n in rankings_gene_pvals_adj],
-            dtype=[(rn, 'float32') for rn in groups_order_save])
-
-    # if method == 'wilcoxon':
-    #     adata.uns[key_added]['pvals'] = np.rec.fromarrays(
-    #         [n for n in rankings_gene_pvals],
-    #         dtype=[(rn, 'float32') for rn in groups_order_save])
-    #     adata.uns[key_added]['pvals_adj'] = np.rec.fromarrays(
-    #         [n for n in rankings_gene_pvals_adj],
-    #         dtype=[(rn, 'float32') for rn in groups_order_save])
+            dtype=[(rn, 'float64') for rn in groups_order_save])
     
     logg.info('    finished', time=True, end=' ' if settings.verbosity > 2 else '\n')
     logg.hint(
@@ -298,8 +289,8 @@ def rank_genes_groups(
         '    \'names\', sorted np.recarray to be indexed by group ids\n'
         '    \'scores\', sorted np.recarray to be indexed by group ids\n'
         .format(key_added)
-        + ('    \'logfoldchanges\', sorted np.recarray to be indexed by group ids'
-           if method in {'t-test', 't-test_overestim_var'} else '')
-        + ('    \'pvals\', sorted np.recarray to be indexed by group ids'
-           if method in {'wilcoxon'} else ''))
+        + ('    \'logfoldchanges\', sorted np.recarray to be indexed by group ids\n'
+           '    \'pvals\', sorted np.recarray to be indexed by group ids\n'
+           '    \'pvals_adj\', sorted np.recarray to be indexed by group ids'
+           if method in {'t-test', 't-test_overestim_var', 'wilcoxon'} else ''))
     return adata if copy else None

--- a/scanpy/tools/rank_genes_groups.py
+++ b/scanpy/tools/rank_genes_groups.py
@@ -240,8 +240,14 @@ def rank_genes_groups(
             scores = np.zeros(n_genes)
             pvals = np.zeros(n_genes)
 
-            X1=X[mask].todense()
-            X2=X[mask_rest].todense()
+            X1 = X[mask]
+            X2 = X[mask_rest]
+            #Check if matrix is sparse
+            if issparse(X1):
+                X1 = X1.todense()
+
+            if issparse(X2):
+                X2 = X2.todense()
 
             # Loop over all genes
             for gene_idx in range(n_genes):

--- a/scanpy/tools/rank_genes_groups.py
+++ b/scanpy/tools/rank_genes_groups.py
@@ -137,6 +137,8 @@ def rank_genes_groups(
     rankings_gene_scores = []
     rankings_gene_names = []
     rankings_gene_logfoldchanges = []
+    rankings_gene_pvals = []
+    rankings_gene_pvals_adj = []
     
     if method in {'t-test', 't-test_overestim_var'}:
         # loop over all masks and compute means, variances and sample numbers
@@ -202,98 +204,140 @@ def rank_genes_groups(
                 break
 
     elif method == 'wilcoxon':
-        # The whole thing below is an early draft by Tobias Callies and should be cleaned up at some point.
-
-        CONST_MAX_SIZE = 10000000
-        ns_rest = np.zeros(n_groups, dtype=int)
-        # initialize space for z-scores
-        scores = np.zeros(n_genes)
-        # First loop: Loop over all genes
-        if reference != 'rest':
-            for imask, mask in enumerate(groups_masks):
-                if imask == ireference: continue
-                else: mask_rest = groups_masks[ireference]
-                ns_rest[imask] = np.where(mask_rest)[0].size
-                if ns_rest[imask] <= 25 or ns[imask] <= 25:
-                    logg.hint('Few observations in a group for '
-                              'normal approximation (<=25). Lower test accuracy.')
-                n_active = ns[imask]
-                m_active = ns_rest[imask]
-                # Now calculate gene expression ranking in chunkes:
-                chunk = []
-                # Calculate chunk frames
-                n_genes_max_chunk = floor(CONST_MAX_SIZE / (n_active + m_active))
-                if n_genes_max_chunk < n_genes - 1:
-                    chunk_index = n_genes_max_chunk
-                    while chunk_index < n_genes - 1:
-                        chunk.append(chunk_index)
-                        chunk_index = chunk_index + n_genes_max_chunk
-                    chunk.append(n_genes - 1)
-                else:
-                    chunk.append(n_genes - 1)
-                left = 0
-                # Calculate rank sums for each chunk for the current mask
-                for chunk_index, right in enumerate(chunk):
-                    # Check if issparse is true: AnnData objects are currently sparse.csr or ndarray.
-                    if issparse(X):
-                        df1 = pd.DataFrame(data=X[mask, left:right].todense())
-                        df2 = pd.DataFrame(data=X[mask_rest, left:right].todense(),
-                                           index=np.arange(start=n_active, stop=n_active + m_active))
-                    else:
-                        df1 = pd.DataFrame(data=X[mask, left:right])
-                        df2 = pd.DataFrame(data=X[mask_rest, left:right],
-                                           index=np.arange(start=n_active, stop=n_active + m_active))
-                    df1 = df1.append(df2)
-                    ranks = df1.rank()
-                    # sum up adjusted_ranks to calculate W_m,n
-                    scores[left:right] = np.sum(ranks.loc[0:n_active, :])
-                    left = right + 1
-                scores = (scores - (n_active * (n_active + m_active + 1) / 2)) / sqrt(
-                    (n_active * m_active * (n_active + m_active + 1) / 12))
-                scores = scores if not rankby_abs else np.abs(scores)
-                scores[np.isnan(scores)] = 0
-                partition = np.argpartition(scores, -n_genes_user)[-n_genes_user:]
-                partial_indices = np.argsort(scores[partition])[::-1]
-                global_indices = reference_indices[partition][partial_indices]
-                rankings_gene_scores.append(scores[global_indices])
-                rankings_gene_names.append(adata_comp.var_names[global_indices])
-        # If no reference group exists, ranking needs only to be done once (full mask)
-        else:
-            scores = np.zeros((n_groups, n_genes))
-            chunk = []
-            n_cells = X.shape[0]
-            n_genes_max_chunk = floor(CONST_MAX_SIZE / n_cells)
-            if n_genes_max_chunk < n_genes - 1:
-                chunk_index = n_genes_max_chunk
-                while chunk_index < n_genes - 1:
-                    chunk.append(chunk_index)
-                    chunk_index = chunk_index + n_genes_max_chunk
-                chunk.append(n_genes - 1)
+        # Edited to use scicpy.stats.ranksum test and output p-values
+        from scipy.stats import ranksums
+        # loop over all masks and compute means, variances and sample numbers
+        means = np.zeros((n_groups, n_genes))
+        vars = np.zeros((n_groups, n_genes))
+        for imask, mask in enumerate(groups_masks):
+            means[imask], vars[imask] = simple._get_mean_var(X[mask])
+        # test each either against the union of all other groups or against a
+        # specific group
+            if reference == 'rest':
+                mask_rest = ~mask
             else:
-                chunk.append(n_genes - 1)
-            left = 0
-            for chunk_index, right in enumerate(chunk):
-                # Check if issparse is true
-                if issparse(X):
-                    df1 = pd.DataFrame(data=X[:, left:right].todense())
+                if imask == ireference:
+                    continue
                 else:
-                    df1 = pd.DataFrame(data=X[:, left:right])
-                ranks = df1.rank()
-                # sum up adjusted_ranks to calculate W_m,n
-                for imask, mask in enumerate(groups_masks):
-                    scores[imask, left:right] = np.sum(ranks.loc[mask, :])
-                left = right + 1
+                    mask_rest = groups_masks[ireference]
+            current_group = groups_order[imask]
+            mean_rest, var_rest = simple._get_mean_var(X[mask_rest])
+            ns_group = ns[imask]  # number of observations in group
+            ns_rest = np.where(mask_rest)[0].size #number of observations in 'rest'
 
-            for imask, mask in enumerate(groups_masks):
-                scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
-                    (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
-                scores = scores if not rankby_abs else np.abs(scores)
-                scores[np.isnan(scores)] = 0
-                partition = np.argpartition(scores[imask, :], -n_genes_user)[-n_genes_user:]
-                partial_indices = np.argsort(scores[imask, partition])[::-1]
-                global_indices = reference_indices[partition][partial_indices]
-                rankings_gene_scores.append(scores[imask, global_indices])
-                rankings_gene_names.append(adata_comp.var_names[global_indices])
+            #Initialize scores and p-values vectors
+            scores = np.zeros(n_genes)
+            pvals = np.zeros(n_genes)
+
+            X1=X[mask].todense()
+            X2=X[mask_rest].todense()
+
+            # Loop over all genes
+            for gene_idx in range(n_genes):
+                # if gene_idx % 20 == 0:
+                #     print('Group {}, Gene regressions:{:.2%}'.format(current_group, gene_idx / n_genes))
+                scores[gene_idx], pvals[gene_idx] = ranksums(X1[:,gene_idx],X2[:,gene_idx])
+
+            mean_rest[mean_rest == 0] = 1e-9  # set 0s to small value
+            foldchanges = (means[imask] + 1e-9) / mean_rest
+            scores[np.isnan(scores)] = 0
+            pvals_adj = pvals*n_genes
+            scores_sort = np.abs(scores) if rankby_abs else scores
+            partition = np.argpartition(scores_sort, -n_genes_user)[-n_genes_user:]
+            partial_indices = np.argsort(scores_sort[partition])[::-1]
+            global_indices = reference_indices[partition][partial_indices]
+            rankings_gene_scores.append(scores[global_indices])
+            rankings_gene_logfoldchanges.append(np.log2(np.abs(foldchanges[global_indices])))
+            rankings_gene_names.append(adata_comp.var_names[global_indices])
+            rankings_gene_pvals.append(pvals[global_indices])
+            rankings_gene_pvals_adj.append(pvals_adj[global_indices])
+
+        # # First loop: Loop over all genes
+        # if reference != 'rest':
+        #     for imask, mask in enumerate(groups_masks):
+        #         if imask == ireference: continue
+        #         else: mask_rest = groups_masks[ireference]
+        #         ns_rest[imask] = np.where(mask_rest)[0].size
+        #         if ns_rest[imask] <= 25 or ns[imask] <= 25:
+        #             logg.hint('Few observations in a group for '
+        #                       'normal approximation (<=25). Lower test accuracy.')
+        #         n_active = ns[imask]
+        #         m_active = ns_rest[imask]
+        #         # Now calculate gene expression ranking in chunkes:
+        #         chunk = []
+        #         # Calculate chunk frames
+        #         n_genes_max_chunk = floor(CONST_MAX_SIZE / (n_active + m_active))
+        #         if n_genes_max_chunk < n_genes - 1:
+        #             chunk_index = n_genes_max_chunk
+        #             while chunk_index < n_genes - 1:
+        #                 chunk.append(chunk_index)
+        #                 chunk_index = chunk_index + n_genes_max_chunk
+        #             chunk.append(n_genes - 1)
+        #         else:
+        #             chunk.append(n_genes - 1)
+        #         left = 0
+        #         # Calculate rank sums for each chunk for the current mask
+        #         for chunk_index, right in enumerate(chunk):
+        #             # Check if issparse is true: AnnData objects are currently sparse.csr or ndarray.
+        #             if issparse(X):
+        #                 df1 = pd.DataFrame(data=X[mask, left:right].todense())
+        #                 df2 = pd.DataFrame(data=X[mask_rest, left:right].todense(),
+        #                                    index=np.arange(start=n_active, stop=n_active + m_active))
+        #             else:
+        #                 df1 = pd.DataFrame(data=X[mask, left:right])
+        #                 df2 = pd.DataFrame(data=X[mask_rest, left:right],
+        #                                    index=np.arange(start=n_active, stop=n_active + m_active))
+        #             df1 = df1.append(df2)
+        #             ranks = df1.rank()
+        #             # sum up adjusted_ranks to calculate W_m,n
+        #             scores[left:right] = np.sum(ranks.loc[0:n_active, :])
+        #             left = right + 1
+        #         scores = (scores - (n_active * (n_active + m_active + 1) / 2)) / sqrt(
+        #             (n_active * m_active * (n_active + m_active + 1) / 12))
+        #         scores = scores if not rankby_abs else np.abs(scores)
+        #         scores[np.isnan(scores)] = 0
+        #         partition = np.argpartition(scores, -n_genes_user)[-n_genes_user:]
+        #         partial_indices = np.argsort(scores[partition])[::-1]
+        #         global_indices = reference_indices[partition][partial_indices]
+        #         rankings_gene_scores.append(scores[global_indices])
+        #         rankings_gene_names.append(adata_comp.var_names[global_indices])
+        # # If no reference group exists, ranking needs only to be done once (full mask)
+        # else:
+        #     scores = np.zeros((n_groups, n_genes))
+        #     chunk = []
+        #     n_cells = X.shape[0]
+        #     n_genes_max_chunk = floor(CONST_MAX_SIZE / n_cells)
+        #     if n_genes_max_chunk < n_genes - 1:
+        #         chunk_index = n_genes_max_chunk
+        #         while chunk_index < n_genes - 1:
+        #             chunk.append(chunk_index)
+        #             chunk_index = chunk_index + n_genes_max_chunk
+        #         chunk.append(n_genes - 1)
+        #     else:
+        #         chunk.append(n_genes - 1)
+        #     left = 0
+        #     for chunk_index, right in enumerate(chunk):
+        #         # Check if issparse is true
+        #         if issparse(X):
+        #             df1 = pd.DataFrame(data=X[:, left:right].todense())
+        #         else:
+        #             df1 = pd.DataFrame(data=X[:, left:right])
+        #         ranks = df1.rank()
+        #         # sum up adjusted_ranks to calculate W_m,n
+        #         for imask, mask in enumerate(groups_masks):
+        #             scores[imask, left:right] = np.sum(ranks.loc[mask, :])
+        #         left = right + 1
+        #
+        #     for imask, mask in enumerate(groups_masks):
+        #         scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
+        #             (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
+        #         scores = scores if not rankby_abs else np.abs(scores)
+        #         scores[np.isnan(scores)] = 0
+        #         partition = np.argpartition(scores[imask, :], -n_genes_user)[-n_genes_user:]
+        #         partial_indices = np.argsort(scores[imask, partition])[::-1]
+        #         global_indices = reference_indices[partition][partial_indices]
+        #         rankings_gene_scores.append(scores[imask, global_indices])
+        #         rankings_gene_names.append(adata_comp.var_names[global_indices])
 
     groups_order_save = [str(g) for g in groups_order]
     if (reference != 'rest' and method != 'logreg') or (method == 'logreg' and len(groups) == 2):
@@ -305,9 +349,17 @@ def rank_genes_groups(
         [n for n in rankings_gene_names],
         dtype=[(rn, 'U50') for rn in groups_order_save])
 
-    if method in {'t-test', 't-test_overestim_var'}:
+    if method in {'t-test', 't-test_overestim_var', 'wilcoxon'}:
         adata.uns[key_added]['logfoldchanges'] = np.rec.fromarrays(
             [n for n in rankings_gene_logfoldchanges],
+            dtype=[(rn, 'float32') for rn in groups_order_save])
+
+    if method == 'wilcoxon':
+        adata.uns[key_added]['pvals'] = np.rec.fromarrays(
+            [n for n in rankings_gene_pvals],
+            dtype=[(rn, 'float32') for rn in groups_order_save])
+        adata.uns[key_added]['pvals_adj'] = np.rec.fromarrays(
+            [n for n in rankings_gene_pvals_adj],
             dtype=[(rn, 'float32') for rn in groups_order_save])
     
     logg.info('    finished', time=True, end=' ' if settings.verbosity > 2 else '\n')
@@ -317,5 +369,7 @@ def rank_genes_groups(
         '    \'scores\', sorted np.recarray to be indexed by group ids\n'
         .format(key_added)
         + ('    \'logfoldchanges\', sorted np.recarray to be indexed by group ids'
-           if method in {'t-test', 't-test_overestim_var'} else ''))
+           if method in {'t-test', 't-test_overestim_var'} else '')
+        + ('    \'pvals\', sorted np.recarray to be indexed by group ids'
+           if method in {'wilcoxon'} else ''))
     return adata if copy else None


### PR DESCRIPTION
I updated the rank_genes_groups function to output p-values for t-tests and the wilcoxon rank-sum test, as discussed with @falexwolf  in #159. 
The changes are outlined below:
- The t-test in the original file used a Welch t-test. I kept this, calculated the relevant degrees of freedom for a Welch test and then extracted the corresponding two-tailed p-value for the t-statistic (score). 
- The Wilcoxon test was originally done in chunks. To get the p-values I had to simplify this approach and use the ranksums function in scipy.stats. This caused me to loop through all of the genes being tested, which was fine for my dataset, but might need to be optimized for larger datasets.
- The adjusted p-values (pvals_adj) were calculated with a standard Bonferroni correction.
- All p-values are outputted and sorted the same way as 'names' or 'scores'. The only difference is that the p-values recarrays use float64 as a datatype to avoid converting a lot of the very small p-values to 0.

Hope this is helpful!

Andrés
