### PR TITLE
Fix default verbosity level from the erroneous 'warning' to 'warn'.

### DIFF
--- a/scanpy/settings.py
+++ b/scanpy/settings.py
@@ -1,7 +1,7 @@
 """Settings
 """
 
-verbosity = 'warning'
+verbosity = 'warn'
 """Set global verbosity level.
 
 Level 0: only show 'error' messages.


### PR DESCRIPTION
This is a result of a change in fc840961c4a9f49cfcea975d01f79e5345fc521e. The problem is not exposed in tests since `scanpy/tests/conftest.py` overrides the default verbosity to `hint`. However, if the line in that file is commented out then the tests fail. I'm not sure of a simple way to add a regression test, but this change fixes the problem as verified by a manual test.