### PR TITLE
Better 10x read errors

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -132,14 +132,20 @@ def _read_legacy_10x_h5(filename, genome=None):
     """
     with tables.open_file(str(filename), 'r') as f:
         try:
+            children = [x._v_name for x in f.list_nodes(f.root)]
             if not genome:
-                children = [x._v_name for x in f.list_nodes(f.root)]
                 if len(children) > 1:
                     raise ValueError("This file contains more than one genome."
                                     " For legacy 10x h5 files you must specify"
                                     " the genome if more than one is present. "
                                     "Available genomes are: {}".format(children))
                 genome = children[0]
+            elif genome not in children:
+                raise ValueError("Could not find genome '{genome}' in "
+                                 "'{filename}'. Available genomes are:"
+                                 " {avail}".format(
+                                     genome=genome, filename=str(filename), 
+                                     avail=children))
             dsets = {}
             for node in f.walk_nodes('/' + genome, 'Array'):
                 dsets[node.name] = node.read()

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -173,8 +173,6 @@ def _read_legacy_10x_h5(filename, genome=None):
                              'gene_ids': dsets['genes'].astype(str)})
             logg.info(t=True)
             return adata
-        except tables.NoSuchNodeError:
-            raise Exception('Genome %s does not exist in this file.' % genome)
         except KeyError:
             raise Exception('File is missing one or more required datasets.')
 

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -118,6 +118,12 @@ def read_10x_h5(filename, genome=None, gex_only=True):
     if v3:
         adata = _read_v3_10x_h5(filename)
         if genome:
+            if genome not in adata.var['genome'].values:
+                raise ValueError("Could not find data corresponding to genome "
+                                 "'{genome}' in '{filename}'. Available "
+                                 "genomes are: {avail}.".format(
+                                     genome=genome, filename=filename,
+                                     avail=list(adata.var["genome"].unique())))
             adata = adata[:, list(map(lambda x: x == str(genome), adata.var['genome']))]
         if gex_only:
             adata = adata[:, list(map(lambda x: x == 'Gene Expression', adata.var['feature_types']))]

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -141,10 +141,12 @@ def _read_legacy_10x_h5(filename, genome=None):
             children = [x._v_name for x in f.list_nodes(f.root)]
             if not genome:
                 if len(children) > 1:
-                    raise ValueError("This file contains more than one genome."
-                                    " For legacy 10x h5 files you must specify"
-                                    " the genome if more than one is present. "
-                                    "Available genomes are: {}".format(children))
+                    raise ValueError("'{filename}' contains more than one "
+                                     "genome. For legacy 10x h5 files you must"
+                                     " specify the genome if more than one is "
+                                     "present. Available genomes are: {avail}"
+                                     .format(filename=filename, 
+                                             avail=children))
                 genome = children[0]
             elif genome not in children:
                 raise ValueError("Could not find genome '{genome}' in "

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -119,11 +119,14 @@ def read_10x_h5(filename, genome=None, gex_only=True):
         adata = _read_v3_10x_h5(filename)
         if genome:
             if genome not in adata.var['genome'].values:
-                raise ValueError("Could not find data corresponding to genome "
-                                 "'{genome}' in '{filename}'. Available "
-                                 "genomes are: {avail}.".format(
-                                     genome=genome, filename=filename,
-                                     avail=list(adata.var["genome"].unique())))
+                raise ValueError(
+                    "Could not find data corresponding to genome '{genome}' in '{filename}'. "
+                    "Available genomes are: {avail}."
+                    .format(
+                        genome=genome, filename=filename,
+                        avail=list(adata.var["genome"].unique()),
+                    )
+                )
             adata = adata[:, list(map(lambda x: x == str(genome), adata.var['genome']))]
         if gex_only:
             adata = adata[:, list(map(lambda x: x == 'Gene Expression', adata.var['feature_types']))]
@@ -141,19 +144,22 @@ def _read_legacy_10x_h5(filename, genome=None):
             children = [x._v_name for x in f.list_nodes(f.root)]
             if not genome:
                 if len(children) > 1:
-                    raise ValueError("'{filename}' contains more than one "
-                                     "genome. For legacy 10x h5 files you must"
-                                     " specify the genome if more than one is "
-                                     "present. Available genomes are: {avail}"
-                                     .format(filename=filename, 
-                                             avail=children))
+                    raise ValueError(
+                        "'{filename}' contains more than one genome. For legacy 10x h5 "
+                        "files you must specify the genome if more than one is present. "
+                        "Available genomes are: {avail}"
+                        .format(filename=filename, avail=children)
+                    )
                 genome = children[0]
             elif genome not in children:
-                raise ValueError("Could not find genome '{genome}' in "
-                                 "'{filename}'. Available genomes are:"
-                                 " {avail}".format(
-                                     genome=genome, filename=str(filename), 
-                                     avail=children))
+                raise ValueError(
+                    "Could not find genome '{genome}' in '{filename}'. "
+                    "Available genomes are: {avail}"
+                    .format(
+                        genome=genome, filename=str(filename),
+                        avail=children,
+                    )
+                )
             dsets = {}
             for node in f.walk_nodes('/' + genome, 'Array'):
                 dsets[node.name] = node.read()

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -41,3 +41,8 @@ def test_error_10x_h5_legacy(tmp_path):
     with pytest.raises(ValueError):
         sc.read_10x_h5(twopth)
     sc.read_10x_h5(twopth, genome="hg19_chr21_copy")
+
+def test_error_missing_genome():
+    legacy_pth = os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5')
+    with pytest.raises(ValueError, match=r".*hg19_chr21.*"):
+        sc.read_10x_h5(legacy_pth, genome="not a genome")

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -44,5 +44,8 @@ def test_error_10x_h5_legacy(tmp_path):
 
 def test_error_missing_genome():
     legacy_pth = os.path.join(ROOT, '1.2.0', 'filtered_gene_bc_matrices_h5.h5')
+    v3_pth = os.path.join(ROOT, '3.0.0', 'filtered_feature_bc_matrix.h5')
     with pytest.raises(ValueError, match=r".*hg19_chr21.*"):
         sc.read_10x_h5(legacy_pth, genome="not a genome")
+    with pytest.raises(ValueError, match=r".*GRCh38_chr21.*"):
+        sc.read_10x_h5(v3_pth, genome="not a genome")


### PR DESCRIPTION
An addendum to #442, now if you try to read a 10x file and pass a genome it doesn't have, the error tells you which file it was and the genomes it does have:

```python
In [1]: import scanpy as sc 
   ...: sc.read_10x_h5("scanpy/tests/_data/10x_data/1.2.0/filtered_gene_bc_matrices_h5.h5", "not a genome")                                                                          
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)

...

ValueError: Could not find genome 'not a genome' in 'scanpy/tests/_data/10x_data/1.2.0/filtered_gene_bc_matrices_h5.h5'. Available genomes are: ['hg19_chr21']
```

Previous behavior:

```python
In [1]: import scanpy as sc 
   ...: sc.read_10x_h5("scanpy/tests/_data/10x_data/1.2.0/filtered_gene_bc_matrices_h5.h5", "not a genome")                                                                          
---------------------------------------------------------------------------
NoSuchNodeError                           Traceback (most recent call last)

...

Exception: Genome not a genome does not exist in this file.
```