### PR TITLE
Add `smallest_dot` parameter to dotplot

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1305,7 +1305,7 @@ def heatmap(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
 @doc_params(show_save_ax=doc_show_save_ax, common_plot_args=doc_common_plot_args)
 def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categories=7,
             color_map='Reds', dot_max=None, dot_min=None, figsize=None, dendrogram=False,
-            gene_symbols=None, var_group_positions=None,
+            gene_symbols=None, var_group_positions=None, smallest_dot=0,
             var_group_labels=None, var_group_rotation=None, layer=None, show=None, save=None, **kwds):
     """\
     Makes a *dot plot* of the expression values of `var_names`.
@@ -1334,6 +1334,9 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
         If none, the minimum dot size is set to 0. If given,
         the value should be a number between 0 and 1. All fractions smaller than dot_min are clipped to
         this value.
+    smallest_dot : `float` optional (default: 0)
+        If not set, the smallest dot size is set to 0. Clusters with `dot_min` percent of cells 
+        expressing a given gene still have this minimum `smallest_dot` size.  Helps with visibility.
 
     {show_save_ax}
     **kwds : keyword arguments
@@ -1489,6 +1492,7 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
         frac = ((frac - dot_min) / old_range)
 
     size = (frac * 10) ** 2
+    size += smallest_dot
     import matplotlib.colors
 
     normalize = matplotlib.colors.Normalize(vmin=kwds.get('vmin'), vmax=kwds.get('vmax'))


### PR DESCRIPTION
The dots in dotplot can be quite small and difficult to see.  In order to help with visibility and customizability of the dotplot, added a `smallest_dot` parameter to specify the size of the smallest dot.