### PR TITLE
Fix for #577

### DIFF
--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -725,7 +725,7 @@ def _get_color_values(adata, value_to_plot, groups=None, palette=None, use_raw=F
             color_vector = adata[:, value_to_plot].layers[layer]
         elif use_raw and value_to_plot in adata.var_names:
             color_vector = adata.raw[:, value_to_plot].X
-        elif value_to_plot in adata.raw.var_names:
+        elif value_to_plot in adata.var_names:
             color_vector = adata[:, value_to_plot].X
 
         else:


### PR DESCRIPTION
I think this should fix it – it fixes it on my machine and the tests pass.

There's no reason to access raw if `use_raw` isn't passed, right?