### PR TITLE
Add pipenv files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,9 @@ scripts/tgdyn_simple.py
 .spyproject/
 scanpy/.spyproject/
 
-
+# Environment management
+Pipfile
+Pipfile.lock
 
 # always-ignore extensions
 *~


### PR DESCRIPTION
Would anyone mind if these were added? I've used this to manage my `scanpy` dev environment, but would like it to stop showing up in `git status`.