### PR TITLE
Consistent hint for the distance matrix

### DIFF
--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -96,7 +96,7 @@ def neighbors(
     logg.info('    finished', time=True, end=' ' if settings.verbosity > 2 else '\n')
     logg.hint(
         'added to `.uns[\'neighbors\']`\n'
-        '    \'distances\', weighted adjacency matrix\n'
+        '    \'distances\', distances for each pair of neighbors\n'
         '    \'connectivities\', weighted adjacency matrix')
     return adata if copy else None
 


### PR DESCRIPTION
Define `.uns['neighbors']['distances']` as the distance matrix instead of the weighted adjacency matrix in logg.hint.

By the way, when `knn=True`, distances to non-neighbor data points are stored as zero in this matrix to keep it sparse, right? But technically these are not zeros, but rather "unknown values". Does it make sense to add a note in the documentation about that? Because for `knn=False`, the semantics of zeros change completely.