### PR TITLE
Add an explicit expression threshold to dotplot

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1391,6 +1391,11 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     # transform obs_tidy into boolean matrix using the expression_cutoff
     obs_bool = obs_tidy > expression_cutoff
 
+    # compute the sum per group which in the boolean matrix this is the number
+    # of values > expression_cutoff, and divide the result by the total number of values
+    # in the group (given by `count()`)
+    fraction_obs = obs_bool.groupby(level=0).sum() / obs_bool.groupby(level=0).count()
+
     # 2. compute mean value
     if mean_only_expressed:
         mean_obs = obs_tidy.mask(~obs_bool).groupby(level=0).mean().fillna(0)
@@ -1408,10 +1413,6 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     else:
         logg.warn('Unknown type for standard_scale, ignored')
 
-    # compute the sum per group which in the boolean matrix this is the number
-    # of values > expression_cutoff, and divide the result by the total number of values
-    # in the group (given by `count()`)
-    fraction_obs = obs_bool.groupby(level=0).sum() / obs_bool.groupby(level=0).count()
 
     dendro_width = 0.8 if dendrogram else 0
     colorbar_width = 0.2

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1345,7 +1345,7 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
         of cells expressing given genes. A gene is expressed only if the expression value is greater than
         this threshold.
     mean_only_expressed : `bool` (default: `False`)
-        If True, gene expression is averaged only over cells expressing the gene.
+        If True, gene expression is averaged only over the cells expressing the given genes.
     color_map : `str`, optional (default: `Reds`)
         String denoting matplotlib color map.
     dot_max : `float` optional (default: `None`)

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1329,13 +1329,14 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     For each var_name and each `groupby` category a dot is plotted. Each dot
     represents two values: mean expression within each category (visualized by
     color) and fraction of cells expressing the var_name in the
-    category. (visualized by the size of the dot).  If groupby is not given, the
-    dotplot assumes that all data belongs to a single category. A gene is
-    considered expressed if the expression value in the adata (or adata.raw) is
-    above the specified threshold which is zero by default.
+    category (visualized by the size of the dot).  If groupby is not given, the
+    dotplot assumes that all data belongs to a single category. 
+    
+    **Note**: A gene is considered expressed if the expression value in the adata 
+    (or adata.raw) is above the specified threshold which is zero by default.
 
-    For instance, for each marker gene, the mean value and the percentage of cells
-    expressing the gene can be visualized for each cluster.
+    An example of dotplot usage is to visualize, for multiple marker genes, 
+    the mean value and the percentage of cells expressing the gene accross multiple clusters.
 
     Parameters
     ----------

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1341,8 +1341,8 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     ----------
     {common_plot_args}
     expression_cutoff : `float` (default: `0.`)
-        Expression cutoff that is used for binarizing gene expression and determining the fraction
-        of cells expressing the gene. A gene is expressed only if expression value is greater than
+        Expression cutoff that is used for binarizing the gene expression and determining the fraction
+        of cells expressing given genes. A gene is expressed only if the expression value is greater than
         this threshold.
     mean_only_expressed : `bool` (default: `False`)
         If True, gene expression is averaged only over cells expressing the gene.
@@ -1409,8 +1409,8 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
         logg.warn('Unknown type for standard_scale, ignored')
 
     # compute the sum per group which in the boolean matrix this is the number
-    # of values >0, and divide the result by the total number of values in the group
-    # (given by `count()`)
+    # of values > expression_cutoff, and divide the result by the total number of values
+    # in the group (given by `count()`)
     fraction_obs = obs_bool.groupby(level=0).sum() / obs_bool.groupby(level=0).count()
 
     dendro_width = 0.8 if dendrogram else 0


### PR DESCRIPTION
This also adds an option to calculate the mean only over the cells expressing given genes. I think these options give users more flexibility to binarize expression. For example, for z-score normalized data, a combination of `expression_threshold=-1` and `use_raw=False` binarizes the expression using a cutoff value corresponding to one sd away from the mean.

Also the `obs_bool = obs_tidy.astype(bool)` was erroneous for scaled data without the .raw since both positive and negative values were mapped to True. 
