### PR TITLE
Use np.asarray() rather than Zappy-specific code.

### DIFF
--- a/scanpy/preprocessing/_distributed.py
+++ b/scanpy/preprocessing/_distributed.py
@@ -1,26 +1,15 @@
+import numpy as np
+
 # install dask if available
 try:
     import dask.array as da
 except ImportError:
     da = None
 
-# install zappy (which wraps numpy), or fall back to plain numpy
-try:
-    import zappy.base as np
-except ImportError:
-    import numpy as np
-
-
 def materialize_as_ndarray(a):
     """Convert distributed arrays to ndarrays."""
     if type(a) in (list, tuple):
         if da is not None and any(isinstance(arr, da.Array) for arr in a):
             return da.compute(*a, sync=True)
-        elif hasattr(np, 'asarray'): # zappy case
-            return tuple(np.asarray(arr) for arr in a)
-    else:
-        if da is not None and isinstance(a, da.Array):
-            return a.compute()
-        elif hasattr(np, 'asarray'): # zappy case
-            return np.asarray(a)
-    return a
+        return tuple(np.asarray(arr) for arr in a)
+    return np.asarray(a)

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -6,6 +6,7 @@ import warnings
 from typing import Union, Optional, Tuple
 
 import numba
+import numpy as np
 import scipy as sp
 from scipy.sparse import issparse, isspmatrix_csr, csr_matrix, spmatrix
 from sklearn.utils import sparsefuncs
@@ -23,12 +24,6 @@ try:
     import dask.array as da
 except ImportError:
     da = None
-
-# install zappy (which wraps numpy), or fall back to plain numpy
-try:
-    import zappy.base as np
-except ImportError:
-    import numpy as np
 
 N_PCS = 50  # default number of PCs
 
@@ -204,7 +199,7 @@ def filter_genes(
             `n_counts` or `n_cells` per gene.
     """
     if copy:
-       logg.warn('`copy` is deprecated, use `inplace` instead.') 
+       logg.warn('`copy` is deprecated, use `inplace` instead.')
     n_given_options = sum(
         option is not None for option in
         [min_cells, min_counts, max_cells, max_counts])
@@ -667,7 +662,7 @@ def normalize_per_cell_weinreb16_deprecated(X, max_fraction=1,
     """
     if max_fraction < 0 or max_fraction > 1:
         raise ValueError('Choose max_fraction between 0 and 1.')
-        
+
     counts_per_cell = X.sum(1).A1 if issparse(X) else X.sum(1)
     gene_subset = np.all(X <= counts_per_cell[:, None] * max_fraction, axis=0)
     if issparse(X): gene_subset = gene_subset.A1
@@ -960,9 +955,9 @@ def downsample_cell(col: np.array, target: int, random_state: int=0,
                     replace: bool=True, inplace: bool=False):
     """
     Evenly reduce counts in cell to target amount.
-    
+
     This is an internal function and has some restrictions:
-    
+
     * `dtype` of col must be an integer (i.e. satisfy issubclass(col.dtype.type, np.integer))
     * total counts in cell must be less than target
     """


### PR DESCRIPTION
This uses the `__array__` method on ndarray-like classes to convert from
a distributed array to a regular NumPy ndarray when `materialize_as_ndarray` is called. This was prompted by an [improvement in Zappy](https://github.com/lasersonlab/zappy/pull/7) (released in 0.2.0) that makes Zappy arrays implement the `__array__` method. As another benefit, this change should make it easier to use other implementations of the ndarray interface in Scanpy in the future.

Note that there is still a Dask-specific call for the case of a sequence of arrays, since Dask can materialize these in one call to `compute`.