### PR TITLE
Update numba usage in qc metrics

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ patsy
 networkx
 natsort
 joblib
-numba>=0.40.0
+numba>=0.41.0

--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -161,7 +161,7 @@ def top_proportions(mtx, n):
     else:
         return top_proportions_dense(mtx, n)
 
-@numba.jit
+
 def top_proportions_dense(mtx, n):
     sums = mtx.sum(axis=1)
     partitioned = np.apply_along_axis(np.argpartition, 1, -mtx, n-1)
@@ -174,7 +174,7 @@ def top_proportions_dense(mtx, n):
         values[i, :] = vec
     return values
 
-@numba.jit(parallel=True)
+
 def top_proportions_sparse_csr(data, indptr, n):
     values = np.zeros((indptr.size-1, n), dtype=np.float64)
     for i in numba.prange(indptr.size-1):


### PR DESCRIPTION
This is a small update to use numba more effectively and slightly decrease test times for calculating qc metrics.

* I've enabled no python mode for `top_segment_proportions_sparse_csr`
* I've removed `numba` from functions currently only used for testing
  * This mainly reduces test time. If anyone wants to use the `top_proportions` function to make `plotScater` type plots, maybe these should get re-enabled.

Test times are still not great, but since it's due to numba compilation I'm not sure much can be done about it. The ideal solution is it becoming possible to have numba functions which are both parallel and cached.