### PR TITLE
Add 'equal_frequency' option to highly_variable_genes

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -114,8 +114,7 @@ def highly_variable_genes(
         if binning_method == 'equal_width':
             df['mean_bin'] = pd.cut(df['mean'], bins=n_bins)
         elif binning_method == 'equal_frequency':
-            # be consistent with Seurat, even if qcut would also work
-            df['mean_bin'] = pd.qcut(df['mean'], q=n_bins)
+            df['mean_bin'] = pd.qcut(df['mean'], q=n_bins, duplicates='drop')
         else:
             raise ValueError('`binning_method` needs to be "equal_width" or "equal_frequency"')
         disp_grouped = df.groupby('mean_bin')['dispersion']

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -9,6 +9,7 @@ FILE = Path(__file__).parent / Path('_scripts/seurat_hvg.csv')
 def test_highly_variable_genes_basic():
     adata = sc.datasets.blobs()
     sc.pp.highly_variable_genes(adata)
+    sc.pp.highly_variable_genes(adata, binning_method="equal_frequency")
 
 
 def test_higly_variable_genes_compare_to_seurat():


### PR DESCRIPTION
This fixes #415, by allowing one to find variable genes using the `equal_frequency` option. It also adds and option to change the number of bins for cell ranger flavor.

I originally tried to copy the implementation in Seurat, which would allow a test similar to what's already present for the `equal_width` implementation. However the Seurat code has an error:
```R
else if (binning.method=="equal_frequency") {
        data_x_bin <- cut(x = gene.mean, breaks = c(-1,quantile(gene.mean[gene.mean>0],probs=seq(0,1,length.out=num.bin))))
}
```
The `-1` in the code makes it such that there is always only one value in the first bin, which goes from -1 to the minimum value. Not sure why they have this, but then we get different answers since the Scanpy code in `highly_variable_genes` always makes bins that have only one gene significant (to correct the other error from Seurat that normally excludes these bins/genes, which often contain some highly-expressed genes). Additionally, the `cut` function in R sometimes returns bin edges with different rounding than the Seurat implementation since Seurat does not modify the default `dig.lab = 3`. In contrast, I believe pandas uses the actual cutoffs in the data.
