### PR TITLE
Downsample total counts

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -15,7 +15,7 @@ from anndata import AnnData
 
 from .. import settings as sett
 from .. import logging as logg
-from ..utils import sanitize_anndata
+from ..utils import sanitize_anndata, deprecated_arg_names
 from ._distributed import materialize_as_ndarray
 from ._utils import _get_mean_var
 
@@ -899,14 +899,15 @@ def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
         return X[obs_indices], obs_indices
 
 
-def downsample_counts(adata, total_counts=None, counts_per_cell=None, random_state=0,
+@deprecated_arg_names({"target_counts": "counts_per_cell"})
+def downsample_counts(adata, counts_per_cell=None, total_counts=None, random_state=0,
                       replace=False, copy=False):
     """
     Downsample counts from count matrix.
 
-    If `total_counts` is specified, expression matrix will be downsampled to
-    contain at most `total_counts`. If `counts_per_cell` in specified, each
-    cell will downsampled.
+    If `counts_per_cell` in specified, each cell will downsampled. If
+    `total_counts` is specified, expression matrix will be downsampled to
+    contain at most `total_counts`.
 
     Parameters
     ----------

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -899,20 +899,26 @@ def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
         return X[obs_indices], obs_indices
 
 
-def downsample_counts(adata, target_counts=20000, random_state=0,
+def downsample_counts(adata, total_counts=None, counts_per_cell=None, random_state=0,
                       replace=True, copy=False):
-    """Downsample counts so that each cell has no more than `target_counts`.
+    """
+    Downsample counts from count matrix 
 
-    Cells with fewer counts than `target_counts` are unaffected by this. This
-    has been implemented by M. D. Luecken.
+    If `total_counts` is specified, expression matrix will be downsampled to
+    contain at most `total_counts`. If `counts_per_cell` in specified, each
+    cell will downsampled.
 
     Parameters
     ----------
     adata : :class:`~anndata.AnnData`
         Annotated data matrix.
-    target_counts : `int` (default: 20,000)
-        Target number of counts for downsampling. Cells with more counts than
-        'target_counts' will be downsampled to have 'target_counts' counts.
+    total_counts : `int`, optional (default: None)
+        Target total counts. If count matrix has more than `total_counts` it 
+        will be downsampled to have `total_counts` counts.
+    counts_per_cell : `int`, optional (default: None)
+        Target number of counts for downsampling per cell. Cells with more
+        counts than 'counts_per_cell' will be downsampled to have
+        'counts_per_cell' counts.
     random_state : `int` or `None`, optional (default: 0)
         Random seed to change subsampling.
     replace : `bool`, optional (default: `True`)
@@ -926,33 +932,60 @@ def downsample_counts(adata, target_counts=20000, random_state=0,
     AnnData, None
         Depending on `copy` returns or updates an `adata` with downsampled `.X`.
     """
+    if type(total_counts) == type(counts_per_cell):
+        raise ValueError("Must specify only one of `total_counts` or `counts_per_cell`.")
     if copy:
         adata = adata.copy()
     adata.X = adata.X.astype(np.integer)  # Numba doesn't want floats
+    if total_counts:
+        adata = _downsample_total_counts(adata, total_counts, random_state, replace)
+    elif counts_per_cell:
+        adata = _downsample_per_cell(adata, counts_per_cell, random_state, replace)
+    if copy: 
+        return adata
+
+
+def _downsample_per_cell(adata, counts_per_cell, random_state, replace):
     if issparse(adata.X):
         X = adata.X
         if not isspmatrix_csr(X):
             X = csr_matrix(X)
         totals = np.ravel(X.sum(axis=1))
-        under_target = np.nonzero(totals > target_counts)[0]
+        under_target = np.nonzero(totals > counts_per_cell)[0]
         cols = np.split(X.data.view(), X.indptr[1:-1])
         for colidx in under_target:
             col = cols[colidx]
-            downsample_cell(col, target_counts, random_state=random_state,
+            _downsample_array(col, counts_per_cell, random_state=random_state,
                             replace=replace, inplace=True)
         if not isspmatrix_csr(adata.X):  # Put it back
             adata.X = type(adata.X)(X)
     else:
         totals = np.ravel(adata.X.sum(axis=1))
-        under_target = np.nonzero(totals > target_counts)[0]
+        under_target = np.nonzero(totals > counts_per_cell)[0]
         adata.X[under_target, :] = \
-            np.apply_along_axis(downsample_cell, 1, adata.X[under_target, :],
-                                target_counts, random_state=random_state, replace=replace)
-    if copy: return adata
+            np.apply_along_axis(_downsample_array, 1, adata.X[under_target, :],
+                                counts_per_cell, random_state=random_state, replace=replace)
+    return adata
+
+def _downsample_total_counts(adata, total_counts, random_state, replace):
+    X = adata.X
+    total = X.sum()
+    if total < total_counts:
+        return adata
+    if issparse(X):
+        if not isspmatrix_csr(X):
+            X = csr_matrix(X)
+        _downsample_array(X.data, total_counts, random_state=random_state,
+                          replace=replace, inplace=True)
+    else:
+        v = X.view().reshape(np.multiply(*X.shape))
+        _downsample_array(v, total_counts, random_state, replace=replace,
+                          inplace=True)
+    return adata
 
 
-@numba.njit
-def downsample_cell(col: np.array, target: int, random_state: int=0,
+@numba.njit(cache=True  )
+def _downsample_array(col: np.array, target: int, random_state: int=0,
                     replace: bool=True, inplace: bool=False):
     """
     Evenly reduce counts in cell to target amount.

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -900,7 +900,7 @@ def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
 
 
 def downsample_counts(adata, total_counts=None, counts_per_cell=None, random_state=0,
-                      replace=True, copy=False):
+                      replace=False, copy=False):
     """
     Downsample counts from count matrix.
 
@@ -920,7 +920,7 @@ def downsample_counts(adata, total_counts=None, counts_per_cell=None, random_sta
         it will be downsampled to this number.
     random_state : `int` or `None`, optional (default: 0)
         Random seed for subsampling.
-    replace : `bool`, optional (default: `True`)
+    replace : `bool`, optional (default: `False`)
         Whether to sample the counts with replacement.
     copy : `bool`, optional (default: `False`)
         If an :class:`~anndata.AnnData` is passed, determines whether a copy

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -900,8 +900,14 @@ def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
 
 
 @deprecated_arg_names({"target_counts": "counts_per_cell"})
-def downsample_counts(adata, counts_per_cell=None, total_counts=None, random_state=0,
-                      replace=False, copy=False):
+def downsample_counts(
+    adata: AnnData,
+    counts_per_cell: Optional[int] = None,
+    total_counts: Optional[int] = None,
+    random_state: Optional[int] = 0,
+    replace: bool = False,
+    copy: bool = False,
+) -> Optional[AnnData]:
     """
     Downsample counts from count matrix.
 
@@ -911,19 +917,19 @@ def downsample_counts(adata, counts_per_cell=None, total_counts=None, random_sta
 
     Parameters
     ----------
-    adata : :class:`~anndata.AnnData`
+    adata
         Annotated data matrix.
-    total_counts : `int`, optional (default: None)
-        Target total counts. If the count matrix has more than `total_counts`
-        it will be downsampled to have this number.
-    counts_per_cell : `int`, optional (default: None)
+    counts_per_cell
         Target total counts per cell. If a cell has more than 'counts_per_cell',
         it will be downsampled to this number.
-    random_state : `int` or `None`, optional (default: 0)
+    total_counts
+        Target total counts. If the count matrix has more than `total_counts`
+        it will be downsampled to have this number.
+    random_state
         Random seed for subsampling.
-    replace : `bool`, optional (default: `False`)
+    replace
         Whether to sample the counts with replacement.
-    copy : `bool`, optional (default: `False`)
+    copy
         If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
 

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -5,7 +5,7 @@ import sys
 import inspect
 from weakref import WeakSet
 from collections import namedtuple
-from functools import partial
+from functools import partial, wraps
 from types import ModuleType
 from typing import Union, Callable, Optional
 
@@ -16,12 +16,12 @@ from textwrap import dedent
 from pandas.api.types import CategoricalDtype
 
 from . import settings, logging as logg
+import warnings
 
 EPS = 1e-15
 
 
 def check_versions():
-    import warnings
     from distutils.version import LooseVersion
 
     if sys.version_info < (3, 0):
@@ -36,7 +36,6 @@ def check_versions():
             raise ImportError('Scanpy {} needs anndata version >=0.6.10, not {}.\n'
                               'Run `pip install anndata -U --no-deps`.'
                               .format(__version__, anndata.__version__))
-
 
 
 def getdoc(c_or_f: Union[Callable, type]) -> Optional[str]:
@@ -60,6 +59,40 @@ def getdoc(c_or_f: Union[Callable, type]) -> Optional[str]:
         '{} : {}'.format(line, type_doc(line)) if line.strip() in sig.parameters else line
         for line in doc.split('\n')
     )
+
+
+def deprecated_arg_names(arg_mapping):
+    """
+    Decorator which marks a functions keyword arguments as deprecated. It will
+    result in a warning being emitted when the deprecated keyword argument is
+    used, and the function being called with the new argument.
+
+    Parameters
+    ----------
+    arg_mapping : dict[str, str]
+        Mapping from deprecated argument name to current argument name.
+    """
+    def decorator(func):
+        @wraps(func)
+        def func_wrapper(*args, **kwargs):
+            warnings.simplefilter(
+                'always', DeprecationWarning)  # turn off filter
+            for old, new in arg_mapping.items():
+                if old in kwargs:
+                    warnings.warn(
+                        "Keyword argument '{0}' has been deprecated in favour "
+                        "of '{1}'. '{0}' will be removed in a future version."
+                        .format(old, new),
+                        category=DeprecationWarning,
+                        stacklevel=2,
+                    )
+                    val = kwargs.pop(old)
+                    kwargs[new] = val
+            warnings.simplefilter(
+                'default', DeprecationWarning)  # reset filter
+            return func(*args, **kwargs)
+        return func_wrapper
+    return decorator
 
 
 def descend_classes_and_funcs(mod: ModuleType, root: str, encountered=None):
@@ -775,7 +808,6 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
     --------
     http://stackoverflow.com/questions/22373927/get-traceback-of-warnings
     """
-    import warnings
     import traceback
     traceback.print_stack()
     log = file if hasattr(file, 'write') else sys.stderr


### PR DESCRIPTION
Update to `downsample_counts` to allow downsampling total counts, similar to normalization by `cellranger aggr` (I'm pretty sure on this, there's a lot going on in their code). Additionally, enabled caching for the `numba`'d function, which cuts down on test time.

As adding this feature meant renaming `target_counts` to `counts_per_cell`, this becomes a breaking change. Since it's breaking, I've also gone ahead and set `replace=False` by default as mentioned before (#340).

Definitely willing to make changes. I've implemented this since I'm doing some integration work and figured it'd be nice to be able to try the basic `cellranger` strategy.

Edit: The failing PAGA test occurs locally on master as well, but I don't think I broke that.