### PR TITLE
Marker overlap fix

### DIFF
--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -22,11 +22,6 @@ def test_marker_overlap_base():
 
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
 
-    print(t1)
-    print(marker_genes)
-    print(test_data.uns['rank_genes_groups']['names']['c0'])
-    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
-    
     assert t1['c0']['type 1'] == 3.0
     assert t1['c1']['type 2'] == 3.0
 
@@ -36,13 +31,6 @@ def test_marker_overlap_normalization():
 
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
     t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
-
-    print(t2)
-    print(t3)
-    print(marker_genes)
-    print(test_data.uns['rank_genes_groups']['names']['c0'])
-    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
-
 
     assert t2['c0']['type 1'] == 1.0
     assert t3['c1']['type 2'] == 0.6
@@ -54,12 +42,6 @@ def test_marker_overlap_methods():
     t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
     t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
 
-    print(t4)
-    print(t5)
-    print(marker_genes)
-    print(test_data.uns['rank_genes_groups']['names']['c0'])
-    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
-
     assert t4['c0']['type 1'] == 1.0
     assert t5['c0']['type 1'] == 0.6
 
@@ -69,12 +51,6 @@ def test_marker_overlap_subsetting():
 
     t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
     t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
-
-    print(t6)
-    print(t7)
-    print(marker_genes)
-    print(test_data.uns['rank_genes_groups']['names']['c0'])
-    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
 
     assert t6['c0']['type 1'] == 2.0
     assert t7['c0']['type 1'] == 1.0

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -21,6 +21,11 @@ def test_marker_overlap_base():
     test_data,marker_genes = generate_test_data()
 
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
+
+    print(t1)
+    print(marker_genes)
+    print(test_data.uns['rank_genes_groups']['names']['c0'])
+    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
     
     assert t1['c0']['type 1'] == 3.0
     assert t1['c1']['type 2'] == 3.0
@@ -32,6 +37,13 @@ def test_marker_overlap_normalization():
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
     t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
 
+    print(t2)
+    print(t3)
+    print(marker_genes)
+    print(test_data.uns['rank_genes_groups']['names']['c0'])
+    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
+
+
     assert t2['c0']['type 1'] == 1.0
     assert t3['c1']['type 2'] == 0.6
 
@@ -42,6 +54,12 @@ def test_marker_overlap_methods():
     t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
     t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
 
+    print(t4)
+    print(t5)
+    print(marker_genes)
+    print(test_data.uns['rank_genes_groups']['names']['c0'])
+    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
+
     assert t4['c0']['type 1'] == 1.0
     assert t5['c0']['type 1'] == 0.6
 
@@ -51,6 +69,12 @@ def test_marker_overlap_subsetting():
 
     t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
     t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
+
+    print(t6)
+    print(t7)
+    print(marker_genes)
+    print(test_data.uns['rank_genes_groups']['names']['c0'])
+    print(test_data.uns['rank_genes_groups']['pvals_adj']['c1'])
 
     assert t6['c0']['type 1'] == 2.0
     assert t7['c0']['type 1'] == 1.0

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -14,15 +14,17 @@ def test_marker_overlap():
 
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
-    t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
-    t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
-    t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
-    t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
+    t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
+    t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
+    t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
+    t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
+    t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
 
     assert t1.iloc[1,1] == 3.0
     assert t1.iloc[0,0] == 3.0
-    assert t2.iloc[0,0] == 0.75
-    assert t3.iloc[0,0] == 1.0
-    assert t4.iloc[0,0] == 0.6
-    assert t5.iloc[0,0] == 2
-    assert t6.iloc[0,0] == 1.0
+    assert t2.iloc[0,0] == 1.0
+    assert t3.iloc[1,1] == 0.6
+    assert t4.iloc[0,0] == 1.0
+    assert t5.iloc[0,0] == 0.6
+    assert t6.iloc[0,0] == 2
+    assert t7.iloc[0,0] == 1.0

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -6,9 +6,10 @@ def generate_test_data():
     test_data = sc.AnnData(X = np.ones((9,10)))
     test_data.uns['rank_genes_groups'] = dict()
     test_data.uns['rank_genes_groups']['names'] = np.rec.fromarrays(
-        [['a', 'b','c','d','e'], ['a','f','g','h','i']])
+        [['a', 'b','c','d','e'], ['a','f','g','h','i']], names='c0,c1')
     test_data.uns['rank_genes_groups']['pvals_adj'] = np.rec.fromarrays(
-        [[0.001, 0.01, 0.02, 0.05, 0.6], [0.001, 0.01, 0.02, 0.05, 0.6]])
+        [[0.001, 0.01, 0.02, 0.05, 0.6], [0.001, 0.01, 0.02, 0.05, 0.6]], 
+        names='c0,c1')
 
     marker_genes = {'type 1':{'a','b','c'}, 'type 2':{'a','f','g'}}
 
@@ -21,10 +22,8 @@ def test_marker_overlap_base():
 
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
     
-    print(t1)
-
-    assert t1.iloc[1,1] == 3.0
-    assert t1.iloc[0,0] == 3.0
+    assert t1['c0']['type 1'] == 3.0
+    assert t1['c1']['type 2'] == 3.0
 
 
 def test_marker_overlap_normalization():
@@ -32,11 +31,9 @@ def test_marker_overlap_normalization():
 
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
     t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
-    print(t2)
-    print(t3)
 
-    assert t2.iloc[0,0] == 1.0
-    assert t3.iloc[1,1] == 0.6
+    assert t2['c0']['type 1'] == 1.0
+    assert t3['c1']['type 2'] == 0.6
 
 
 def test_marker_overlap_methods():
@@ -44,8 +41,7 @@ def test_marker_overlap_methods():
 
     t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
     t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
-    print(t4)
-    print(t5)
+
     assert t4.iloc[0,0] == 1.0
     assert t5.iloc[0,0] == 0.6
 
@@ -55,9 +51,7 @@ def test_marker_overlap_subsetting():
 
     t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
     t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
-    print(t6)
-    print(t7)
 
-    assert t6.iloc[0,0] == 2
-    assert t7.iloc[0,0] == 1.0
+    assert t6['c0']['type 1'] == 2.0
+    assert t7['c0']['type 1'] == 1.0
 

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -20,6 +20,8 @@ def test_marker_overlap_base():
     test_data,marker_genes = generate_test_data()
 
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
+    
+    print(t1)
 
     assert t1.iloc[1,1] == 3.0
     assert t1.iloc[0,0] == 3.0
@@ -30,6 +32,8 @@ def test_marker_overlap_normalization():
 
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
     t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
+    print(t2)
+    print(t3)
 
     assert t2.iloc[0,0] == 1.0
     assert t3.iloc[1,1] == 0.6
@@ -40,7 +44,8 @@ def test_marker_overlap_methods():
 
     t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
     t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
-
+    print(t4)
+    print(t5)
     assert t4.iloc[0,0] == 1.0
     assert t5.iloc[0,0] == 0.6
 
@@ -50,6 +55,8 @@ def test_marker_overlap_subsetting():
 
     t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
     t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
+    print(t6)
+    print(t7)
 
     assert t6.iloc[0,0] == 2
     assert t7.iloc[0,0] == 1.0

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -42,8 +42,8 @@ def test_marker_overlap_methods():
     t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
     t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
 
-    assert t4.iloc[0,0] == 1.0
-    assert t5.iloc[0,0] == 0.6
+    assert t4['c0']['type 1'] == 1.0
+    assert t5['c0']['type 1'] == 0.6
 
 
 def test_marker_overlap_subsetting():

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -1,8 +1,8 @@
 import scanpy as sc
 import numpy as np
 
-def test_marker_overlap():
-    # Test all overlap calculations on artificial data
+def generate_test_data():
+    # Create an artificial data set
     test_data = sc.AnnData(X = np.ones((9,10)))
     test_data.uns['rank_genes_groups'] = dict()
     test_data.uns['rank_genes_groups']['names'] = np.rec.fromarrays(
@@ -12,19 +12,45 @@ def test_marker_overlap():
 
     marker_genes = {'type 1':{'a','b','c'}, 'type 2':{'a','f','g'}}
 
+    return test_data,marker_genes
+    
+
+def test_marker_overlap_base():
+    # Test all overlap calculations on artificial data
+    test_data,marker_genes = generate_test_data()
+
     t1 = sc.tl.marker_gene_overlap(test_data, marker_genes)
+
+    assert t1.iloc[1,1] == 3.0
+    assert t1.iloc[0,0] == 3.0
+
+
+def test_marker_overlap_normalization():
+    test_data,marker_genes = generate_test_data()
+
     t2 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='reference')
     t3 = sc.tl.marker_gene_overlap(test_data, marker_genes, normalize='data')
-    t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
-    t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
-    t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
-    t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
 
     assert t2.iloc[0,0] == 1.0
     assert t3.iloc[1,1] == 0.6
+
+
+def test_marker_overlap_methods():
+    test_data,marker_genes = generate_test_data()
+
+    t4 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='overlap_coef')
+    t5 = sc.tl.marker_gene_overlap(test_data, marker_genes, method='jaccard')
+
     assert t4.iloc[0,0] == 1.0
     assert t5.iloc[0,0] == 0.6
+
+
+def test_marker_overlap_subsetting():
+    test_data,marker_genes = generate_test_data()
+
+    t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
+    t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
+
     assert t6.iloc[0,0] == 2
     assert t7.iloc[0,0] == 1.0
-    assert t1.iloc[1,1] == 3.0
-    assert t1.iloc[0,0] == 3.0
+

--- a/scanpy/tests/test_marker_gene_overlap.py
+++ b/scanpy/tests/test_marker_gene_overlap.py
@@ -20,11 +20,11 @@ def test_marker_overlap():
     t6 = sc.tl.marker_gene_overlap(test_data, marker_genes, top_n_markers=2)
     t7 = sc.tl.marker_gene_overlap(test_data, marker_genes, adj_pval_threshold=0.01)
 
-    assert t1.iloc[1,1] == 3.0
-    assert t1.iloc[0,0] == 3.0
     assert t2.iloc[0,0] == 1.0
     assert t3.iloc[1,1] == 0.6
     assert t4.iloc[0,0] == 1.0
     assert t5.iloc[0,0] == 0.6
     assert t6.iloc[0,0] == 2
     assert t7.iloc[0,0] == 1.0
+    assert t1.iloc[1,1] == 3.0
+    assert t1.iloc[0,0] == 3.0

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -69,7 +69,7 @@ def _calc_jaccard(
 
 def marker_gene_overlap(
     adata: AnnData,
-    reference_markers: Dict[str, set],
+    reference_markers: Union[Dict[str, set], Dict[str,list]],
     *,
     key: str = 'rank_genes_groups',
     method: Optional[str] = 'overlap_count',
@@ -94,8 +94,8 @@ def marker_gene_overlap(
         The annotated data matrix.
     reference_markers
         A marker gene dictionary object. Keys should be strings with the 
-        cell identity name and values are sets of strings which match format
-        of `adata.var_name`.
+        cell identity name and values are sets or lists of strings which match 
+        format of `adata.var_name`.
     key
         The key in `adata.uns` where the rank_genes_groups output is stored.
         By default this is `'rank_genes_groups'`.
@@ -171,8 +171,12 @@ def marker_gene_overlap(
         raise ValueError('Can only normalize with method=`overlap_count`.')
 
     if not np.all([isinstance(val, set) for val in reference_markers.values()]):
-        raise ValueError('Please ensure that `reference_markers` contains sets '
-                         'of markers as values.')
+        try:
+            reference_markers = {key:set(val) for key,val
+                                 in reference_markers.items()}
+        except:
+            raise ValueError('Please ensure that `reference_markers` contains '
+                             'sets or lists of markers as values.')
 
     if adj_pval_threshold is not None:
         if 'pvals_adj' not in adata.uns[key]:


### PR DESCRIPTION
Noticed that I did not normalized as intended, and made the input dictionary more flexible.

Now:
1. Normalization is not just performed so that rows/columns sum to 1, but instead over the number of marker genes in the reference/the number of marker genes used from the data.
2. Reference marker dictionaries now accept `Union[Dict[str, set], Dict[str,list]]`. Dictionaries of lists are easier to use in other applications, like scoring based on gene sets.

Still no idea why Travis is failing though :/.