### PR TITLE
Easier 10x reading

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -114,15 +114,16 @@ def read_10x_h5(filename, genome=None, gex_only=True):
     """
     logg.info('reading', filename, r=True, end=' ')
     with tables.open_file(str(filename), 'r') as f:
-        if '/matrix' in f:
-            adata = _read_v3_10x_h5(filename)
-            if genome:
-                adata = adata[:, list(map(lambda x: x == str(genome), adata.var['genome']))]
-            if gex_only:
-                adata = adata[:, list(map(lambda x: x == 'Gene Expression', adata.var['feature_types']))]
-            return adata
-        else:
-            return _read_legacy_10x_h5(filename, genome=genome)
+        v3 = '/matrix' in f
+    if v3:
+        adata = _read_v3_10x_h5(filename)
+        if genome:
+            adata = adata[:, list(map(lambda x: x == str(genome), adata.var['genome']))]
+        if gex_only:
+            adata = adata[:, list(map(lambda x: x == 'Gene Expression', adata.var['feature_types']))]
+        return adata
+    else:
+        return _read_legacy_10x_h5(filename, genome=genome)
 
 
 def _read_legacy_10x_h5(filename, genome=None):

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -133,12 +133,13 @@ def _read_legacy_10x_h5(filename, genome=None):
     with tables.open_file(str(filename), 'r') as f:
         try:
             if not genome:
-                children = f.list_nodes(f.root)
+                children = [x._v_name for x in f.list_nodes(f.root)]
                 if len(children) > 1:
                     raise ValueError("This file contains more than one genome."
                                     " For legacy 10x h5 files you must specify"
-                                    " the genome if more than one is present.")
-                genome = children[0]._v_name
+                                    " the genome if more than one is present. "
+                                    "Available genomes are: {}".format(children))
+                genome = children[0]
             dsets = {}
             for node in f.walk_nodes('/' + genome, 'Array'):
                 dsets[node.name] = node.read()

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -1,6 +1,9 @@
-import scanpy as sc
+import h5py
 import numpy as np
 import os
+import pytest
+import scanpy as sc
+
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.join(ROOT, '_data', '10x_data')
@@ -28,3 +31,13 @@ def test_read_10x_h5():
                                     genome='GRCh38_chr21')
     nospec_genome_v3 = sc.read_10x_h5(os.path.join(ROOT, '3.0.0', 'filtered_feature_bc_matrix.h5'))
     assert_anndata_equal(spec_genome_v3, nospec_genome_v3)
+
+def test_error_10x_h5_legacy(tmp_path):
+    onepth = os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5')
+    twopth = str(tmp_path / "two_genomes.h5")
+    with h5py.File(onepth, "r") as one, h5py.File(twopth, "w") as two:
+        one.copy("hg19_chr21", two)
+        one.copy("hg19_chr21", two, name="hg19_chr21_copy")
+    with pytest.raises(ValueError):
+        sc.read_10x_h5(twopth)
+    sc.read_10x_h5(twopth, genome="hg19_chr21_copy")

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -1,9 +1,15 @@
 import scanpy as sc
+import numpy as np
 import os
 
 ROOT = os.path.dirname(os.path.abspath(__file__))
 ROOT = os.path.join(ROOT, '_data', '10x_data')
 
+def assert_anndata_equal(a1, a2):
+    assert a1.shape == a2.shape
+    assert all(a1.obs == a2.obs)
+    assert all(a1.var == a2.var)
+    assert np.allclose(a1.X.todense(), a2.X.todense())
 
 def test_read_10x_mtx():
     sc.read_10x_mtx(os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices', 'hg19_chr21'),
@@ -11,9 +17,14 @@ def test_read_10x_mtx():
     sc.read_10x_mtx(os.path.join(ROOT, '3.0.0', 'filtered_feature_bc_matrix'),
                     var_names='gene_symbols', cache=True)
 
+def test_read_10x_h5_v1():
+    spec_genome_v1 = sc.read_10x_h5(os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5'),
+                                    genome='hg19_chr21')
+    nospec_genome_v1 = sc.read_10x_h5(os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5'))
+    assert_anndata_equal(spec_genome_v1, nospec_genome_v1)
 
 def test_read_10x_h5():
-    sc.read_10x_h5(os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5'),
-                   genome='hg19_chr21')
-    sc.read_10x_h5(os.path.join(ROOT, '3.0.0',  'filtered_feature_bc_matrix.h5'),
-                   genome='GRCh38_chr21')
+    spec_genome_v3 = sc.read_10x_h5(os.path.join(ROOT, '3.0.0', 'filtered_feature_bc_matrix.h5'), 
+                                    genome='GRCh38_chr21')
+    nospec_genome_v3 = sc.read_10x_h5(os.path.join(ROOT, '3.0.0', 'filtered_feature_bc_matrix.h5'))
+    assert_anndata_equal(spec_genome_v3, nospec_genome_v3)

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         bbknn=['bbknn'],
         combat=['patsy'],
         doc=['sphinx', 'sphinx_rtd_theme', 'sphinx_autodoc_typehints', 'scanpydoc'],
-        test=['pytest'],
+        test=['pytest>=3.9'],
     ),
     packages=find_packages(),
     # `package_data` does NOT work for source distributions!!!


### PR DESCRIPTION
Removes the need to specify a genome string in 10x h5 files by default. This removes a personal annoyance of mine, where I had to figure out what the reference was called when there's often only one reference used per file.

For cellranger `v3.0.0+` files, specifying a genome acts as a filter on input, as it did already. However, it doesn't only act if `gex_only` is `True`. Additionally, the behavior of `gex_only` has been changed to fit the documentation, i.e. it just filters for gene expression variables.

For legacy files:

* If the file only has one genome group, that one is used by default
* If multiple genomes are found and the user did not specify one, an error will be thrown. This is because there are no structural assurances the genomes will match to the same samples.

As the behavior of the function has meaningfully changed, this is a breaking change (though I'd be surprised if it affected many people). Personally, I haven't seen many 10x files which contain multiple genomes, so I'd appreciate feedback or examples from people who have.