### PR TITLE
Add fixes for bugs in rank_genes_groups

### DIFF
--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -663,8 +663,22 @@ def select_groups(adata, groups_order_subset='all', key='groups'):
     if groups_order_subset != 'all':
         groups_ids = []
         for name in groups_order_subset:
-            groups_ids.append(
-                np.where(adata.obs[key].cat.categories.values == name)[0][0])
+            # deal with case that all group names were originally integers,
+            # since these are automatically converted to strings at the start 
+            # of the rank_gene_groups function
+            if ( 
+                np.issubdtype(
+                    adata.obs[key].cat.categories.values.dtype, np.number 
+                )
+            ):
+                groups_ids.append(
+                    np.where(
+                        adata.obs[key].cat.categories.values == float(name)
+                    )[0][0]
+                )
+            else:
+                groups_ids.append(
+                    np.where(adata.obs[key].cat.categories.values == name)[0][0])
         if len(groups_ids) == 0:
             # fallback to index retrieval
             groups_ids = np.where(


### PR DESCRIPTION
This includes fixes for both #469 and #470 

#469 was a small indexing error

To fix #470, a `rankby_abs` check is included in the `logreg` section of the method that mirrors the `rankby_abs` checks in the other two methods.

This PR additionally updates `select_groups` function in `scanpy/utils.py.`  I was having some issues when the clusters that I was using were labelled by integers (i.e. when `adata.obs[key].cat.catagories.values.dtype` was some form of integer) AND when I was looking at a subset of the clusters (e.g. `groups=[0,1]`, not when `groups='all'`).  At the start of the `rank_genes_groups` function, these cluster labels are converted into strings in the `groups_order` variable.  In the `select_groups` function (line 667 of the original utils.py file), however, we call 
``` 
np.where(adata.obs[key].cat.categories.values == name)[0][0]
```
which fails with an error (since `name` is a string from `select_groups`  and the elements of `adata.obs[key].cat.categories.values` are integers).  Thus, this PR includes a check for the `dtype` of `adata.obs[key].cat.categories.values` - if it is numeric, we instead look at 
``` 
np.where(adata.obs[key].cat.categories.values == float(name))[0][0]
```

This error should only appear if the cluster labels are integers (since this is the only time that the cluster labels are converted to strings for `groups_order` in `rank_genes_groups`) but the above fix should also work if the cluster labels are any floating point numbers (just in case the `rank_genes_groups` is ever generalized in this way).

([Here](https://docs.scipy.org/doc/numpy-1.13.0/reference/arrays.scalars.html) is a link to the numpy type hierarchy)

Edit: added a line number