### PR TITLE
Speed up `downsample_counts`

### DIFF
--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -86,3 +86,23 @@ def test_regress_out_categorical():
 
     multi = sc.pp.regress_out(adata, keys='batch', n_jobs=8, copy=True)
     assert adata.X.shape == multi.X.shape
+
+def test_downsample_counts():
+    TARGET = 1000
+    X = np.random.randint(0, 100, (1000, 100)) * \
+        np.random.binomial(1, .3, (1000, 100))
+    adata_dense = AnnData(X=X.copy())
+    adata_csr = AnnData(X=sp.csr_matrix(X))
+    adata_csc = AnnData(X=sp.csc_matrix(X))
+    for adata in [adata_dense, adata_csr, adata_csc]:
+        initial_totals = np.ravel(adata.X.sum(axis=1))
+        sc.pp.downsample_counts(adata, target_counts=TARGET)
+        new_totals = np.ravel(adata.X.sum(axis=1))
+        if sp.issparse(adata.X):
+            assert all(adata.X.toarray()[X == 0] == 0)
+        else:
+            assert all(adata.X[X == 0] == 0)
+        assert all(new_totals <= TARGET)
+        assert all(initial_totals >= new_totals)
+        assert all(initial_totals[initial_totals <= TARGET]
+                    == new_totals[initial_totals <= TARGET])


### PR DESCRIPTION
On master (37851434b2) from the base of the repo, I haven't seen the following code finish running:

```python
import scanpy.api as sc
adata = sc.read("./data/pbmc3k_raw.h5ad")
%time sc.pp.downsample_counts(adata, 1500)
```

This PR implements an optimized version of the same thing, which gives:

```python
%time sc.pp.downsample_counts(adata, 1500)                                                   
CPU times: user 2.25 s, sys: 44.7 ms, total: 2.29 s
Wall time: 2.32 s
```

## What's changed

* I've rewritten the function to use numba along with fewer allocations
* Added a test for the function
* Added argument `replace`, which indicates whether subsampling should happen with replacement

## Notes

To me, it makes more sense to sample without replacement, since for small changes in total counts you'll have more similar profiles. However, I've set the default for replacement to `True` to preserve the current behavior.

Neither this or the previous method scale well with sampling depth, and it's maybe worth using a call to sample a multinomial or multivariate hypergeometric distribution instead.