### PR TITLE
Quick fix for typo

### DIFF
--- a/scanpy/preprocessing/_dca.py
+++ b/scanpy/preprocessing/_dca.py
@@ -151,4 +151,4 @@ def dca(adata,
         threads=threads,
         verbose=verbose,
         training_kwds=training_kwds,
-        return_model=return_model
+        return_model=return_model)


### PR DESCRIPTION
Looks like there was a typo at the bottom of `scanpy/preprocessing/_dca.py` that was causing a parse error. This should fix it.