### PR TITLE
[Bugfix] I had forgotten what `all(dataframe)` does

### DIFF
--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -10,8 +10,8 @@ ROOT = os.path.join(ROOT, '_data', '10x_data')
 
 def assert_anndata_equal(a1, a2):
     assert a1.shape == a2.shape
-    assert all(a1.obs == a2.obs)
-    assert all(a1.var == a2.var)
+    assert (a1.obs == a2.obs).all(axis=None)
+    assert (a1.var == a2.var).all(axis=None)
     assert np.allclose(a1.X.todense(), a2.X.todense())
 
 def test_read_10x_mtx():


### PR DESCRIPTION
Just spent an hour re-figuring out that `all(dataframe)` does `all(bool(c) for c in dataframe.columns)` 😢. Now finding out where I've written that.