### PR TITLE
Add .readwrite.write to the new API

### DIFF
--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -35,6 +35,6 @@ from . import datasets, logging, queries, settings
 
 from anndata import AnnData
 from anndata import read_h5ad, read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools
-from .readwrite import read, read_10x_h5, read_10x_mtx
+from .readwrite import read, read_10x_h5, read_10x_mtx, write
 from .neighbors import Neighbors
 from .settings import set_figure_params


### PR DESCRIPTION
I'm not sure if `sc.write` is forgotten or left out on purpose. Leaving it out make sense as it only offers `sc.write('file.csv', adata)` over `adata.write()`. Alternatively, extending `sc.write` functionality to loom and zarr and keeping it in the new API might make it more useful.

I was using it just to make the code more symmetric :)  i.e. `sc.read` and `sc.write`, but I don't mind if it's removed.