### PR TITLE
qc_metrics update

### DIFF
--- a/scanpy/preprocessing/qc.py
+++ b/scanpy/preprocessing/qc.py
@@ -5,7 +5,7 @@ from scipy.sparse import csr_matrix, issparse, isspmatrix_csr, isspmatrix_coo
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
 
-def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", control_vars=(),
+def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", qc_vars=(),
                          percent_top=(50, 100, 200, 500), inplace=False):
     """
     Calculate quality control metrics.
@@ -22,9 +22,9 @@ def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", control_va
         Name of kind of values in X.
     var_type : `str`, optional (default: `"genes"`)
         The kind of thing the variables are.
-    control_vars : `Container`, optional (default: `()`)
-        Keys for boolean columns of `.var` which identify controls,
-        e.g. "ERCC" or "mito".
+    qc_vars : `Container`, optional (default: `()`)
+        Keys for boolean columns of `.var` which identify variables you could 
+        want to control for (e.g. "ERCC" or "mito").
     percent_top : `Container[int]`, optional (default: `(50, 100, 200, 500)`)
         Which proportions of top genes to cover. If empty or `None` don't
         calculate.
@@ -42,8 +42,8 @@ def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", control_va
         * `total_{var_type}_by_{expr_type}`
         * `total_{expr_type}`
         * `pct_{expr_type}_in_top_{n}_{var_type}` - for `n` in `percent_top`
-        * `total_{expr_type}_{control_var}` - for `control_var` in `control_vars`
-        * `pct_{expr_type}_{control_var}` - for `control_var` in `control_vars`
+        * `total_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
+        * `pct_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
 
         Variable level metrics include:
 
@@ -75,15 +75,15 @@ def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", control_va
     for i, n in enumerate(percent_top):
         obs_metrics["pct_{expr_type}_in_top_{n}_{var_type}".format(**locals())] = \
             proportions[:, i] * 100
-    for ctrl_var in control_vars:
-        obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())] = \
-            X[:, adata.var[ctrl_var].values].sum(axis=1)
-        obs_metrics["log1p_total_{expr_type}_{ctrl_var}".format(**locals())] = \
+    for qc_var in qc_vars:
+        obs_metrics["total_{expr_type}_{qc_var}".format(**locals())] = \
+            X[:, adata.var[qc_var].values].sum(axis=1)
+        obs_metrics["log1p_total_{expr_type}_{qc_var}".format(**locals())] = \
             np.log1p(
-                obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())])
+                obs_metrics["total_{expr_type}_{qc_var}".format(**locals())])
         # "total_{expr_type}" not formatted yet
-        obs_metrics["pct_{expr_type}_{ctrl_var}".format(**locals())] = \
-            obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())] / \
+        obs_metrics["pct_{expr_type}_{qc_var}".format(**locals())] = \
+            obs_metrics["total_{expr_type}_{qc_var}".format(**locals())] / \
             obs_metrics["total_{expr_type}"] * 100
     # Calculate var metrics
     if issparse(X):

--- a/scanpy/preprocessing/qc.py
+++ b/scanpy/preprocessing/qc.py
@@ -5,7 +5,7 @@ from scipy.sparse import csr_matrix, issparse, isspmatrix_csr, isspmatrix_coo
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
 
-def calculate_qc_metrics(adata, exprs_values="counts", feature_controls=(),
+def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", control_vars=(),
                          percent_top=(50, 100, 200, 500), inplace=False):
     """
     Calculate quality control metrics.
@@ -18,10 +18,12 @@ def calculate_qc_metrics(adata, exprs_values="counts", feature_controls=(),
     ----------
     adata : :class:`~anndata.AnnData`
         Annotated data matrix.
-    exprs_values : `str`, optional (default: `"counts"`)
+    expr_type : `str`, optional (default: `"counts"`)
         Name of kind of values in X.
-    feature_controls : `Container`, optional (default: `()`)
-        Keys for boolean columns of `.var` which identify feature controls,
+    var_type : `str`, optional (default: `"genes"`)
+        The kind of thing the variables are.
+    control_vars : `Container`, optional (default: `()`)
+        Keys for boolean columns of `.var` which identify controls,
         e.g. "ERCC" or "mito".
     percent_top : `Container[int]`, optional (default: `(50, 100, 200, 500)`)
         Which proportions of top genes to cover. If empty or `None` don't
@@ -37,59 +39,67 @@ def calculate_qc_metrics(adata, exprs_values="counts", feature_controls=(),
 
         Observation level metrics include:
 
-        * `total_features_by_{exprs_values}`
-        * `total_{expr_values}`
-        * `pct_{expr_values}_in_top_{n}_features` - for `n` in `percent_top`
-        * `total_{exprs_values}_{feature_control}` - for each `feature_control`
-        * `pct_{exprs_values}_{feature_control}` - for each `feature_control`
+        * `total_{var_type}_by_{expr_type}`
+        * `total_{expr_type}`
+        * `pct_{expr_type}_in_top_{n}_{var_type}` - for `n` in `percent_top`
+        * `total_{expr_type}_{control_var}` - for `control_var` in `control_vars`
+        * `pct_{expr_type}_{control_var}` - for `control_var` in `control_vars`
 
         Variable level metrics include:
 
-        * `total_{expr_values}`
-        * `mean_{expr_values}`
-        * `n_cells_by_{expr_values}`
-        * `pct_dropout_by_{expr_values}`
+        * `total_{expr_type}`
+        * `mean_{expr_type}`
+        * `n_cells_by_{expr_type}`
+        * `pct_dropout_by_{expr_type}`
     """
     X = adata.X
-    if issparse(X):
-        X.eliminate_zeros()
-    if isspmatrix_coo(X):
-        X = csr_matrix(X)  # COO not subscriptable
     obs_metrics = pd.DataFrame(index=adata.obs_names)
     var_metrics = pd.DataFrame(index=adata.var_names)
+    if isspmatrix_coo(X):
+        X = csr_matrix(X)  # COO not subscriptable
+    if issparse(X):
+        X.eliminate_zeros()
     # Calculate obs metrics
-    obs_metrics["total_features_by_{exprs_values}"] = X.getnnz(axis=1)
-    obs_metrics["log1p_total_features_by_{exprs_values}"] = np.log1p(
-        obs_metrics["total_features_by_{exprs_values}"])
-    obs_metrics["total_{exprs_values}"] = X.sum(axis=1)
-    obs_metrics["log1p_total_{exprs_values}"] = np.log1p(
-        obs_metrics["total_{exprs_values}"])
+    if issparse(X):
+        obs_metrics["n_{var_type}_by_{expr_type}"] = X.getnnz(axis=1)
+    else:
+        obs_metrics["n_{var_type}_by_{expr_type}"] = np.count_nonzero(X, axis=1)
+    obs_metrics["log1p_n_{var_type}_by_{expr_type}"] = np.log1p(
+        obs_metrics["n_{var_type}_by_{expr_type}"])
+    obs_metrics["total_{expr_type}"] = X.sum(axis=1)
+    obs_metrics["log1p_total_{expr_type}"] = np.log1p(
+        obs_metrics["total_{expr_type}"])
     proportions = top_segment_proportions(X, percent_top)
     # Since there are local loop variables, formatting must occur in their scope
     # Probably worth looking into a python3.5 compatable way to make this better
     for i, n in enumerate(percent_top):
-        obs_metrics["pct_{exprs_values}_in_top_{n}_features".format(**locals())] = \
+        obs_metrics["pct_{expr_type}_in_top_{n}_{var_type}".format(**locals())] = \
             proportions[:, i] * 100
-    for feature_control in feature_controls:
-        obs_metrics["total_{exprs_values}_{feature_control}".format(**locals())] = \
-            X[:, adata.var[feature_control].values].sum(axis=1)
-        obs_metrics["log1p_total_{exprs_values}_{feature_control}".format(**locals())] = \
+    for ctrl_var in control_vars:
+        obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())] = \
+            X[:, adata.var[ctrl_var].values].sum(axis=1)
+        obs_metrics["log1p_total_{expr_type}_{ctrl_var}".format(**locals())] = \
             np.log1p(
-                obs_metrics["total_{exprs_values}_{feature_control}".format(**locals())])
-        # "total_{exprs_values}" not formatted yet
-        obs_metrics["pct_{exprs_values}_{feature_control}".format(**locals())] = \
-            obs_metrics["total_{exprs_values}_{feature_control}".format(**locals())] / \
-            obs_metrics["total_{exprs_values}"] * 100
+                obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())])
+        # "total_{expr_type}" not formatted yet
+        obs_metrics["pct_{expr_type}_{ctrl_var}".format(**locals())] = \
+            obs_metrics["total_{expr_type}_{ctrl_var}".format(**locals())] / \
+            obs_metrics["total_{expr_type}"] * 100
     # Calculate var metrics
-    var_metrics["mean_{exprs_values}"] = mean_variance_axis(X, axis=0)[0]
-    var_metrics["log1p_mean_{exprs_values}"] = np.log1p(
-        var_metrics["mean_{exprs_values}"])
-    var_metrics["n_cells_by_{exprs_values}"] = X.getnnz(axis=0) # Current memory bottleneck for csr matrices
-    var_metrics["pct_dropout_by_{exprs_values}"] = \
-        (1 - var_metrics["n_cells_by_{exprs_values}"] / X.shape[0]) * 100
-    var_metrics["total_{exprs_values}"] = np.ravel(X.sum(axis=0))
-    var_metrics["log1p_total_{exprs_values}"] = np.log1p(
-        var_metrics["total_{exprs_values}"])
+    if issparse(X):
+        # Current memory bottleneck for csr matrices:
+        var_metrics["n_cells_by_{expr_type}"] = X.getnnz(axis=0)
+        var_metrics["mean_{expr_type}"] = mean_variance_axis(X, axis=0)[0]
+    else:
+        var_metrics["n_cells_by_{expr_type}"] = np.count_nonzero(X, axis=0)
+        var_metrics["mean_{expr_type}"] = X.mean(axis=0)
+    var_metrics["log1p_mean_{expr_type}"] = np.log1p(
+        var_metrics["mean_{expr_type}"])
+    var_metrics["pct_dropout_by_{expr_type}"] = \
+        (1 - var_metrics["n_cells_by_{expr_type}"] / X.shape[0]) * 100
+    var_metrics["total_{expr_type}"] = np.ravel(X.sum(axis=0))
+    var_metrics["log1p_total_{expr_type}"] = np.log1p(
+        var_metrics["total_{expr_type}"])
     # Format strings
     for df in obs_metrics, var_metrics:
         new_colnames = []

--- a/scanpy/tests/test_qc_metrics.py
+++ b/scanpy/tests/test_qc_metrics.py
@@ -67,17 +67,17 @@ def test_qc_metrics():
     adata.var["mito"] = np.concatenate(
         (np.ones(100, dtype=bool), np.zeros(900, dtype=bool)))
     adata.var["negative"] = False
-    sc.pp.calculate_qc_metrics(adata, feature_controls=[
+    sc.pp.calculate_qc_metrics(adata, control_vars=[
                                "mito", "negative"], inplace=True)
-    assert (adata.obs["total_features_by_counts"] < adata.shape[1]).all()
-    assert (adata.obs["total_features_by_counts"] >= adata.obs["log1p_total_features_by_counts"]).all()
+    assert (adata.obs["n_genes_by_counts"] < adata.shape[1]).all()
+    assert (adata.obs["n_genes_by_counts"] >= adata.obs["log1p_n_genes_by_counts"]).all()
     assert (adata.obs["total_counts"] == np.ravel(adata.X.sum(axis=1))).all()
     assert (adata.obs["total_counts"] >= adata.obs["log1p_total_counts"]).all()
     assert (adata.obs["total_counts_mito"] >=
             adata.obs["log1p_total_counts_mito"]).all()
     assert (adata.obs["total_counts_negative"] == 0).all()
-    assert (adata.obs["pct_counts_in_top_50_features"] <=
-            adata.obs["pct_counts_in_top_100_features"]).all()
+    assert (adata.obs["pct_counts_in_top_50_genes"] <=
+            adata.obs["pct_counts_in_top_100_genes"]).all()
     for col in filter(lambda x: "negative" not in x, adata.obs.columns):
         assert (adata.obs[col] >= 0).all() # Values should be positive or zero
         assert (adata.obs[col] != 0).any().all() # Nothing should be all zeros
@@ -91,7 +91,7 @@ def test_qc_metrics():
     assert (adata.var["total_counts"] >= adata.var["log1p_total_counts"]).all()
     # Should return the same thing if run again
     old_obs, old_var = adata.obs.copy(), adata.var.copy()
-    sc.pp.calculate_qc_metrics(adata, feature_controls=[
+    sc.pp.calculate_qc_metrics(adata, control_vars=[
                                "mito", "negative"], inplace=True)
     assert set(adata.obs.columns) == set(old_obs.columns)
     assert set(adata.var.columns) == set(old_var.columns)
@@ -106,11 +106,11 @@ def test_qc_metrics_format():
     init_var = pd.DataFrame({"mito": np.concatenate(
         (np.ones(100, dtype=bool), np.zeros(900, dtype=bool)))})
     adata_dense = sc.AnnData(X=a, var=init_var.copy())
-    sc.pp.calculate_qc_metrics(adata_dense, feature_controls=["mito"], 
+    sc.pp.calculate_qc_metrics(adata_dense, control_vars=["mito"], 
         inplace=True)
     for fmt in [sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix]:
         adata = sc.AnnData(X=fmt(a), var=init_var.copy())
-        sc.pp.calculate_qc_metrics(adata, feature_controls=["mito"], 
+        sc.pp.calculate_qc_metrics(adata, control_vars=["mito"], 
             inplace=True)
         assert np.allclose(adata.obs, adata_dense.obs)
         for col in adata.var: # np.allclose doesn't like mix of types

--- a/scanpy/tests/test_qc_metrics.py
+++ b/scanpy/tests/test_qc_metrics.py
@@ -67,8 +67,8 @@ def test_qc_metrics():
     adata.var["mito"] = np.concatenate(
         (np.ones(100, dtype=bool), np.zeros(900, dtype=bool)))
     adata.var["negative"] = False
-    sc.pp.calculate_qc_metrics(adata, control_vars=[
-                               "mito", "negative"], inplace=True)
+    sc.pp.calculate_qc_metrics(adata, qc_vars=["mito", "negative"], 
+                               inplace=True)
     assert (adata.obs["n_genes_by_counts"] < adata.shape[1]).all()
     assert (adata.obs["n_genes_by_counts"] >= adata.obs["log1p_n_genes_by_counts"]).all()
     assert (adata.obs["total_counts"] == np.ravel(adata.X.sum(axis=1))).all()
@@ -91,7 +91,7 @@ def test_qc_metrics():
     assert (adata.var["total_counts"] >= adata.var["log1p_total_counts"]).all()
     # Should return the same thing if run again
     old_obs, old_var = adata.obs.copy(), adata.var.copy()
-    sc.pp.calculate_qc_metrics(adata, control_vars=[
+    sc.pp.calculate_qc_metrics(adata, qc_vars=[
                                "mito", "negative"], inplace=True)
     assert set(adata.obs.columns) == set(old_obs.columns)
     assert set(adata.var.columns) == set(old_var.columns)
@@ -106,11 +106,11 @@ def test_qc_metrics_format():
     init_var = pd.DataFrame({"mito": np.concatenate(
         (np.ones(100, dtype=bool), np.zeros(900, dtype=bool)))})
     adata_dense = sc.AnnData(X=a, var=init_var.copy())
-    sc.pp.calculate_qc_metrics(adata_dense, control_vars=["mito"], 
+    sc.pp.calculate_qc_metrics(adata_dense, qc_vars=["mito"], 
         inplace=True)
     for fmt in [sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix]:
         adata = sc.AnnData(X=fmt(a), var=init_var.copy())
-        sc.pp.calculate_qc_metrics(adata, control_vars=["mito"], 
+        sc.pp.calculate_qc_metrics(adata, qc_vars=["mito"], 
             inplace=True)
         assert np.allclose(adata.obs, adata_dense.obs)
         for col in adata.var: # np.allclose doesn't like mix of types


### PR DESCRIPTION
Following on discussion from #316, I've renamed a number of arguments and metrics. Additionally I've optimized a bit for memory usage.

Changes to naming can be summarized as follows:

| current | proposed |
| ------- | -------- |
|`total_features_by_{expr_values}` | `n_{var_type}_by_{expr_type}`|
|`total_{expr_values}` | `total_{expr_type}`|
|`pct_{expr_values}_in_top_{n}_features` | `pct_{expr_type}_in_top_{n}_{var_type}`|
|`total_{expr_values}_{feature_control}` | `total_{expr_type}_{qc_var}`|
|`pct_{expr_values}_{feature_control}` | `pct_{expr_type}_{qc_var}`|
| | |
|`total_{expr_values}` | `total_{expr_type}`|
|`mean_{expr_values}` | `mean_{expr_type}`|
|`n_cells_by_{expr_values}` | `n_cells_by_{expr_type}`|
|`pct_dropout_by_{expr_values}` | `pct_dropout_by_{expr_type}`|

I went with `qc_vars` over `control_vars` on the recommendation of a lab mate, since they are presumably variables which are important for quality control, but were not necessarily controlled.