### PR TITLE
Updated PyPairs to v3.0.9

### DIFF
--- a/scanpy/tools/_pypairs.py
+++ b/scanpy/tools/_pypairs.py
@@ -1,22 +1,14 @@
 """Calculate scores based on relative expression change of maker pairs
 """
 
-import pandas as pd
-
-
 def sandbag(
         adata,
-        categories,
+        annotation,
         gene_names,
         sample_names,
-        fraction=0.5,
-        subset_genes=None,
-        subset_samples=None,
-        filter_genes_dispersion=False,
-        always_keep_genes=None,
-        min_diff=0,
-        rm_zeros=True,
-        n_jobs=1):
+        fraction=0.65,
+        filter_genes=None,
+        filter_samples=None):
     """Generate pairs of genes [Scialdone15]_ [Fechtner18]_.
 
     Calculates the pairs of genes serving as marker pairs for each phase,
@@ -41,20 +33,10 @@ def sandbag(
         List of samples.
     fraction : `float`, optional (default: 0.5)
         Fraction to be used as threshold.
-    subset_genes : `list` or `None`, optional (default: `None`)
+    filter_genes : `list` or `None`, optional (default: `None`)
         Genes for sampling the reference set. Default is all genes.
-    subset_samples : `list` or `None`, optional (default: `None`)
+    filter_samples : `list` or `None`, optional (default: `None`)
         Cells for sampling the reference set. Default is all samples.
-    filter_genes_dispersion: `bool`, optional (default: False)
-        Filtered genes based on dispersion
-    always_keep_genes: `list`, optional (default: None)
-        List of genes to always keep
-    min_diff : `int`, optional (default: 0)
-        Minimum different
-    rm_zeros: `bool`, optional (default: True)
-        Remove zeros
-    n_jobs : `int`, optional (default: 1)
-        Number of concurrent n_jobs to be used. 0 = use all available cores.
 
     Returns
     -------
@@ -63,25 +45,33 @@ def sandbag(
     containing marker pairs per phase
     """
     try:
-        from pypairs import sandbag
+        from pypairs import __version__ as pypairsversion
+        from distutils.version import LooseVersion
+        
+        if LooseVersion(pypairsversion) < LooseVersion("v3.0.9"):
+            raise ImportError('Please only use `pypairs` >= v3.0.9 ')
     except ImportError:
         raise ImportError('You need to install the package `pypairs`.')
-
-    x = pd.DataFrame(adata.X)
-
-    return sandbag.sandbag(
-        matrix=x,
-        categories=categories,
-        gene_names=gene_names,
-        sample_names=sample_names,
-        fraction=fraction,
-        subset_genes=subset_genes,
-        subset_samples=subset_samples,
-        rm_zeros=rm_zeros,
-        filter_genes_dispersion=filter_genes_dispersion,
-        always_keep_genes=always_keep_genes,
-        min_diff=min_diff,
-        processes=n_jobs
+        
+    
+    from pypairs.pairs import sandbag
+    from . import settings
+    from pypairs import settings as pp_settings
+    
+    pp_settings.verbosity = settings.verbosity
+    pp_settings.n_jobs = settings.n_jobs
+    pp_settings.writedir = settings.writedir
+    pp_settings.cachedir = settings.cachedir
+    pp_settings.logfile = settings.logfile
+    
+    return sandbag(
+        data = adata,
+        annotation = annotation,
+        gene_names = gene_names,
+        sample_names = sample_names,
+        fraction = fraction,
+        filter_genes = filter_genes,
+        filter_samples = filter_samples
     )
 
 
@@ -90,13 +80,9 @@ def cyclone(
         marker_pairs,
         gene_names,
         sample_names,
-        subset_genes=None,
-        subset_samples=None,
         iterations=1000,
         min_iter=100,
-        min_pairs=50,
-        rm_zeros=True,
-        n_jobs=1):
+        min_pairs=50):
     """Assigns scores and predicted class to observations [Scialdone15]_ [Fechtner18]_.
 
     Calculates scores for each observation and each phase and assigns prediction
@@ -115,10 +101,6 @@ def cyclone(
         List of genes.
     sample_names: `list`
         List of samples.
-    subset_genes : `list` or `None`, optional (default: `None`)
-        Genes for sampling the reference set. Default is all genes.
-    subset_samples : `list` or `None`, optional (default: `None`)
-        Cells for sampling the reference set. Default is all samples.
     iterations : `int`, optional (default: 1000)
         An integer scalar specifying the number of
         iterations for random sampling to obtain a cycle score.
@@ -128,38 +110,43 @@ def cyclone(
     min_pairs : `int`, optional (default: 50)
         An integer scalar specifying the minimum number of iterations
         for score estimation
-    rm_zeros: `bool`, optional (default: True)
-        Remove zeros
-    n_jobs : `int`, optional (default: 1)
-        Number of concurrent n_jobs to be used. 0 = use all available cores.
 
     Returns
     -------
-    `dict` of `list`
-    {
-        "prediction": The predicted classes based on scores
-        "prediction_normalized": The predicted classes based on normalized scores
-        "scores": Prediction scores
-        "normalized": Normalized prediction scores
-    }
+     A :class:`~pandas.DataFrame` with samples as index and categories as columns with scores for each category for each
+    sample and a additional column with the name of the max scoring category for each sample.
+    
+        *
+            If marker pairs contain only the cell cycle categories G1, S and G2M an additional column
+            ``pypairs_cc_prediction`` will be added. Where category S is assigned to samples where G1 and G2M score are
+            below 0.5.
     """
     try:
-        from pypairs import cyclone
+        from pypairs import __version__ as pypairsversion
+        from distutils.version import LooseVersion
+        
+        if LooseVersion(pypairsversion) < LooseVersion("v3.0.9"):
+            raise ImportError('Please only use `pypairs` >= v3.0.9 ')
     except ImportError:
         raise ImportError('You need to install the package `pypairs`.')
+        
+    
+    from pypairs.pairs import cyclone
+    from . import settings
+    from pypairs import settings as pp_settings
+    
+    pp_settings.verbosity = settings.verbosity
+    pp_settings.n_jobs = settings.n_jobs
+    pp_settings.writedir = settings.writedir
+    pp_settings.cachedir = settings.cachedir
+    pp_settings.logfile = settings.logfile
 
-    x = pd.DataFrame(adata.X)
-
-    return cyclone.cyclone(
-        matrix=x,
-        marker_pairs=marker_pairs,
-        gene_names=gene_names,
-        sample_names=sample_names,
-        subset_genes=subset_genes,
-        subset_samples=subset_samples,
-        iterations=iterations,
-        min_iter=min_iter,
-        min_pairs=min_pairs,
-        rm_zeros=rm_zeros,
-        processes=n_jobs
+    return cyclone(
+        data = adata,
+        marker_pairs = marker_pairs,
+        gene_names = gene_names,
+        sample_names = sample_names,
+        iterations = iterations,
+        min_iter = min_iter,
+        min_pairs = min_pairs
     )


### PR DESCRIPTION
PyPairs v3.0.9 is fully rewritten and will now directly accept AnnData objects. Further it will respect the settings from scanpy regarding verbosity, n_jobs, and output directories. The full documentation can be found at: pypairs.rtfd.io