### PR TITLE
Enable autocompletion for scatterplot functions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -71,6 +71,7 @@ intersphinx_mapping = dict(
     leidenalg=('https://leidenalg.readthedocs.io/en/latest/', None),
     louvain=('https://louvain-igraph.readthedocs.io/en/latest/', None),
     matplotlib=('https://matplotlib.org/', None),
+    networkx=('https://networkx.github.io/documentation/networkx-1.10/', None),
     numpy=('https://docs.scipy.org/doc/numpy/', None),
     pandas=('http://pandas.pydata.org/pandas-docs/stable/', None),
     python=('https://docs.python.org/3', None),

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -3,91 +3,97 @@
 
 
 doc_adata_color_etc = """\
-adata : :class:`~anndata.AnnData`
+adata
     Annotated data matrix.
-color : string or list of strings, optional (default: `None`)
+color
     Keys for annotations of observations/cells or variables/genes, e.g.,
     `'ann1'` or `['ann1', 'ann2']`.
-gene_symbols : string, optional (default: `None`)
+gene_symbols
     Column name in `.var` DataFrame that stores gene symbols. By default `var_names` 
     refer to the index column of the `.var` DataFrame. Setting this option allows
     alternative names to be used.
-use_raw : `bool`, optional (default: `None`)
+use_raw
     Use `.raw` attribute of `adata` for coloring with gene expression. If
     `None`, uses `.raw` if present.\
 """
 
 
 doc_edges_arrows = """\
-edges : `bool`, optional (default: `False`)
+edges
     Show edges.
-edges_width : `float`, optional (default: 0.1)
+edges_width
     Width of edges.
-edges_color : matplotlib color, optional (default: 'grey')
-    Color of edges.
-arrows : `bool`, optional (default: `False`)
-    Show arrows (requires to run :func:`~scanpy.api.tl.rna_velocity` before).\
+edges_color : matplotlib color(s), optional (default: 'grey')
+    Color of edges. See :func:`~networkx.drawing.nx_pylab.draw_networkx_edges`.
+arrows
+    Show arrows (requires to run :func:`~scanpy.api.tl.rna_velocity` before).
+arrows_kwds
+    Passed to :func:`~matplotlib.axes.Axes.quiver`\
 """
 
 
 doc_scatter_bulk = """\
-sort_order : `bool`, optional (default: `True`)
+sort_order
     For continuous annotations used as color parameter, plot data points
     with higher values on top of others.
-groups : `str`, optional (default: `all groups`)
+groups
     Restrict to a few categories in categorical observation annotation.
-components : `str` or list of `str`, optional (default: '1,2')
+    The default is not to restrict to any groups.
+components
     For instance, `['1,2', '2,3']`. To plot all available components use
     `components='all'`.
 projection : {'2d', '3d'}, optional (default: '2d')
     Projection of plot.
-legend_loc : `str`, optional (default: 'right margin')
+legend_loc
     Location of legend, either 'on data', 'right margin' or valid keywords for
     `matplotlib.legend`.
-legend_fontsize : `int`, optional (default: `None`)
+legend_fontsize
     Legend font size.
 legend_fontweight : {'normal', 'bold', ...}, optional (default: `None`)
     Legend font weight. Defaults to 'bold' if `legend_loc == 'on data'`,
     otherwise to 'normal'. Available are `['light', 'normal', 'medium',
     'semibold', 'bold', 'heavy', 'black']`.
-size : `float` (default: `None`)
+size
     Point size. If `None`, is automatically computed.
-color_map : `matplotlib.colors.Colormap` or `str`, optional (default: None)
+color_map
     Color map to use for continous variables. Anything that works for `cmap`
     argument of `pyplot.scatter` should work here (e.g. `"magma"`, `"viridis"`,
     `mpl.cm.cividis`). If `None` value of `mpl.rcParams["image.cmap"]` is used.
-palette : `str`, list of `str`, or `Cycler` optional (default: `None`)
+palette
     Colors to use for plotting categorical annotation groups. The palette can be
     a valid `matplotlib.pyplot.colormap` name like `'Set2'` or `'tab20'`, a list
     of colors like `['red', '#ccdd11', (0.1, 0.2, 1)]` or a Cycler object. If
     `None`, `mpl.rcParams["axes.prop_cycle"]` is used unless the categorical
     variable already has colors stored in `adata.uns["{var}_colors"]`. If
     provided, values of `adata.uns["{var}_colors"]` will be set by this palette.
-frameon : `bool`, optional (default: `None`)
+frameon
     Draw a frame around the scatter plot. Defaults to value set in
     :func:`~scanpy.api.tl.set_figure_params`, defaults to `True`.
-ncols : `int` (default: 4)
+ncols
     Number of panels per row.
-wspace : `float` (default: 0.1)
+wspace
     Adjust the width of the space between multiple panels.
-hspace : `float` (default: 0.25)
+hspace
     Adjust the height of the space between multiple panels.
-title : `str` or list of `str`, optional (default: `None`)
-    Provide title for panels either as, e.g. `['title1', 'title2', ...]`.
+title
+    Provide title for panels either as string or list of strings,
+    e.g. `['title1', 'title2', ...]`.
 kwargs : further keyword arguments, optional
-    Arguments to pass to `matplotlib.pyplot.scatter`, for instance: the maximum
-    and minimum values (e.g. `vmin=-2, vmax=5`).\
+    Arguments to pass to :func:`matplotlib.pyplot.scatter`,
+    for instance: the maximum and minimum values (e.g. `vmin=-2, vmax=5`).\
 """
 
 
 doc_show_save_ax = """\
-show : `bool`, optional (default: `None`)
+show
      Show the plot, do not return axis.
-save : `bool` or `str`, optional (default: `None`)
+save
     If `True` or a `str`, save the figure. A string is appended to the default
     filename. Infer the filetype if ending on {'.pdf', '.png', '.svg'}.
-ax : `matplotlib.Axes`, optional (default: `None`)
-    A matplotlib axes object. Only works if plotting a single component.\
+ax
+    A matplotlib axes object. Only works if plotting a single component.
+return_fig
+    Return the matplotlib figure.\
 """
 
 

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -48,7 +48,7 @@ def plot_scatter(
     save: Union[bool, str, None] = None,
     ax: Optional[Axes] = None,
     return_fig: Optional[bool] = None,
-    **kwargs,
+    **kwargs
 ) -> Union[Figure, Axes, None]:
     sanitize_anndata(adata)
     if color_map is not None:

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -20,6 +20,8 @@ from ... import logging as logg
 
 def plot_scatter(
     adata: AnnData,
+    basis: str,
+    *,
     color: Union[str, Sequence[str], None] = None,
     gene_symbols: Optional[str] = None,
     use_raw: Optional[bool] = None,
@@ -29,7 +31,6 @@ def plot_scatter(
     edges_color: Union[str, Sequence[float], Sequence[str]] = 'grey',
     arrows: bool = False,
     arrows_kwds: Optional[Mapping[str, Any]] = None,
-    basis: Optional[str] = None,
     groups: Optional[str] = None,
     components: Union[str, Sequence[str]] = None,
     projection: str = '2d',

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -1,15 +1,264 @@
-from matplotlib import pyplot as pl
-from pandas.api.types import is_categorical_dtype
+from collections import abc
+from typing import Union, Optional, Sequence, Any, Mapping
+
 import numpy as np
+from anndata import AnnData
+from cycler import Cycler
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
+from pandas.api.types import is_categorical_dtype
+from matplotlib import pyplot as pl
 from matplotlib import rcParams
-from matplotlib.colors import is_color_like
+from matplotlib.colors import is_color_like, Colormap
+
 from .. import _utils as utils
-from ...utils import sanitize_anndata, doc_params
-from ... import settings
 from .._docs import doc_adata_color_etc, doc_edges_arrows, doc_scatter_bulk, doc_show_save_ax
+from ... import settings
+from ...utils import sanitize_anndata, doc_params
 from ... import logging as logg
 
 
+def plot_scatter(
+    adata: AnnData,
+    color: Union[str, Sequence[str], None] = None,
+    gene_symbols: Optional[str] = None,
+    use_raw: Optional[bool] = None,
+    sort_order: bool = True,
+    edges: bool = False,
+    edges_width: float = 0.1,
+    edges_color: Union[str, Sequence[float], Sequence[str]] = 'grey',
+    arrows: bool = False,
+    arrows_kwds: Optional[Mapping[str, Any]] = None,
+    basis: Optional[str] = None,
+    groups: Optional[str] = None,
+    components: Union[str, Sequence[str]] = None,
+    projection: str = '2d',
+    color_map: Union[Colormap, str, None] = None,
+    palette: Union[str, Sequence[str], Cycler, None] = None,
+    size: Optional[float] = None,
+    frameon: Optional[bool] = None,
+    legend_fontsize: Optional[int] = None,
+    legend_fontweight: str = 'bold',
+    legend_loc: str = 'right margin',
+    ncols: int = 4,
+    hspace: float = 0.25,
+    wspace: Optional[float] = None,
+    title: Union[str, Sequence[str], None] = None,
+    show: Optional[bool] = None,
+    save: Union[bool, str, None] = None,
+    ax: Optional[Axes] = None,
+    return_fig: Optional[bool] = None,
+    **kwargs,
+) -> Union[Figure, Axes, None]:
+    sanitize_anndata(adata)
+    if color_map is not None:
+        kwargs['cmap'] = color_map
+    if size is not None:
+        kwargs['s'] = size
+    if 'edgecolor' not in kwargs:
+        # by default turn off edge color. Otherwise, for
+        # very small sizes the edge will not reduce its size
+        # (https://github.com/theislab/scanpy/issues/293)
+        kwargs['edgecolor'] = 'none'
+
+    if projection == '3d':
+        from mpl_toolkits.mplot3d import Axes3D
+        args_3d = {'projection': '3d'}
+    else:
+        args_3d = {}
+
+    if use_raw is None:
+        # check if adata.raw is set
+        if adata.raw is None:
+            use_raw = False
+        else:
+            use_raw = True
+
+    if wspace is None:
+        #  try to set a wspace that is not too large or too small given the
+        #  current figure size
+        wspace = 0.75 / rcParams['figure.figsize'][0] + 0.02
+    if adata.raw is None and use_raw is True:
+        raise ValueError(
+            "`use_raw` is set to True but AnnData object does not have raw. "
+            "Please check."
+        )
+    # turn color into a python list
+    color = [color] if isinstance(color, str) or color is None else list(color)
+    if title is not None:
+        # turn title into a python list if not None
+        title = [title] if isinstance(title, str) else list(title)
+
+    ####
+    # get the points position and the components list (only if components is not 'None)
+    data_points, components_list = _get_data_points(adata, basis, projection, components)
+
+    ###
+    # setup layout. Most of the code is for the case when multiple plots are required
+    # 'color' is a list of names that want to be plotted. Eg. ['Gene1', 'louvain', 'Gene2'].
+    # component_list is a list of components [[0,1], [1,2]]
+    if (isinstance(color, abc.Sequence) and len(color) > 1) or len(components_list) > 1:
+        if ax is not None:
+            raise ValueError(
+                "When plotting multiple panels (each for a given value of 'color') "
+                "a given ax can not be used"
+            )
+        if len(components_list) == 0:
+            components_list = [None]
+
+        multi_panel = True
+        # each plot needs to be its own panel
+        from matplotlib import gridspec
+        # set up the figure
+        num_panels = len(color) * len(components_list)
+        n_panels_x = min(ncols, num_panels)
+        n_panels_y = np.ceil(num_panels / n_panels_x).astype(int)
+        # each panel will have the size of rcParams['figure.figsize']
+        fig = pl.figure(figsize=(n_panels_x * rcParams['figure.figsize'][0] * (1 + wspace),
+                                 n_panels_y * rcParams['figure.figsize'][1]))
+        left = 0.2 / n_panels_x
+        bottom = 0.13 / n_panels_y
+        gs = gridspec.GridSpec(
+            nrows=n_panels_y, ncols=n_panels_x,
+            left=left, right=1-(n_panels_x-1)*left-0.01/n_panels_x,
+            bottom=bottom, top=1-(n_panels_y-1)*bottom-0.1/n_panels_y,
+            hspace=hspace, wspace=wspace,
+        )
+    else:
+        if len(components_list) == 0:
+            components_list = [None]
+        multi_panel = False
+        if ax is None:
+            fig = pl.figure()
+            ax = fig.add_subplot(111, **args_3d)
+
+    ###
+    # make the plots
+    axs = []
+    import itertools
+    idx_components = range(len(components_list))
+
+    # use itertools.product to make a plot for each color and for each component
+    # For example if color=[gene1, gene2] and components=['1,2, '2,3'].
+    # The plots are: [color=gene1, components=[1,2], color=gene1, components=[2,3],
+    #                 color=gene2, components = [1, 2], color=gene2, components=[2,3]]
+    for count, (value_to_plot, component_idx) in enumerate(itertools.product(color, idx_components)):
+        color_vector, categorical = _get_color_values(
+            adata, value_to_plot,
+            groups=groups, palette=palette,
+            use_raw=use_raw, gene_symbols=gene_symbols,
+        )
+
+        # check if higher value points should be plot on top
+        if sort_order is True and value_to_plot is not None and categorical is False:
+            order = np.argsort(color_vector)
+            color_vector = color_vector[order]
+            _data_points = data_points[component_idx][order, :]
+
+        else:
+            _data_points = data_points[component_idx]
+
+        # if plotting multiple panels, get the ax from the grid spec
+        # else use the ax value (either user given or created previously)
+        if multi_panel is True:
+            ax = pl.subplot(gs[count], **args_3d)
+            axs.append(ax)
+        if not (settings._frameon if frameon is None else frameon):
+            ax.axis('off')
+        if title is None:
+            if value_to_plot is not None:
+                ax.set_title(value_to_plot)
+            else:
+                ax.set_title('')
+        else:
+            try:
+                ax.set_title(title[count])
+            except IndexError:
+                logg.warn("The title list is shorter than the number of panels. Using 'color' value instead for"
+                          "some plots.")
+                ax.set_title(value_to_plot)
+
+        if 's' not in kwargs:
+            kwargs['s'] = 120000 / _data_points.shape[0]
+
+        # make the scatter plot
+        if projection == '3d':
+            cax = ax.scatter(
+                _data_points[:, 0], _data_points[:, 1], _data_points[:, 2],
+                marker=".", c=color_vector, rasterized=settings._vector_friendly,
+                **kwargs,
+            )
+        else:
+            cax = ax.scatter(
+                _data_points[:, 0], _data_points[:, 1],
+                marker=".", c=color_vector, rasterized=settings._vector_friendly,
+                **kwargs,
+            )
+
+        # remove y and x ticks
+        ax.set_yticks([])
+        ax.set_xticks([])
+        if projection == '3d':
+            ax.set_zticks([])
+
+        # set default axis_labels
+        name = _basis2name(basis)
+        if components is not None:
+            axis_labels = [name + str(x + 1) for x in components_list[component_idx]]
+        elif projection == '3d':
+            axis_labels = [name + str(x + 1) for x in range(3)]
+
+        else:
+            axis_labels = [name + str(x + 1) for x in range(2)]
+
+        ax.set_xlabel(axis_labels[0])
+        ax.set_ylabel(axis_labels[1])
+        if projection == '3d':
+            # shift the label closer to the axis
+            ax.set_zlabel(axis_labels[2], labelpad=-7)
+        ax.autoscale_view()
+
+        if edges:
+            utils.plot_edges(ax, adata, basis, edges_width, edges_color)
+        if arrows:
+            utils.plot_arrows(ax, adata, basis, arrows_kwds)
+
+        if value_to_plot is None:
+            # if only dots were plotted without an associated value
+            # there is not need to plot a legend or a colorbar
+            continue
+
+        _add_legend_or_colorbar(
+            adata, ax, cax, categorical, value_to_plot, legend_loc,
+            _data_points, legend_fontweight, legend_fontsize, groups, multi_panel,
+        )
+
+    if return_fig is True:
+        return fig
+    axs = axs if multi_panel else ax
+    utils.savefig_or_show(basis, show=show, save=save)
+    if show is False:
+        return axs
+
+
+def _wraps_plot_scatter(wrapper):
+    annots_orig = {
+        k: v for k, v in wrapper.__annotations__.items()
+        if k not in {'adata', 'kwargs'}
+    }
+    annots_scatter = {
+        k: v for k, v in plot_scatter.__annotations__.items()
+        if k != 'basis'
+    }
+    wrapper.__annotations__ = {**annots_scatter, **annots_orig}
+    wrapper.__wrapped__ = plot_scatter
+    return wrapper
+
+
+# API
+
+
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def umap(adata, **kwargs):
     """\
@@ -26,9 +275,10 @@ def umap(adata, **kwargs):
     -------
     If `show==False` a `matplotlib.Axis` or a list of it.
     """
-    return plot_scatter(adata, basis='umap', **kwargs)
+    return plot_scatter(adata, 'umap', **kwargs)
 
 
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def tsne(adata, **kwargs):
     """\
@@ -45,9 +295,10 @@ def tsne(adata, **kwargs):
     -------
     If `show==False` a `matplotlib.Axis` or a list of it.
     """
-    return plot_scatter(adata, basis='tsne', **kwargs)
+    return plot_scatter(adata, 'tsne', **kwargs)
 
 
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def phate(adata, **kwargs):
     """\
@@ -83,9 +334,10 @@ def phate(adata, **kwargs):
                     color='branches',
                     color_map='tab20')
     """
-    return plot_scatter(adata, basis='phate', **kwargs)
+    return plot_scatter(adata, 'phate', **kwargs)
 
 
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def diffmap(adata, **kwargs):
     """\
@@ -101,9 +353,10 @@ def diffmap(adata, **kwargs):
     -------
     If `show==False` a `matplotlib.Axis` or a list of it.
     """
-    return plot_scatter(adata, basis='diffmap', **kwargs)
+    return plot_scatter(adata, 'diffmap', **kwargs)
 
 
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def draw_graph(adata, layout=None, **kwargs):
     """\
@@ -131,14 +384,17 @@ def draw_graph(adata, layout=None, **kwargs):
         raise ValueError('Did not find {} in adata.obs. Did you compute layout {}?'
                          .format('draw_graph_' + layout, layout))
 
-    return plot_scatter(adata, basis=basis, **kwargs)
+    return plot_scatter(adata, basis, **kwargs)
 
 
+@_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
 def pca(adata, **kwargs):
     """\
     Scatter plot in PCA coordinates.
 
+    Parameters
+    ----------
     {adata_color_etc}
     {scatter_bulk}
     {show_save_ax}
@@ -147,218 +403,10 @@ def pca(adata, **kwargs):
     -------
     If `show==False` a `matplotlib.Axis` or a list of it.
     """
-    return plot_scatter(adata, basis='pca', **kwargs)
+    return plot_scatter(adata, 'pca', **kwargs)
 
 
-def plot_scatter(adata,
-                 color=None,
-                 gene_symbols=None,
-                 use_raw=None,
-                 sort_order=True,
-                 edges=False,
-                 edges_width=0.1,
-                 edges_color='grey',
-                 arrows=False,
-                 arrows_kwds=None,
-                 basis=None,
-                 groups=None,
-                 components=None,
-                 projection='2d',
-                 color_map=None,
-                 palette=None,
-                 size=None,
-                 frameon=None,
-                 legend_fontsize=None,
-                 legend_fontweight='bold',
-                 legend_loc='right margin',
-                 ncols=4,
-                 hspace=0.25,
-                 wspace=None,
-                 title=None,
-                 show=None,
-                 save=None,
-                 ax=None, return_fig=None, **kwargs):
-
-    sanitize_anndata(adata)
-    if color_map is not None:
-        kwargs['cmap'] = color_map
-    if size is not None:
-        kwargs['s'] = size
-    if 'edgecolor' not in kwargs:
-        # by default turn off edge color. Otherwise, for
-        # very small sizes the edge will not reduce its size
-        # (https://github.com/theislab/scanpy/issues/293)
-        kwargs['edgecolor'] = 'none'
-
-    if projection == '3d':
-        from mpl_toolkits.mplot3d import Axes3D
-        args_3d = {'projection': '3d'}
-    else:
-        args_3d = {}
-
-    if use_raw is None:
-        # check if adata.raw is set
-        if adata.raw is None:
-            use_raw = False
-        else:
-            use_raw = True
-
-    if wspace is None:
-        #  try to set a wspace that is not too large or too small given the
-        #  current figure size
-        wspace = 0.75 / rcParams['figure.figsize'][0] + 0.02
-    if adata.raw is None and use_raw is True:
-        raise ValueError("`use_raw` is set to True but annData object does not have raw. "
-                         "Please check.")
-    # turn color into a python list
-    color = [color] if isinstance(color, str) or color is None else list(color)
-    if title is not None:
-        # turn title into a python list if not None
-        title = [title] if isinstance(title, str) else list(title)
-
-    ####
-    # get the points position and the components list (only if components is not 'None)
-    data_points, components_list = _get_data_points(adata, basis, projection, components)
-
-    ###
-    # setup layout. Most of the code is for the case when multiple plots are required
-    # 'color' is a list of names that want to be plotted. Eg. ['Gene1', 'louvain', 'Gene2'].
-    # component_list is a list of components [[0,1], [1,2]]
-    if (isinstance(color, list) and len(color) > 1) or len(components_list) > 1:
-        if ax is not None:
-            raise ValueError("When plotting multiple panels (each for a given value of 'color' "
-                             "a given ax can not be used")
-        if len(components_list) == 0:
-            components_list = [None]
-
-        multi_panel = True
-        # each plot needs to be its own panel
-        from matplotlib import gridspec
-        # set up the figure
-        num_panels = len(color) * len(components_list)
-        n_panels_x = min(ncols, num_panels)
-        n_panels_y = np.ceil(num_panels / n_panels_x).astype(int)
-        # each panel will have the size of rcParams['figure.figsize']
-        fig = pl.figure(figsize=(n_panels_x * rcParams['figure.figsize'][0] * (1 + wspace),
-                                 n_panels_y * rcParams['figure.figsize'][1]))
-        left = 0.2 / n_panels_x
-        bottom = 0.13 / n_panels_y
-        gs = gridspec.GridSpec(nrows=n_panels_y,
-                               ncols=n_panels_x,
-                               left=left,
-                               right=1-(n_panels_x-1)*left-0.01/n_panels_x,
-                               bottom=bottom,
-                               top=1-(n_panels_y-1)*bottom-0.1/n_panels_y,
-                               hspace=hspace,
-                               wspace=wspace)
-    else:
-        if len(components_list) == 0:
-            components_list = [None]
-        multi_panel = False
-        if ax is None:
-            fig = pl.figure()
-            ax = fig.add_subplot(111, **args_3d)
-
-    ###
-    # make the plots
-    axs = []
-    import itertools
-    idx_components = range(len(components_list))
-
-    # use itertools.product to make a plot for each color and for each component
-    # For example if color=[gene1, gene2] and components=['1,2, '2,3'].
-    # The plots are: [color=gene1, components=[1,2], color=gene1, components=[2,3],
-    #                 color=gene2, components = [1, 2], color=gene2, components=[2,3]]
-    for count, (value_to_plot, component_idx) in enumerate(itertools.product(color, idx_components)):
-        color_vector, categorical = _get_color_values(adata, value_to_plot,
-                                                      groups=groups, palette=palette,
-                                                      use_raw=use_raw, gene_symbols=gene_symbols)
-
-        # check if higher value points should be plot on top
-        if sort_order is True and value_to_plot is not None and categorical is False:
-            order = np.argsort(color_vector)
-            color_vector = color_vector[order]
-            _data_points = data_points[component_idx][order, :]
-
-        else:
-            _data_points = data_points[component_idx]
-
-        # if plotting multiple panels, get the ax from the grid spec
-        # else use the ax value (either user given or created previously)
-        if multi_panel is True:
-            ax = pl.subplot(gs[count], **args_3d)
-            axs.append(ax)
-        if not (settings._frameon if frameon is None else frameon):
-            ax.axis('off')
-        if title is None:
-            if value_to_plot is not None:
-                ax.set_title(value_to_plot)
-            else:
-                ax.set_title('')
-        else:
-
-            try:
-                ax.set_title(title[count])
-            except IndexError:
-                logg.warn("The title list is shorter than the number of panels. Using 'color' value instead for"
-                          "some plots.")
-                ax.set_title(value_to_plot)
-
-        if 's' not in kwargs:
-            kwargs['s'] = 120000 / _data_points.shape[0]
-
-        # make the scatter plot
-        if projection == '3d':
-            cax= ax.scatter(_data_points[:, 0], _data_points[:, 1], _data_points[:, 2],
-                            marker=".", c=color_vector, rasterized=settings._vector_friendly,
-                            **kwargs)
-        else:
-            cax= ax.scatter(_data_points[:, 0], _data_points[:, 1],
-                            marker=".", c=color_vector, rasterized=settings._vector_friendly,
-                            **kwargs)
-
-        # remove y and x ticks
-        ax.set_yticks([])
-        ax.set_xticks([])
-        if projection == '3d':
-            ax.set_zticks([])
-
-        # set default axis_labels
-        name = _basis2name(basis)
-        if components is not None:
-            axis_labels = [name + str(x + 1) for x in components_list[component_idx]]
-        elif projection == '3d':
-            axis_labels = [name + str(x + 1) for x in range(3)]
-
-        else:
-            axis_labels = [name + str(x + 1) for x in range(2)]
-
-        ax.set_xlabel(axis_labels[0])
-        ax.set_ylabel(axis_labels[1])
-        if projection == '3d':
-            # shift the label closer to the axis
-            ax.set_zlabel(axis_labels[2], labelpad=-7)
-        ax.autoscale_view()
-
-        if edges:
-            utils.plot_edges(ax, adata, basis, edges_width, edges_color)
-        if arrows:
-            utils.plot_arrows(ax, adata, basis, arrows_kwds)
-
-        if value_to_plot is None:
-            # if only dots were plotted without an associated value
-            # there is not need to plot a legend or a colorbar
-            continue
-
-        _add_legend_or_colorbar(adata, ax, cax, categorical, value_to_plot, legend_loc,
-                                _data_points, legend_fontweight, legend_fontsize, groups, multi_panel)
-
-    if return_fig is True:
-        return fig
-    axs = axs if multi_panel else ax
-    utils.savefig_or_show(basis, show=show, save=save)
-    if show is False:
-        return axs
+# Helpers
 
 
 def _get_data_points(adata, basis, projection, components):
@@ -401,7 +449,7 @@ def _get_data_points(adata, basis, projection, components):
             # eg: components='1,2'
             components_list.append([int(x.strip()) - 1 + offset for x in components.split(',')])
 
-        elif isinstance(components, list):
+        elif isinstance(components, abc.Sequence):
             if isinstance(components[0], int):
                 # components=[1,2]
                 components_list.append([int(x) - 1 + offset for x in components])
@@ -522,7 +570,7 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
     else:
         # check if palette is a list and convert it to a cycler, thus
         # it doesnt matter if the list is shorter than the categories length:
-        if isinstance(palette, list):
+        if isinstance(palette, abc.Sequence):
             if len(palette) < len(categories):
                 logg.warn("Length of palette colors is smaller than the number of "
                           "categories (palette length: {}, categories length: {}. "


### PR DESCRIPTION
Fixes #535

Sorry for the messy diff, I had to put the API functions after `plot_scatter` since the decorator is called at import time and needs `plot_scatter` to be defined beforehand.

This also fixes the docs for `pca` and adds parameter docs for `arrows_kwds` and `return_fig`.