### PR TITLE
removed normalize_quantile

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -36,7 +36,6 @@ For visual quality control, see :func:`~scanpy.pl.highest_expr_gens` and
    pp.log1p
    pp.pca
    pp.normalize_total
-   pp.normalize_quantile
    pp.regress_out
    pp.scale
    pp.subsample

--- a/scanpy/api/pp.py
+++ b/scanpy/api/pp.py
@@ -10,4 +10,4 @@ from ..preprocessing._dca import dca
 from ..preprocessing._magic import magic
 from ..neighbors import neighbors
 from ..preprocessing._combat import combat
-from ..preprocessing._normalization import normalize_quantile, normalize_total
+from ..preprocessing._normalization import normalize_total

--- a/scanpy/preprocessing/__init__.py
+++ b/scanpy/preprocessing/__init__.py
@@ -5,6 +5,6 @@ from ._highly_variable_genes import highly_variable_genes
 from ._simple import log1p, sqrt, pca, normalize_per_cell, regress_out, scale, subsample, downsample_counts
 from ._qc import calculate_qc_metrics
 from ._combat import combat
-from ._normalization import normalize_quantile, normalize_total
+from ._normalization import normalize_total
 
 from ..neighbors import neighbors

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -5,6 +5,7 @@ from .. import logging as logg
 from ..utils import doc_params
 from ._docs import doc_norm_descr, doc_quant_descr, doc_params_bulk, doc_norm_quant, doc_norm_return, doc_ex_quant, doc_ex_total
 
+
 def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
     after = np.median(counts[counts>0]) if after is None else after
@@ -16,10 +17,11 @@ def _normalize_data(X, counts, after=None, copy=False):
         X /= counts[:, None]
     return X if copy else None
 
+
 @doc_params(quant_descr=doc_quant_descr, params_bulk=doc_params_bulk, norm_quant=doc_norm_quant,
             norm_return=doc_norm_return, ex_quant=doc_ex_quant)
-def normalize_quantile(adata, target_sum=None, quantile=0.95, key_added=None,
-                       layers=None, layer_norm=None, inplace=True):
+def normalize_total(adata, target_sum=None, quantile=1, key_added=None,
+                    layers=None, layer_norm=None, inplace=True):
     """\
     {quant_descr}
 
@@ -104,18 +106,3 @@ def normalize_quantile(adata, target_sum=None, quantile=0.95, key_added=None,
             .format(key_added))
 
     return dat if not inplace else None
-
-@doc_params(norm_descr=doc_norm_descr, params_bulk=doc_params_bulk, norm_return=doc_norm_return, ex_total=doc_ex_total)
-def normalize_total(adata, target_sum=None, key_added=None, layers=None, layer_norm=None, inplace=True):
-    """\
-    {norm_descr}
-
-    {params_bulk}
-
-    {norm_return}
-
-    {ex_total}
-    """
-    return normalize_quantile(adata=adata, target_sum=target_sum,
-                              key_added=key_added, layers=layers,
-                              layer_norm=layer_norm, quantile=1, inplace=inplace)

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -88,6 +88,7 @@ def test_regress_out_categorical():
     multi = sc.pp.regress_out(adata, keys='batch', n_jobs=8, copy=True)
     assert adata.X.shape == multi.X.shape
 
+
 def test_downsample_counts_per_cell():
     TARGET = 1000
     X = np.random.randint(0, 100, (1000, 100)) * \
@@ -109,6 +110,7 @@ def test_downsample_counts_per_cell():
                     == new_totals[initial_totals <= TARGET])
         if not replace:
             assert np.all(X >= adata.X)
+
 
 def test_downsample_total_counts():
     X = np.random.randint(0, 100, (1000, 100)) * \


### PR DESCRIPTION
Hi @Koncopd, as discussed, we should probably not call this function using this name. As we might have multiple conceptually more different normalization functions in the future, we should probably just be satisfied with this one normalization function for now. The most natural thing is to have a `quantile` param in `normalize_total`. What do you think?