### PR TITLE
Fix read softgz

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -567,8 +567,7 @@ def _read_softgz(filename):
     obs['groups'] = groups
     var = np.zeros((len(gene_names),), dtype=[('var_names', 'S21')])
     var['var_names'] = gene_names
-    ddata = {'X': X, 'obs': obs, 'var': var}
-    return AnnData(**ddata)
+    return AnnData(X=X, obs=obs, var=var)
 
 
 # -------------------------------------------------------------------------------

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -568,7 +568,7 @@ def _read_softgz(filename):
     var = np.zeros((len(gene_names),), dtype=[('var_names', 'S21')])
     var['var_names'] = gene_names
     ddata = {'X': X, 'obs': obs, 'var': var}
-    return AnnData(ddata)
+    return AnnData(**ddata)
 
 
 # -------------------------------------------------------------------------------


### PR DESCRIPTION
While testing my changes to dataset code, I saw that `sc.datasets.burczynski06()` raised the error:

```python
ValueError: `X` needs to be of one of ndarray, MaskedArray, spmatrix, ZarrArray, ZappyArray, not <class 'dict'>.
```

But it had a pretty easy fix.