### PR TITLE
Downsample improvements

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -994,22 +994,22 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         original_type = type(X)
         if not isspmatrix_csr(X):
             X = csr_matrix(X)
-        totals = np.ravel(X.sum(axis=1))
+        totals = np.ravel(X.sum(axis=1))  # Faster for csr matrix
         under_target = np.nonzero(totals > counts_per_cell)[0]
-        cols = np.split(X.data.view(), X.indptr[1:-1])
-        for colidx in under_target:
-            col = cols[colidx]
-            _downsample_array(col, counts_per_cell[colidx], random_state=random_state,
+        rows = np.split(X.data.view(), X.indptr[1:-1])
+        for rowidx in under_target:
+            row = rows[rowidx]
+            _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
                               replace=replace, inplace=True)
         X.eliminate_zeros()
-        if original_type is not csr_matrix: # Put it back
+        if original_type is not csr_matrix:  # Put it back
             X = original_type(X)
     else:
         totals = np.ravel(X.sum(axis=1))
         under_target = np.nonzero(totals > counts_per_cell)[0]
-        for colidx in under_target:
-            col = X[colidx, :].view()
-            _downsample_array(col, counts_per_cell[colidx], random_state=random_state,
+        for rowidx in under_target:
+            row = X[rowidx, :].view()
+            _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
                               replace=replace, inplace=True)
     return X
 

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -2,6 +2,7 @@ from itertools import product
 import numpy as np
 from scipy import sparse as sp
 import scanpy as sc
+import pytest
 from anndata import AnnData
 
 
@@ -89,49 +90,55 @@ def test_regress_out_categorical():
     assert adata.X.shape == multi.X.shape
 
 
-def test_downsample_counts_per_cell():
+@pytest.fixture(params=[lambda x: x.copy(), sp.csr_matrix, sp.csc_matrix])
+def count_matrix_format(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False])
+def replace(request):
+    return request.param
+
+
+def test_downsample_counts_per_cell(count_matrix_format, replace):
     TARGET = 1000
     X = np.random.randint(0, 100, (1000, 100)) * \
         np.random.binomial(1, .3, (1000, 100))
-    adata_dense = AnnData(X=X.copy())
-    adata_csr = AnnData(X=sp.csr_matrix(X))
-    adata_csc = AnnData(X=sp.csc_matrix(X))
-    for adata, replace in product((adata_dense, adata_csr, adata_csc), (True, False)):
-        initial_totals = np.ravel(adata.X.sum(axis=1))
-        adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGET, replace=replace, copy=True)
-        new_totals = np.ravel(adata.X.sum(axis=1))
-        if sp.issparse(adata.X):
-            assert all(adata.X.toarray()[X == 0] == 0)
-        else:
-            assert all(adata.X[X == 0] == 0)
-        assert all(new_totals <= TARGET)
-        assert all(initial_totals >= new_totals)
-        assert all(initial_totals[initial_totals <= TARGET]
-                    == new_totals[initial_totals <= TARGET])
-        if not replace:
-            assert np.all(X >= adata.X)
+    adata = AnnData(X=count_matrix_format(X))
+    initial_totals = np.ravel(adata.X.sum(axis=1))
+    adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGET,
+                                    replace=replace, copy=True)
+    new_totals = np.ravel(adata.X.sum(axis=1))
+    if sp.issparse(adata.X):
+        assert all(adata.X.toarray()[X == 0] == 0)
+    else:
+        assert all(adata.X[X == 0] == 0)
+    assert all(new_totals <= TARGET)
+    assert all(initial_totals >= new_totals)
+    assert all(initial_totals[initial_totals <= TARGET]
+                == new_totals[initial_totals <= TARGET])
+    if not replace:
+        assert np.all(X >= adata.X)
 
 
-def test_downsample_total_counts():
+def test_downsample_total_counts(count_matrix_format, replace):
     X = np.random.randint(0, 100, (1000, 100)) * \
         np.random.binomial(1, .3, (1000, 100))
+    adata_orig = AnnData(X=count_matrix_format(X))
     total = X.sum()
     target = np.floor_divide(total, 10)
-    adata_dense = AnnData(X=X.copy())
-    adata_csr = AnnData(X=sp.csr_matrix(X))
-    for adata, replace in product((adata_dense, adata_csr), (True, False)):
-        initial_totals = np.ravel(adata.X.sum(axis=1))
-        adata = sc.pp.downsample_counts(adata, total_counts=target, replace=replace, copy=True)
-        new_totals = np.ravel(adata.X.sum(axis=1))
-        if sp.issparse(adata.X):
-            assert all(adata.X.toarray()[X == 0] == 0)
-        else:
-            assert all(adata.X[X == 0] == 0)
-        assert adata.X.sum() == target
-        assert all(initial_totals >= new_totals)
-        if not replace:
-            assert np.all(X >= adata.X)
-    for adata in (adata_dense, adata_csr): # When specified total is greater than current total
-        adata = sc.pp.downsample_counts(adata, total_counts=total + 10, replace=False, copy=True)
+    initial_totals = np.ravel(adata_orig.X.sum(axis=1))
+    adata = sc.pp.downsample_counts(adata_orig, total_counts=target,
+                                    replace=replace, copy=True)
+    new_totals = np.ravel(adata.X.sum(axis=1))
+    if sp.issparse(adata.X):
+        assert all(adata.X.toarray()[X == 0] == 0)
+    else:
+        assert all(adata.X[X == 0] == 0)
+    assert adata.X.sum() == target
+    assert all(initial_totals >= new_totals)
+    if not replace:
+        assert np.all(X >= adata.X)
+        adata = sc.pp.downsample_counts(adata_orig, total_counts=total + 10,
+                                        replace=False, copy=True)
         assert (adata.X == X).all()
-

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -105,6 +105,10 @@ def test_downsample_counts_per_cell(count_matrix_format, replace):
     X = np.random.randint(0, 100, (1000, 100)) * \
         np.random.binomial(1, .3, (1000, 100))
     adata = AnnData(X=count_matrix_format(X))
+    with pytest.raises(ValueError):
+        sc.pp.downsample_counts(adata, counts_per_cell=TARGET, total_counts=TARGET, replace=replace)
+    with pytest.raises(ValueError):
+        sc.pp.downsample_counts(adata, replace=replace)
     initial_totals = np.ravel(adata.X.sum(axis=1))
     adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGET,
                                     replace=replace, copy=True)
@@ -127,7 +131,6 @@ def test_downsample_counts_per_cell_multiple_targets(count_matrix_format, replac
         np.random.binomial(1, .3, (1000, 100))
     adata = AnnData(X=count_matrix_format(X))
     initial_totals = np.ravel(adata.X.sum(axis=1))
-    # assert all(initial_totals == 0)
     with pytest.raises(ValueError):
         sc.pp.downsample_counts(adata, counts_per_cell=[40, 10], replace=replace)
     adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGETS, replace=replace, copy=True)
@@ -142,6 +145,7 @@ def test_downsample_counts_per_cell_multiple_targets(count_matrix_format, replac
                 == new_totals[initial_totals <= TARGETS])
     if not replace:
         assert np.all(X >= adata.X)
+
 
 def test_downsample_total_counts(count_matrix_format, replace):
     X = np.random.randint(0, 100, (1000, 100)) * \


### PR DESCRIPTION
Just a minor improvement. Now you can specify the total counts to downsample to on a per-cell basis by passing an array for `counts_per_cell`. This is so I don't have to split and merge an AnnData object when I want multiple distributions of counts per cell.