### PR TITLE
Fix stacked_violin plot bug

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -878,7 +878,7 @@ def stacked_violin(adata, var_names, groupby=None, log=False, use_raw=None, num_
         else:
             width, height = figsize
 
-        num_rows = len(categories)
+        num_rows = len(var_names)
         height_ratios = None
         if has_var_groups:
             # add some space in case 'brackets' want to be plotted on top of the image


### PR DESCRIPTION
`num_rows` was incorrectly calculated when `swap_axes=False` in the `stacked_violin` plot. This fixes issue #405 