### PR TITLE
Old, simple method for flat return sections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,16 +47,22 @@ or updates `adata` with normalized version of the original
 ```
 
 Many functions also just modify parts of the passed AnnData object,
-like e.g. [`tl.leiden`](https://scanpy.readthedocs.io/en/latest/api/scanpy.tl.leiden.html)
+like e.g. [`tl.dpt`](https://scanpy.readthedocs.io/en/latest/api/scanpy.tl.dpt.html)
 
 ```rst
 Returns
 -------
-`adata.obs[key_added]`
-    Array of dim (number of samples) that stores the subgroup id (`'0'`, `'1'`, ...) for each cell.
+Depending on `copy`, returns or updates `adata` with the following fields.
 
-`adata.uns['leiden']['params']`
-    A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
+If `n_branchings==0`, no field `dpt_groups` will be written.
+
+dpt_pseudotime : `pd.Series` (`adata.obs`, dtype `float`)
+    Array of dim (number of samples) that stores the pseudotime of each
+    cell, that is, the DPT distance with respect to the root cell.
+dpt_groups : `pd.Series` (`adata.obs`, dtype `category`)
+    Array of dim (number of samples) that stores the subgroup id ('0',
+    '1', ...) for each cell. The groups  typically correspond to
+    'progenitor cells', 'undecided cells' or 'branches' of a process.
 ```
 
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,35 +16,48 @@ We stick to [PEP 8](https://www.python.org/dev/peps/pep-0008) and to this [edito
 
 ### Docs
 
-We use the numpydoc style for writing docstrings. Either take a look at any Scanpy or Numpy function or [here](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
+We use the numpydoc style for writing docstrings.
+Either take a look at any Scanpy or Numpy function or
+[here](http://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_numpy.html).
 
 The `Params` abbreviation is a legit replacement for `Parameters`.
 
-The `Returns` section deserves special attention: you can either use the standard numpydoc way of populating it
-```
+The `Returns` section deserves special attention:
+While you can either use the standard numpydoc way of populating it,
+you can also just write any prose:
+
+```rst
 Returns
 -------
 type of return value 1
     description of return value 1
+
 type of return value 2
     description of return value 2
 ```
-or you can write plain RST-formatted prose, for instance from [`pp.normalize_total`](https://scanpy.readthedocs.io/en/latest/api/scanpy.pp.normalize_total.html)
-```
+
+or like [`pp.normalize_total`](https://scanpy.readthedocs.io/en/latest/api/scanpy.pp.normalize_total.html)
+
+```rst
 Returns
 -------
 Returns dictionary with normalized copies of `adata.X` and `adata.layers`
 or updates `adata` with normalized version of the original
 `adata.X` and `adata.layers`, depending on `inplace`.
 ```
-or from [`tl.leiden`](https://scanpy.readthedocs.io/en/latest/api/scanpy.tl.leiden.html)
-```
+
+Many functions also just modify parts of the passed AnnData object,
+like e.g. [`tl.leiden`](https://scanpy.readthedocs.io/en/latest/api/scanpy.tl.leiden.html)
+
+```rst
 Returns
 -------
-* `adata.obs[key_added]`: Array of dim (number of samples) that stores the subgroup id (`'0'`, `'1'`, ...) for each cell.
-* `adata.uns['leiden']['params']`: A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
+`adata.obs[key_added]`
+    Array of dim (number of samples) that stores the subgroup id (`'0'`, `'1'`, ...) for each cell.
+
+`adata.uns['leiden']['params']`
+    A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
 ```
-Whether a section is interpreted as `numpydoc` or prose depends on whether the second line of the section is indented or not.
 
 
 ### Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ Either take a look at any Scanpy or Numpy function or
 The `Params` abbreviation is a legit replacement for `Parameters`.
 
 The `Returns` section deserves special attention:
-While you can either use the standard numpydoc way of populating it,
+You can either use the standard numpydoc way of populating it,
 e.g. as in [`pp.calculate_qc_metrics`](https://scanpy.readthedocs.io/en/latest/api/scanpy.pp.calculate_qc_metrics.html)
 
 ```rst

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -33,12 +33,7 @@
 }
 
 .rst-content dl:not(.docutils) dl dt .classifier::before {
-	content: ' : ';
-}
-
-/* No narrow parameter lists for plot functions with images */
-.rst-content .docutils.field-list {
-    clear: right;
+    content: ' : ';
 }
 
 .rst-content tt.literal, .rst-content tt.literal, .rst-content code.literal {

--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -32,6 +32,10 @@
     font-size: 111.11%;
 }
 
+.rst-content dl:not(.docutils) dl dt .classifier::before {
+	content: ' : ';
+}
+
 /* No narrow parameter lists for plot functions with images */
 .rst-content .docutils.field-list {
     clear: right;

--- a/docs/_templates/autosummary/base.rst
+++ b/docs/_templates/autosummary/base.rst
@@ -1,7 +1,5 @@
 :github_url: {{ fullname | github_url }}
 
-{{ fullname | api_image }}
-
 {% extends "!autosummary/base.rst" %}
 
 .. http://www.sphinx-doc.org/en/stable/ext/autosummary.html#customizing-templates

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -138,75 +138,16 @@ DEFAULT_FILTERS['api_image'] = api_image
 
 # -- Test for new scanpydoc functionality --------------------------------------
 
-from itertools import repeat, chain
+
 from sphinx.ext.napoleon import NumpyDocstring
 
-# allow "prose" sections...
-def _consume_returns_section(self):
-    # type: () -> List[Tuple[unicode, unicode, List[unicode]]]
-    # this is the full original function
-    fields = self._consume_fields(prefer_type=True)
-    # Let us postprocess the output of this function.
-    # 
-    # fields with empty descriptions are prose fields, the "actual descriptions"
-    # are stored in the types, hence:
-    #
-    # concat fields with empty descriptions
-    #
-    new_fields = []
-    concat_with_old = False
-    for field in fields:
-        name, type, descr = field
-        if (not descr  # empty description (empty list)
-            or len(descr) == 1 and descr[0] == ''):  # empty description (empty string)
-            new_descr = ''
-            if name != '':
-                new_descr = name + ': '
-            new_descr += type + '\n'
-            # deal with escaped *
-            new_descr = new_descr.replace('\* ', '* ')
-            if concat_with_old:
-                # concat to the description section
-                new_fields[-1][2].append(new_descr)
-            else:
-                new_fields.append(('', '', [new_descr]))
-                concat_with_old = True
-        else:
-            new_fields.append(field)
-            concat_with_old = False
-    return new_fields
 
-
-# This is essentially entirely copied, the only change here is removing the bullets.
-def _parse_returns_section(self, section):
-    # type: (unicode) -> List[unicode]
-    fields = self._consume_returns_section()
-    multi = len(fields) > 1
-    if multi:
-        use_rtype = False
-    else:
-        use_rtype = self._config.napoleon_use_rtype
-
-    lines = []  # type: List[unicode]
-    for _name, _type, _desc in fields:
-        if use_rtype:
-            field = self._format_field(_name, '', _desc)
-        else:
-            field = self._format_field(_name, _type, _desc)
-
-        if multi:
-            if lines:
-                lines.extend(self._format_block('          ', field))
-            else:
-                lines.extend(self._format_block(':returns: ', field))
-        else:
-            lines.extend(self._format_block(':returns: ', field))
-            if _type and use_rtype:
-                lines.extend([':rtype: %s' % _type, ''])
+def scanpy_parse_returns_section(self, section):
+    lines_raw = self._dedent(self._consume_to_next_section())
+    lines = self._format_block(':returns: ', lines_raw)
     if lines and lines[-1]:
         lines.append('')
     return lines
 
 
-NumpyDocstring._consume_returns_section = _consume_returns_section
-NumpyDocstring._parse_returns_section = _parse_returns_section
+NumpyDocstring._parse_returns_section = scanpy_parse_returns_section

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,9 +1,6 @@
 import sys
-import logging
 from pathlib import Path
 from datetime import datetime
-
-from jinja2.defaults import DEFAULT_FILTERS
 
 import matplotlib  # noqa
 # Don’t use tkinter agg when importing scanpy → … → matplotlib
@@ -12,9 +9,6 @@ matplotlib.use('agg')
 HERE = Path(__file__).parent
 sys.path.insert(0, str(HERE.parent))
 import scanpy  # noqa
-
-
-logger = logging.getLogger(__name__)
 
 
 # -- General configuration ------------------------------------------------
@@ -101,6 +95,7 @@ html_logo = '_static/img/Scanpy_Logo_RGB.png'
 
 def setup(app):
     app.add_stylesheet('css/custom.css')
+    app.connect('autodoc-process-docstring', insert_function_images)
 
 
 # -- Options for other output formats ------------------------------------------
@@ -122,18 +117,11 @@ texinfo_documents = [
 # -- Images for plot functions -------------------------------------------------
 
 
-def api_image(qualname: str) -> str:
-    # I’d like to make this a contextfilter, but the jinja context doesn’t contain the path,
-    # so no chance to not hardcode “api/” here.
-    path = Path(__file__).parent / 'api' / f'{qualname}.png'
-    print(path, path.is_file())
-    return f'.. image:: {path.name}\n   :width: 200\n   :align: right' if path.is_file() else ''
-
-
-# html_context doesn’t apply to autosummary templates ☹
-# and there’s no way to insert filters into those templates
-# so we have to modify the default filters
-DEFAULT_FILTERS['api_image'] = api_image
+def insert_function_images(app, what, name, obj, options, lines):
+    path = Path(__file__).parent / 'api' / f'{name}.png'
+    if what != 'function' or not path.is_file(): return
+    lines[0:0] = [f'.. image:: {path.name}', '   :width: 200', '   :align: right', '']
+    print(*lines, sep='\n')
 
 
 # -- Test for new scanpydoc functionality --------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ def process_return(lines):
         m = re.fullmatch(r'(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)', line)
         if m:
             # Once this is in scanpydoc, we can use the fancy hover stuff
-            yield f'**{m["param"]}** \\: :class:`{m["type"]}`'
+            yield f'**{m["param"]}** \\: :class:`~{m["type"]}`'
         else:
             yield line
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,7 +148,7 @@ def process_return(lines):
         m = re.fullmatch(r'(?P<param>\w+)\s+:\s+(?P<type>[\w.]+)', line)
         if m:
             # Once this is in scanpydoc, we can use the fancy hover stuff
-            yield f'**{m["param"]}** \\: :class:`~{m["type"]}`'
+            yield f'**{m["param"]}** : :class:`~{m["type"]}`'
         else:
             yield line
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,9 +1,8 @@
 # use highlighting until the merge of https://github.com/rtfd/readthedocs.org/pull/4096
 sphinx_rtd_theme>=0.3.1
 # sphinx-autodoc-typehints needs at least sphinx 1.8
-# we fiddled quite a lot with the return section in the napoleon extension, let's be safe
-# and lock this to 1.8.3
-sphinx==1.8.3
+# Sphinx 2 has nicer looking sections
+sphinx>=2.0.1
 sphinx-autodoc-typehints
 scanpydoc>=0.3.2
 # same as ../requires.txt, but omitting the c++ packages

--- a/scanpy/datasets/__init__.py
+++ b/scanpy/datasets/__init__.py
@@ -4,13 +4,15 @@
 import os
 import numpy as np
 import pandas as pd
+from anndata import AnnData
+
 from .. import logging as logg
 from .._settings import settings
 import scanpy as sc
 from ._ebi_expression_atlas import ebi_expression_atlas
 
 
-def blobs(n_variables=11, n_centers=5, cluster_std=1.0, n_observations=640):
+def blobs(n_variables=11, n_centers=5, cluster_std=1.0, n_observations=640) -> AnnData:
     """Gaussian Blobs.
 
     Parameters
@@ -27,9 +29,8 @@ def blobs(n_variables=11, n_centers=5, cluster_std=1.0, n_observations=640):
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix containing a observation annotation 'blobs' that
-        indicates cluster identity.
+    Annotated data matrix containing a observation annotation 'blobs' that
+    indicates cluster identity.
     """
     import sklearn.datasets
     X, y = sklearn.datasets.make_blobs(n_samples=n_observations,
@@ -37,10 +38,10 @@ def blobs(n_variables=11, n_centers=5, cluster_std=1.0, n_observations=640):
                                        centers=n_centers,
                                        cluster_std=cluster_std,
                                        random_state=0)
-    return sc.AnnData(X, obs={'blobs': y.astype(str)})
+    return AnnData(X, obs={'blobs': y.astype(str)})
 
 
-def burczynski06():
+def burczynski06() -> AnnData:
     """Bulk data with conditions ulcerative colitis (UC) and Crohn's disease (CD).
 
     The study assesses transcriptional profiles in peripheral blood mononuclear
@@ -60,7 +61,7 @@ def burczynski06():
     return adata
 
 
-def krumsiek11():
+def krumsiek11() -> AnnData:
     """Simulated myeloid progenitors [Krumsiek11]_.
 
     The literature-curated boolean network from [Krumsiek11]_ was used to
@@ -73,8 +74,7 @@ def krumsiek11():
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
     filename = os.path.dirname(__file__) + '/krumsiek11.txt'
     verbosity_save = sc.settings.verbosity
@@ -95,13 +95,12 @@ def krumsiek11():
     return adata
 
 
-def moignard15():
+def moignard15() -> AnnData:
     """Hematopoiesis in early mouse embryos [Moignard15]_.
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
     filename = settings.datasetdir / 'moignard15/nbt.3154-S3.xlsx'
     backup_url = 'http://www.nature.com/nbt/journal/v33/n3/extref/nbt.3154-S3.xlsx'
@@ -124,7 +123,7 @@ def moignard15():
     return adata
 
 
-def paul15():
+def paul15() -> AnnData:
     """Development of Myeloid Progenitors [Paul15]_.
 
     Non-logarithmized raw data.
@@ -135,8 +134,7 @@ def paul15():
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
     logg.warn('In Scanpy 0.*, this returned logarithmized data. '
               'Now it returns non-logarithmized data.')
@@ -151,7 +149,7 @@ def paul15():
         clusters = f['cluster.id'][()].flatten()
         infogenes_names = f['info.genes_strings'][()].astype(str)
     # each row has to correspond to a observation, therefore transpose
-    adata = sc.AnnData(X.transpose())
+    adata = AnnData(X.transpose())
     adata.var_names = gene_names
     adata.row_names = cell_names
     # names reflecting the cell type identifications from the paper
@@ -176,7 +174,7 @@ def paul15():
     return adata
 
 
-def toggleswitch():
+def toggleswitch() -> AnnData:
     """Simulated toggleswitch.
 
     Data obtained simulating a simple toggleswitch `Gardner *et al.*, Nature
@@ -186,8 +184,7 @@ def toggleswitch():
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
     filename = os.path.dirname(__file__) + '/toggleswitch.txt'
     adata = sc.read(filename, first_column_names=True)
@@ -195,7 +192,7 @@ def toggleswitch():
     return adata
 
 
-def pbmc68k_reduced():
+def pbmc68k_reduced() -> AnnData:
     """Subsampled and processed 68k PBMCs.
 
     10x PBMC 68k dataset from
@@ -209,15 +206,14 @@ def pbmc68k_reduced():
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
 
     filename = os.path.dirname(__file__) + '/10x_pbmc68k_reduced.h5ad'
     return sc.read(filename)
 
 
-def pbmc3k():
+def pbmc3k() -> AnnData:
     """3k PBMCs from 10x Genomics.
 
     The data consists in 3k PBMCs from a Healthy Donor and is freely available
@@ -225,30 +221,29 @@ def pbmc3k():
     <http://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz>`__
     from this `webpage
     <https://support.10xgenomics.com/single-cell-gene-expression/datasets/1.1.0/pbmc3k>`__).
-    
-    The exact same data is also used in Seurat's 
+
+    The exact same data is also used in Seurat's
     `basic clustering tutorial <https://satijalab.org/seurat/pbmc3k_tutorial.html>`__.
 
     .. note::
 
         This downloads 5.9 MB of data upon the first call of the function and stores it in `./data/pbmc3k_raw.h5ad`.
-        
-    The following code was run to produce the file.    
-    
+
+    The following code was run to produce the file.
+
     .. code:: python
-    
+
         adata = sc.read_10x_mtx(
         './data/filtered_gene_bc_matrices/hg19/',  # the directory with the `.mtx` file
         var_names='gene_symbols',                  # use gene symbols for the variable names (variables-axis index)
         cache=True)                                # write a cache file for faster subsequent reading
-       
+
         adata.var_names_make_unique()  # this is unnecessary if using 'gene_ids'
-        adata.write('write/pbmc3k_raw.h5ad', compression='gzip')    
+        adata.write('write/pbmc3k_raw.h5ad', compression='gzip')
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
     """
     adata = sc.read(settings.datasetdir / 'pbmc3k_raw.h5ad', backup_url='http://falexwolf.de/data/pbmc3k_raw.h5ad')
     return adata

--- a/scanpy/external/_tools/_palantir.py
+++ b/scanpy/external/_tools/_palantir.py
@@ -1,10 +1,11 @@
 """Run Diffusion maps using the adaptive anisotropic kernel
 """
 
+from anndata import AnnData
 from scanpy import logging as logg
 
 
-def palantir(adata):
+def palantir(adata: AnnData):
     """
     Run Diffusion maps using the adaptive anisotropic kernel [Setty18]_.
 
@@ -21,28 +22,33 @@ def palantir(adata):
 
     Parameters
     ----------
-    adata : :class:`~anndata.AnnData`
+    adata
         An AnnData object, or Dataframe of cells X genes.
 
     Returns
     -------
+    `.uns['palantir_norm_data']`
+        A `data_df` copy of adata if normalized
 
-    `.uns['palantir_norm_data']` which is a `data_df` copy of adata if normalized
+    `pca_results`
+        PCA projections and explained variance ratio of adata:
+        - `.uns['palantir_pca_results']['pca_projections']`
+        - `.uns['palantir_pca_results']['variance_ratio']`
 
-    `pca_results` PCA projections and explained variance ratio of adata:
-    - `.uns['palantir_pca_results']['pca_projections']`
-    - `.uns['palantir_pca_results']['variance_ratio']`
+    `dm_res`
+        Diffusion components, corresponding eigen values and diffusion operator:
+        - `.uns['palantir_diff_maps']['EigenVectors']`
+        - `.uns['palantir_diff_maps']['EigenValues']`
+        - `.uns['palantir_diff_maps']['T']`
 
-    `dm_res` Diffusion components, corresponding eigen values and diffusion operator:
-    - `.uns['palantir_diff_maps']['EigenVectors']`
-    - `.uns['palantir_diff_maps']['EigenValues']`
-    - `.uns['palantir_diff_maps']['T']`
+    `.uns['palantir_ms_data']`
+        The `ms_data` - Multi scale data matrix
 
-    `.uns['palantir_ms_data']` which is the `ms_data` - Multi scale data matrix
+    `.uns['palantir_tsne']` : `tsne`
+        tSNE on diffusion maps
 
-    `.uns['palantir_tsne']` which is `tsne` - tSNE on diffusion maps
-
-    `.uns['palantir_imp_df']` which is `imp_df` - Imputed data matrix (MAGIC imputation)
+    `.uns['palantir_imp_df']` : `imp_df`
+        Imputed data matrix (MAGIC imputation)
 
     Example
     -------

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -74,10 +74,11 @@ def neighbors(
     Returns
     -------
     Depending on `copy`, updates or returns `adata` with the following:
-    connectivities : sparse matrix (`.uns['neighbors']`, dtype `float32`)
+
+    **connectivities** : sparse matrix (`.uns['neighbors']`, dtype `float32`)
         Weighted adjacency matrix of the neighborhood graph of data
         points. Weights should be interpreted as connectivities.
-    distances : sparse matrix (`.uns['neighbors']`, dtype `float32`)
+    **distances** : sparse matrix (`.uns['neighbors']`, dtype `float32`)
         Instead of decaying weights, this stores distances for each pair of
         neighbors.
     """
@@ -170,7 +171,7 @@ def compute_neighbors_umap(
 
     Returns
     -------
-    knn_indices, knn_dists : np.arrays of shape (n_observations, n_neighbors)
+    **knn_indices**, **knn_dists** : np.arrays of shape (n_observations, n_neighbors)
     """
     from .umap import sparse
     from .umap.umap_ import rptree_leaf_array, make_nn_descent
@@ -786,9 +787,10 @@ class Neighbors:
         Returns
         -------
         Writes the following attributes.
-        eigen_values : np.ndarray
+
+        eigen_values : numpy.ndarray
             Eigenvalues of transition matrix.
-        eigen_basis : np.ndarray
+        eigen_basis : numpy.ndarray
              Matrix of eigenvectors (stored in columns).  `.eigen_basis` is
              projection of data matrix on right eigenvectors, that is, the
              projection on the diffusion components.  these are simply the

--- a/scanpy/neighbors/umap/sparse.py
+++ b/scanpy/neighbors/umap/sparse.py
@@ -176,11 +176,11 @@ def sparse_random_projection_cosine_split(inds,
 
     Returns
     -------
-    indices_left: array
+    indices_left : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
 
-    indices_right: array
+    indices_right : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
     """
@@ -298,11 +298,11 @@ def sparse_random_projection_split(inds,
 
     Returns
     -------
-    indices_left: array
+    indices_left : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
 
-    indices_right: array
+    indices_right : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
     """
@@ -585,7 +585,7 @@ def sparse_bray_curtis(ind1, data1, ind2, data2):
 def sparse_jaccard(ind1, data1, ind2, data2):
     num_non_zero = arr_union(ind1, ind2).shape[0]
     num_equal = arr_intersect(ind1, ind2).shape[0]
-    
+
     if num_non_zero == 0:
         return 0.0
     else:

--- a/scanpy/neighbors/umap/umap_.py
+++ b/scanpy/neighbors/umap/umap_.py
@@ -64,11 +64,11 @@ def random_projection_cosine_split(data, indices, rng_state):
 
     Returns
     -------
-    indices_left: array
+    indices_left : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
 
-    indices_right: array
+    indices_right : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
     """
@@ -84,10 +84,10 @@ def random_projection_cosine_split(data, indices, rng_state):
 
     left_norm = norm(data[left])
     right_norm = norm(data[right])
-    
+
     if left_norm == 0.0:
         left_norm = 1.0
-        
+
     if right_norm == 0.0:
         right_norm = 1.0
 
@@ -102,7 +102,7 @@ def random_projection_cosine_split(data, indices, rng_state):
     hyperplane_norm = norm(hyperplane_vector)
     if hyperplane_norm == 0.0:
         hyperplane_norm = 1.0
-        
+
     for d in range(dim):
         hyperplane_vector[d] = hyperplane_vector[d] / hyperplane_norm
 
@@ -172,11 +172,11 @@ def random_projection_split(data, indices, rng_state):
 
     Returns
     -------
-    indices_left: array
+    indices_left : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
 
-    indices_right: array
+    indices_right : numpy.ndarray
         The elements of ``indices`` that fall on the "left" side of the
         random hyperplane.
     """
@@ -276,7 +276,7 @@ def make_tree(data, indices, rng_state, leaf_size=30, angular=False):
 
     Returns
     -------
-    node: RandomProjectionTreeNode
+    node : RandomProjectionTreeNode
         A random projection tree node which links to its child nodes. This
         provides the full tree below the returned node.
     """
@@ -343,7 +343,7 @@ def get_leaves(tree):
 
     Returns
     -------
-    leaves: list
+    leaves : list
         A list of arrays of indices of points in each leaf node.
     """
     if tree.is_leaf:
@@ -381,7 +381,7 @@ def rptree_leaf_array(data, n_neighbors, rng_state, n_trees=10, angular=False):
 
     Returns
     -------
-    leaf_array: array of shape (n_leaves, max(10, n_neighbors))
+    leaf_array : :class:`~numpy.ndarray` of shape (n_leaves, max(10, n_neighbors))
         Each row of leaf array is a list of indices found in a given leaf.
         Since not all leaves are the same size the arrays are padded out with -1
         to ensure we can return a single ndarray.
@@ -528,10 +528,10 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0,
 
     Returns
     -------
-    knn_dist: array of shape (n_samples,)
+    knn_dist: :class:`numpy.ndarray` of shape (n_samples,)
         The distance to kth nearest neighbor, as suitably approximated.
 
-    nn_dist: array of shape (n_samples,)
+    nn_dist: :class:`numpy.ndarray` of shape (n_samples,)
         The distance to the 1st nearest neighbor for each point.
     """
     target = np.log2(k) * bandwidth
@@ -598,11 +598,18 @@ def smooth_knn_dist(distances, k, n_iter=64, local_connectivity=1.0,
 
 
 # @numba.jit(parallel=True)
-def fuzzy_simplicial_set(X, n_neighbors, random_state,
-                         metric, metric_kwds={}, angular=False,
-                         set_op_mix_ratio=1.0,
-                         local_connectivity=1.0, bandwidth=1.0,
-                         verbose=False):
+def fuzzy_simplicial_set(
+    X,
+    n_neighbors,
+    random_state,
+    metric,
+    metric_kwds={},
+    angular=False,
+    set_op_mix_ratio=1.0,
+    local_connectivity=1.0,
+    bandwidth=1.0,
+    verbose=False,
+) -> coo_matrix:
     """Given a set of data X, a neighborhood size, and a measure of distance
     compute the fuzzy simplicial set (here represented as a fuzzy graph in
     the form of a sparse matrix) associated to the data. This is done by
@@ -686,10 +693,9 @@ def fuzzy_simplicial_set(X, n_neighbors, random_state,
 
     Returns
     -------
-    fuzzy_simplicial_set: coo_matrix
-        A fuzzy simplicial set represented as a sparse matrix. The (i,
-        j) entry of the matrix represents the membership strength of the
-        1-simplex between the ith and jth sample points.
+    A fuzzy simplicial set represented as a sparse matrix. The (i,
+    j) entry of the matrix represents the membership strength of the
+    1-simplex between the ith and jth sample points.
     """
 
     rows = np.zeros((X.shape[0] * n_neighbors), dtype=np.int64)
@@ -841,8 +847,8 @@ def spectral_layout(graph, dim, random_state):
 
     Returns
     -------
-    embedding: array of shape (n_vertices, dim)
-        The spectral embedding of the graph.
+    embedding : numpy.ndarray
+        The spectral embedding of the graph. Of shape ``(n_vertices, dim)``
     """
     n_samples = graph.shape[0]
     n_components, labels = scipy.sparse.csgraph.connected_components(graph)
@@ -935,10 +941,21 @@ def rdist(x, y):
 
 
 @numba.njit()
-def optimize_layout(embedding, positive_head, positive_tail,
-                    n_epochs, n_vertices, epochs_per_sample,
-                    a, b, rng_state, gamma=1.0, initial_alpha=1.0,
-                    negative_sample_rate=5.0, verbose=False):
+def optimize_layout(
+    embedding,
+    positive_head,
+    positive_tail,
+    n_epochs,
+    n_vertices,
+    epochs_per_sample,
+    a,
+    b,
+    rng_state,
+    gamma=1.0,
+    initial_alpha=1.0,
+    negative_sample_rate=5.0,
+    verbose=False,
+) -> np.ndarray:
     """Improve an embedding using stochastic gradient descent to minimize the
     fuzzy set cross entropy between the 1-skeletons of the high dimensional
     and low dimensional fuzzy simplicial sets. In practice this is done by
@@ -989,8 +1006,7 @@ def optimize_layout(embedding, positive_head, positive_tail,
 
     Returns
     -------
-    embedding: array of shape (n_samples, n_components)
-        The optimized embedding.
+    The optimized embedding. Of shape ``(n_samples, n_components)``
     """
 
     dim = embedding.shape[1]
@@ -1054,10 +1070,17 @@ def optimize_layout(embedding, positive_head, positive_tail,
     return embedding
 
 
-def simplicial_set_embedding(graph, n_components,
-                             initial_alpha, a, b,
-                             gamma, negative_sample_rate, n_epochs,
-                             init, random_state, verbose):
+def simplicial_set_embedding(
+    graph,
+    n_components,
+    initial_alpha, a, b,
+    gamma,
+    negative_sample_rate,
+    n_epochs,
+    init,
+    random_state,
+    verbose,
+) -> np.ndarray:
     """Perform a fuzzy simplicial set embedding, using a specified
     initialisation method and then minimizing the fuzzy set cross entropy
     between the 1-skeletons of the high and low dimensional fuzzy simplicial
@@ -1102,9 +1125,8 @@ def simplicial_set_embedding(graph, n_components,
 
     Returns
     -------
-    embedding: array of shape (n_samples, n_components)
-        The optimized of ``graph`` into an ``n_components`` dimensional
-        euclidean space.
+    The optimized of ``graph`` into an ``n_components`` dimensional
+    euclidean space. Of shape `` (n_samples, n_components)``
     """
     graph = graph.tocoo()
     graph.sum_duplicates()
@@ -1235,9 +1257,9 @@ class UMAP(BaseEstimator):
         appropriately; this will hopefully be fixed in the future.
 
     negative_sample_rate: int (optional, default 5)
-        The number of negative edge/1-simplex samples to use per positive 
+        The number of negative edge/1-simplex samples to use per positive
         edge/1-simplex sample in optimizing the low dimensional embedding.
-        
+
     alpha: float (optional, default 1.0)
         The initial learning rate for the embedding optimization.
 
@@ -1461,7 +1483,7 @@ class UMAP(BaseEstimator):
 
         return self
 
-    def fit_transform(self, X, y=None):
+    def fit_transform(self, X, y=None) -> np.ndarray:
         """Fit X into an embedded space and return that transformed
         output.
 
@@ -1473,8 +1495,8 @@ class UMAP(BaseEstimator):
 
         Returns
         -------
-        X_new : array, shape (n_samples, n_components)
-            Embedding of the training data in low-dimensional space.
+        Embedding of the training data in low-dimensional space.
+        Of shape ``(n_samples, n_components)``
         """
         self.fit(X)
         return self.embedding_

--- a/scanpy/neighbors/umap/umap_.py
+++ b/scanpy/neighbors/umap/umap_.py
@@ -609,7 +609,7 @@ def fuzzy_simplicial_set(
     local_connectivity=1.0,
     bandwidth=1.0,
     verbose=False,
-) -> coo_matrix:
+) -> scipy.sparse.coo_matrix:
     """Given a set of data X, a neighborhood size, and a measure of distance
     compute the fuzzy simplicial set (here represented as a fuzzy graph in
     the form of a sparse matrix) associated to the data. This is done by

--- a/scanpy/neighbors/umap/utils.py
+++ b/scanpy/neighbors/umap/utils.py
@@ -65,7 +65,7 @@ def norm(vec):
 
 
 @numba.njit()
-def rejection_sample(n_samples, pool_size, rng_state):
+def rejection_sample(n_samples, pool_size, rng_state) -> np.ndarray:
     """Generate n_samples many integers from 0 to pool_size such that no
     integer is selected twice. The duplication constraint is achieved via
     rejection sampling.
@@ -83,8 +83,8 @@ def rejection_sample(n_samples, pool_size, rng_state):
 
     Returns
     -------
-    sample: array of shape(n_samples,)
-        The ``n_samples`` randomly selected elements from the pool.
+    The ``n_samples`` randomly selected elements from the pool.
+    Of shape ``(n_samples,)``
     """
     result = np.empty(n_samples, dtype=np.int64)
     for i in range(n_samples):
@@ -101,7 +101,7 @@ def rejection_sample(n_samples, pool_size, rng_state):
 
 
 @numba.njit('f8[:, :, :](i8,i8)')
-def make_heap(n_points, size):
+def make_heap(n_points, size) -> np.ndarray:
     """Constructor for the numba enabled heap objects. The heaps are used
     for approximate nearest neighbor search, maintaining a list of potential
     neighbors sorted by their distance. We also flag if potential neighbors
@@ -121,7 +121,7 @@ def make_heap(n_points, size):
 
     Returns
     -------
-    heap: An ndarray suitable for passing to other numba enabled heap functions.
+    An ndarray suitable for passing to other numba enabled heap functions.
     """
     result = np.zeros((3, n_points, size))
     result[0] = -1
@@ -132,7 +132,7 @@ def make_heap(n_points, size):
 
 
 @numba.jit('i8(f8[:,:,:],i8,f8,i8,i8)')
-def heap_push(heap, row, weight, index, flag):
+def heap_push(heap, row, weight, index, flag) -> int:
     """Push a new element onto the heap. The heap stores potential neighbors
     for each data point. The ``row`` parameter determines which data point we
     are addressing, the ``weight`` determines the distance (for heap sorting),
@@ -158,7 +158,7 @@ def heap_push(heap, row, weight, index, flag):
 
     Returns
     -------
-    success: The number of new elements successfully pushed into the heap.
+    The number of new elements successfully pushed into the heap.
     """
     indices = heap[0, row]
     weights = heap[1, row]
@@ -214,25 +214,28 @@ def heap_push(heap, row, weight, index, flag):
     return 1
 
 @numba.njit()
-def deheap_sort(heap):
+def deheap_sort(heap) -> Tuple[np.ndarray, np.ndarray]:
     """Given an array of heaps (of indices and weights), unpack the heap
     out to give and array of sorted lists of indices and weights by increasing
     weight. This is effectively just the second half of heap sort (the first
     half not being required since we already have the data in a heap).
-    
+
     Parameters
     ----------
     heap : array of shape (3, n_samples, n_neighbors)
         The heap to turn into sorted lists.
-        
+
     Returns
     -------
-    indices, weights: arrays of shape (n_samples, n_neighbors)
-        The indices and weights sorted by increasing weight.
+    indices : numpy.ndarray
+        The indices sorted by increasing weight.
+        Of shape ``(n_samples, n_neighbors)``
+    weights : numpy.ndarray
+        Array of weights. Of shape ``(n_samples, n_neighbors)``
     """
     indices = heap[0]
     weights = heap[1]
-    
+
     for i in range(indices.shape[0]):
         heap_end = indices.shape[1] - 1
         while heap_end >= 0:
@@ -241,18 +244,18 @@ def deheap_sort(heap):
             weights[i, 0], weights[i, heap_end] = \
                 weights[i, heap_end], weights[i, 0]
             heap_end -= 1
-            
+
             root = 0
             while root * 2 + 1 < heap_end:
                 left_child = root * 2 + 1
                 right_child = left_child + 1
                 swap = root
-                
+
                 if weights[i, swap] < weights[i, left_child]:
                     swap = left_child
                 if right_child < heap_end and weights[i, swap] < weights[i, right_child]:
                     swap = right_child
-                    
+
                 if swap == root:
                     break
                 else:
@@ -260,7 +263,7 @@ def deheap_sort(heap):
                         weights[i, swap], weights[i, root]
                     indices[i, root], indices[i, swap] = \
                         indices[i, swap], indices[i, root]
-                        
+
                     root = swap
     return indices.astype(np.int64), weights
 
@@ -291,7 +294,7 @@ def build_candidates(current_graph, n_vertices, n_neighbors, max_candidates,
 
     Returns
     -------
-    candidate_neighbors: A heap with an array of (randomly sorted) candidate
+    A heap with an array of (randomly sorted) candidate
     neighbors for each vertex in the graph.
     """
     candidate_neighbors = make_heap(n_vertices, max_candidates)

--- a/scanpy/neighbors/umap/utils.py
+++ b/scanpy/neighbors/umap/utils.py
@@ -2,6 +2,8 @@
 #
 # License: BSD 3 clause
 
+from typing import Tuple
+
 import numpy as np
 import numba
 

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -608,7 +608,7 @@ def violin(adata, keys, groupby=None, log=False, use_raw=None, stripplot=True, j
 
     Returns
     -------
-    A `matplotlib.Axes` object if `ax` is `None` else `None`.
+    A :class:`~matplotlib.axes.Axes` object if `ax` is `None` else `None`.
     """
     sanitize_anndata(adata)
     if use_raw is None and adata.raw is not None: use_raw = True
@@ -809,7 +809,7 @@ def stacked_violin(adata, var_names, groupby=None, log=False, use_raw=None, num_
 
     Returns
     -------
-    List of `matplotlib.Axes`
+    List of :class:`~matplotlib.axes.Axes`
 
     Examples
     -------
@@ -1088,7 +1088,7 @@ def heatmap(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
 
     Returns
     -------
-    List of `matplotlib.Axes`
+    List of :class:`~matplotlib.axes.Axes`
 
     Examples
     -------
@@ -1370,7 +1370,7 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
 
     Returns
     -------
-    List of `matplotlib.Axes`
+    List of :class:`~matplotlib.axes.Axes`
 
     Examples
     -------
@@ -1643,7 +1643,7 @@ def matrixplot(adata, var_names, groupby=None, use_raw=None, log=False, num_cate
 
     Returns
     -------
-    List of `matplotlib.Axes`
+    List of :class:`~matplotlib.axes.Axes`
 
     Examples
     --------
@@ -1843,7 +1843,7 @@ def tracksplot(adata, var_names, groupby, use_raw=None, log=False,
 
     Returns
     -------
-    A list of `matplotlib.Axes`.
+    A list of :class:`~matplotlib.axes.Axes`.
 
     Examples
     --------

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -83,7 +83,7 @@ def scatter(
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     if basis is not None:
         axs = _scatter_obs(

--- a/scanpy/plotting/_qc.py
+++ b/scanpy/plotting/_qc.py
@@ -45,7 +45,7 @@ def highest_expr_genes(
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis`.
+    If `show==False` a :class:`~matplotlib.axes.Axes`.
     """
     from scipy.sparse import issparse
 

--- a/scanpy/plotting/_qc.py
+++ b/scanpy/plotting/_qc.py
@@ -65,7 +65,7 @@ def highest_expr_genes(
 
     if not ax:
         # figsize is hardcoded to produce a tall image. To change the fig size,
-        # a matplotlib.Axes object needs to be passed.
+        # a matplotlib.axes.Axes object needs to be passed.
         height = (n_top * 0.2) + 1.5
         fig, ax = plt.subplots(figsize=(5, height))
     sns.boxplot(data=dat, orient='h', ax=ax, fliersize=1, **kwds)

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -343,7 +343,7 @@ def paga(
         grouping.
     cmap : color map
         The color map.
-    cax : `matplotlib.Axes`
+    cax : :class:`~matplotlib.axes.Axes`
         A matplotlib axes object for a potential colorbar.
     cb_kwds : colorbar keywords
         See `here
@@ -362,7 +362,7 @@ def paga(
     save : `bool` or `str`, optional (default: `None`)
         If `True` or a `str`, save the figure. A string is appended to the
         default filename. Infer the filetype if ending on \\{'.pdf', '.png', '.svg'\\}.
-    ax : `matplotlib.Axes`
+    ax : :class:`~matplotlib.axes.Axes`
         A matplotlib axes object.
 
     Returns
@@ -867,7 +867,7 @@ def paga_path(
     save : `bool` or `str`, optional (default: `None`)
         If `True` or a `str`, save the figure. A string is appended to the
         default filename. Infer the filetype if ending on \\{'.pdf', '.png', '.svg'\\}.
-    ax : `matplotlib.Axes`
+    ax : :class:`~matplotlib.axes.Axes`
          A matplotlib axes object.
 
     Returns

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -3,18 +3,19 @@ import numpy as np
 import pandas as pd
 import scipy
 import warnings
-from pandas.api.types import is_categorical_dtype
-import networkx as nx
-from matplotlib import pyplot as pl
-from matplotlib.colors import is_color_like
-from matplotlib import rcParams, ticker
 from collections import Iterable
+from typing import Optional, Union, List
+
+import networkx as nx
+from pandas.api.types import is_categorical_dtype
+from matplotlib import pyplot as pl, rcParams, ticker
+from matplotlib.axes import Axes
+from matplotlib.colors import is_color_like
 
 from .. import _utils as utils
-from ... import utils as sc_utils
-from ..._settings import settings
-from ... import logging as logg
 from .._utils import matrix
+from ... import utils as sc_utils, logging as logg
+from ..._settings import settings
 
 
 def paga_compare(
@@ -216,46 +217,47 @@ def _compute_pos(adjacency_solid, layout=None, random_state=0, init_pos=None, ad
 
 
 def paga(
-        adata,
-        threshold=None,
-        color=None,
-        layout=None,
-        layout_kwds={},
-        init_pos=None,
-        root=0,
-        labels=None,
-        single_component=False,
-        solid_edges='connectivities',
-        dashed_edges=None,
-        transitions=None,
-        fontsize=None,
-        fontweight='bold',
-        text_kwds={},
-        node_size_scale=1,
-        node_size_power=0.5,
-        edge_width_scale=1,
-        min_edge_width=None,
-        max_edge_width=None,
-        arrowsize=30,
-        title=None,
-        left_margin=0.01,
-        random_state=0,
-        pos=None,
-        normalize_to_color=False,
-        cmap=None,
-        cax=None,
-        colorbar=None,
-        cb_kwds={},
-        frameon=None,
-        add_pos=True,
-        export_to_gexf=False,
-        use_raw=True,
-        colors=None,   # backwards compat
-        groups=None,  # backwards compat
-        plot=True,
-        show=None,
-        save=None,
-        ax=None):
+    adata,
+    threshold=None,
+    color=None,
+    layout=None,
+    layout_kwds={},
+    init_pos=None,
+    root=0,
+    labels=None,
+    single_component=False,
+    solid_edges='connectivities',
+    dashed_edges=None,
+    transitions=None,
+    fontsize=None,
+    fontweight='bold',
+    text_kwds={},
+    node_size_scale=1,
+    node_size_power=0.5,
+    edge_width_scale=1,
+    min_edge_width=None,
+    max_edge_width=None,
+    arrowsize=30,
+    title=None,
+    left_margin=0.01,
+    random_state=0,
+    pos=None,
+    normalize_to_color=False,
+    cmap=None,
+    cax=None,
+    colorbar=None,
+    cb_kwds={},
+    frameon=None,
+    add_pos=True,
+    export_to_gexf=False,
+    use_raw=True,
+    colors=None,   # backwards compat
+    groups=None,  # backwards compat
+    plot=True,
+    show=None,
+    save=None,
+    ax=None,
+) -> Union[Axes, List[Axes], None]:
     """Plot the PAGA graph through thresholding low-connectivity edges.
 
     Compute a coarse-grained layout of the data. Reuse this by passing
@@ -365,9 +367,8 @@ def paga(
 
     Returns
     -------
-    `None`, `axs`
-        If `show==False`, one or more `matplotlib.Axis` objects.
-        Adds `'pos'` to `adata.uns['paga']` if `add_pos` is `True`.
+    If `show==False`, one or more :class:`~matplotlib.axes.Axes` objects.
+    Adds `'pos'` to `adata.uns['paga']` if `add_pos` is `True`.
 
     Notes
     -----
@@ -454,7 +455,7 @@ def paga(
 
         if len(colors) == 1 and not isinstance(axs, list):
             axs = [axs]
-        
+
         for icolor, c in enumerate(colors):
             if title[icolor] is not None:
                 axs[icolor].set_title(title[icolor])
@@ -791,32 +792,33 @@ def _paga_graph(
 
 
 def paga_path(
-        adata,
-        nodes,
-        keys,
-        use_raw=True,
-        annotations=['dpt_pseudotime'],
-        color_map=None,
-        color_maps_annotations={'dpt_pseudotime': 'Greys'},
-        palette_groups=None,
-        n_avg=1,
-        groups_key=None,
-        xlim=[None, None],
-        title=None,
-        left_margin=None,
-        ytick_fontsize=None,
-        title_fontsize=None,
-        show_node_names=True,
-        show_yticks=True,
-        show_colorbar=True,
-        legend_fontsize=None,
-        legend_fontweight=None,
-        normalize_to_zero_one=False,
-        as_heatmap=True,
-        return_data=False,
-        show=None,
-        save=None,
-        ax=None):
+    adata,
+    nodes,
+    keys,
+    use_raw=True,
+    annotations=['dpt_pseudotime'],
+    color_map=None,
+    color_maps_annotations={'dpt_pseudotime': 'Greys'},
+    palette_groups=None,
+    n_avg=1,
+    groups_key=None,
+    xlim=[None, None],
+    title=None,
+    left_margin=None,
+    ytick_fontsize=None,
+    title_fontsize=None,
+    show_node_names=True,
+    show_yticks=True,
+    show_colorbar=True,
+    legend_fontsize=None,
+    legend_fontweight=None,
+    normalize_to_zero_one=False,
+    as_heatmap=True,
+    return_data=False,
+    show=None,
+    save=None,
+    ax=None,
+) -> Optional[Axes]:
     """Gene expression and annotation changes along paths in the abstracted graph.
 
     Parameters
@@ -870,8 +872,8 @@ def paga_path(
 
     Returns
     -------
-    A `matplotlib.Axes`, if `ax` is `None`, else `None`. If `return_data`,
-    return the timeseries data in addition to an axes.
+    A :class:`~matplotlib.axes.Axes` object, if `ax` is `None`, else `None`.
+    If `return_data`, return the timeseries data in addition to an axes.
     """
     ax_was_none = ax is None
 

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -266,7 +266,7 @@ def _wraps_plot_scatter(wrapper):
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def umap(adata, **kwargs):
+def umap(adata, **kwargs) -> Union[Axes, List[Axes], None]:
     """\
     Scatter plot in UMAP basis.
 
@@ -279,14 +279,14 @@ def umap(adata, **kwargs):
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     return plot_scatter(adata, 'umap', **kwargs)
 
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def tsne(adata, **kwargs):
+def tsne(adata, **kwargs) -> Union[Axes, List[Axes], None]:
     """\
     Scatter plot in tSNE basis.
 
@@ -299,14 +299,14 @@ def tsne(adata, **kwargs):
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     return plot_scatter(adata, 'tsne', **kwargs)
 
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def phate(adata, **kwargs):
+def phate(adata, **kwargs) -> Union[List[Axes], None]:
     """\
     Scatter plot in PHATE basis.
 
@@ -319,7 +319,7 @@ def phate(adata, **kwargs):
 
     Returns
     -------
-    If `show==False`, a list of `matplotlib.Axis` objects. Every second element
+    If `show==False`, a list of :class:`~matplotlib.axes.Axes` objects. Every second element
     corresponds to the 'right margin' drawing area for color bars and legends.
 
     Examples
@@ -345,7 +345,7 @@ def phate(adata, **kwargs):
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def diffmap(adata, **kwargs):
+def diffmap(adata, **kwargs) -> Union[Axes, List[Axes], None]:
     """\
     Scatter plot in Diffusion Map basis.
 
@@ -357,14 +357,14 @@ def diffmap(adata, **kwargs):
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     return plot_scatter(adata, 'diffmap', **kwargs)
 
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, edges_arrows=doc_edges_arrows, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def draw_graph(adata, layout=None, **kwargs):
+def draw_graph(adata, layout=None, **kwargs) -> Union[Axes, List[Axes], None]:
     """\
     Scatter plot in graph-drawing basis.
 
@@ -381,7 +381,7 @@ def draw_graph(adata, layout=None, **kwargs):
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     if layout is None:
         layout = str(adata.uns['draw_graph']['params']['layout'])
@@ -395,7 +395,7 @@ def draw_graph(adata, layout=None, **kwargs):
 
 @_wraps_plot_scatter
 @doc_params(adata_color_etc=doc_adata_color_etc, scatter_bulk=doc_scatter_bulk, show_save_ax=doc_show_save_ax)
-def pca(adata, **kwargs):
+def pca(adata, **kwargs) -> Union[Axes, List[Axes], None]:
     """\
     Scatter plot in PCA coordinates.
 
@@ -407,7 +407,7 @@ def pca(adata, **kwargs):
 
     Returns
     -------
-    If `show==False` a `matplotlib.Axis` or a list of it.
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
     """
     return plot_scatter(adata, 'pca', **kwargs)
 
@@ -415,7 +415,7 @@ def pca(adata, **kwargs):
 # Helpers
 
 
-def _get_data_points(adata, basis, projection, components):
+def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndarray], List[Tuple[int, int]]]:
     """
     Returns the data points corresponding to the selected basis, projection and/or components.
 
@@ -425,10 +425,11 @@ def _get_data_points(adata, basis, projection, components):
 
     Returns
     -------
-    `tuple` of:
-        data_points : `list`. Each list is a numpy array containing the data points
-        components : `list` The cleaned list of components. Eg. [[0,1]] or [[0,1], [1,2]]
-                    for components = [1,2] and components=['1,2', '2,3'] respectively
+    data_points : list
+        Each entry is a numpy array containing the data points
+    components : list
+        The cleaned list of components. Eg. [(0,1)] or [(0,1), (1,2)]
+        for components = [1,2] and components=['1,2', '2,3'] respectively
     """
     n_dims = 2
     if projection == '3d':
@@ -453,19 +454,19 @@ def _get_data_points(adata, basis, projection, components):
 
         if isinstance(components, str):
             # eg: components='1,2'
-            components_list.append([int(x.strip()) - 1 + offset for x in components.split(',')])
+            components_list.append(tuple(int(x.strip()) - 1 + offset for x in components.split(',')))
 
         elif isinstance(components, abc.Sequence):
             if isinstance(components[0], int):
                 # components=[1,2]
-                components_list.append([int(x) - 1 + offset for x in components])
+                components_list.append(tuple(int(x) - 1 + offset for x in components]))
             else:
                 # in this case, the components are str
                 # eg: components=['1,2'] or components=['1,2', '2,3]
                 # More than one component can be given and is stored
                 # as a new item of components_list
                 for comp in components:
-                    components_list.append([int(x.strip()) - 1 + offset for x in comp.split(',')])
+                    components_list.append(tuple(int(x.strip()) - 1 + offset for x in comp.split(',')]))
 
         else:
             raise ValueError("Given components: '{}' are not valid. Please check. "
@@ -482,7 +483,7 @@ def _get_data_points(adata, basis, projection, components):
         if basis == 'diffmap':
             # remove the offset added in the case of diffmap, such that
             # plot_scatter can print the labels correctly.
-            components_list = [[number-1 for number in comp] for comp in components_list]
+            components_list = [tuple(number-1 for number in comp) for comp in components_list]
     else:
         data_points = [adata.obsm['X_' + basis][:, offset:offset+n_dims]]
         components_list = []
@@ -553,11 +554,14 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
 
     Parameters
     ----------
-    adata : annData object
-    value_to_plot : name of a valid categorical observation
-    palette : Palette should be either a valid `matplotlib.pyplot.colormaps()` string,
-              a list of colors (in a format that can be understood by matplotlib,
-              eg. RGB, RGBS, hex, or a cycler object with key='color'
+    adata
+        annData object
+    value_to_plot
+        name of a valid categorical observation
+    palette
+        Palette should be either a valid :func:`~matplotlib.pyplot.colormaps` string,
+        a list of colors (in a format that can be understood by matplotlib,
+        eg. RGB, RGBS, hex, or a cycler object with key='color'
 
     Returns
     -------

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -1,5 +1,5 @@
 from collections import abc
-from typing import Union, Optional, Sequence, Any, Mapping
+from typing import Union, Optional, Sequence, Any, Mapping, List, Tuple
 
 import numpy as np
 from anndata import AnnData

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -459,7 +459,7 @@ def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndar
         elif isinstance(components, abc.Sequence):
             if isinstance(components[0], int):
                 # components=[1,2]
-                components_list.append(tuple(int(x) - 1 + offset for x in components]))
+                components_list.append(tuple(int(x) - 1 + offset for x in components))
             else:
                 # in this case, the components are str
                 # eg: components=['1,2'] or components=['1,2', '2,3]

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -466,7 +466,7 @@ def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndar
                 # More than one component can be given and is stored
                 # as a new item of components_list
                 for comp in components:
-                    components_list.append(tuple(int(x.strip()) - 1 + offset for x in comp.split(',')]))
+                    components_list.append(tuple(int(x.strip()) - 1 + offset for x in comp.split(',')))
 
         else:
             raise ValueError("Given components: '{}' are not valid. Please check. "

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -1,12 +1,16 @@
 import os
+import warnings
+from typing import Union, List
+
 import numpy as np
 import networkx as nx
 from matplotlib import pyplot as pl
 from matplotlib import rcParams, ticker
+from matplotlib.axes import Axes
 from matplotlib.colors import is_color_like
 from matplotlib.figure import SubplotParams as sppars
 from cycler import Cycler, cycler
-import warnings
+
 from .. import logging as logg
 from .._settings import settings
 from . import palettes
@@ -432,23 +436,25 @@ def setup_axes(
     return axs, panel_pos, draw_region_width, figure_width
 
 
-def scatter_base(Y,
-                 colors='blue',
-                 sort_order=True,
-                 alpha=None,
-                 highlights=[],
-                 right_margin=None,
-                 left_margin=None,
-                 projection='2d',
-                 title=None,
-                 component_name='DC',
-                 component_indexnames=[1, 2, 3],
-                 axis_labels=None,
-                 colorbars=[False],
-                 sizes=[1],
-                 color_map='viridis',
-                 show_ticks=True,
-                 ax=None):
+def scatter_base(
+    Y,
+    colors='blue',
+    sort_order=True,
+    alpha=None,
+    highlights=[],
+    right_margin=None,
+    left_margin=None,
+    projection='2d',
+    title=None,
+    component_name='DC',
+    component_indexnames=[1, 2, 3],
+    axis_labels=None,
+    colorbars=[False],
+    sizes=[1],
+    color_map='viridis',
+    show_ticks=True,
+    ax=None,
+) -> Union[Axes, List[Axes]]:
     """Plot scatter plot of data.
 
     Parameters
@@ -459,9 +465,8 @@ def scatter_base(Y,
 
     Returns
     -------
-    axs : matplotlib.axis or list of matplotlib.axis
-        Depending on whether supplying a single array or a list of arrays,
-        return a single axis or a list of axes.
+    Depending on whether supplying a single array or a list of arrays,
+    return a single axis or a list of axes.
     """
     if isinstance(highlights, dict):
         highlights_indices = sorted(highlights)

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -1,5 +1,5 @@
 import sys
-from typing import List
+from typing import List, Tuple
 
 import numba
 import pandas as pd

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -1,4 +1,5 @@
 import sys
+from typing import List
 
 import numba
 import pandas as pd
@@ -9,7 +10,7 @@ from anndata import AnnData
 
 from .. import logging as logg
 
-def design_mat(model, batch_levels):
+def design_mat(model: pd.DataFrame, batch_levels: List[str]) -> pd.DataFrame:
     """
     Computes a simple design matrix.
 
@@ -18,15 +19,14 @@ def design_mat(model, batch_levels):
 
     Parameters
     --------
-    model : pd.DataFrame
+    model
         Contains the batch annotation
-    batch_levels : list
+    batch_levels
         Levels of the batch annotation
 
     Returns
     --------
-    design : pd.DataFrame
-        The design matrix for the regression problem
+    The design matrix for the regression problem
     """
     import patsy
 
@@ -47,7 +47,10 @@ def design_mat(model, batch_levels):
     return design
 
 
-def stand_data(model, data):
+def stand_data(
+    model: pd.DataFrame,
+    data: pd.DataFrame,
+) -> Tuple[pd.DataFrame, pd.DataFrame, np.ndarray, np.ndarray]:
     """
     Standardizes the data per gene.
 
@@ -55,20 +58,20 @@ def stand_data(model, data):
 
     Parameters
     --------
-    model : pd.DataFrame
+    model
         Contains the batch annotation
-    data : pd.DataFrame
+    data
         Contains the Data
 
     Returns
     --------
-    s_data : pd.DataFrame
+    s_data : pandas.DataFrame
         Standardized Data
-    design : pd.DataFrame
+    design : pandas.DataFrame
         Batch assignment as one-hot encodings
-    var_pooled : np.array
+    var_pooled : numpy.ndarray
         Pooled variance per gene
-    stand_mean : np.array
+    stand_mean : numpy.ndarray
         Gene-wise mean
     """
 
@@ -229,7 +232,7 @@ def combat(adata: AnnData, key: str = 'batch', inplace: bool = True):
 
 
 @numba.jit
-def _it_sol(s_data, g_hat, d_hat, g_bar, t2, a, b, conv=0.0001):
+def _it_sol(s_data, g_hat, d_hat, g_bar, t2, a, b, conv=0.0001) -> Tuple[float, float]:
     """
     Iteratively compute the conditional posterior means for gamma and delta.
 
@@ -253,9 +256,9 @@ def _it_sol(s_data, g_hat, d_hat, g_bar, t2, a, b, conv=0.0001):
 
     Returns:
     --------
-    gamma: float
+    gamma : float
         estimated value for gamma
-    delta: float
+    delta : float
         estimated value for delta
     """
 

--- a/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -30,7 +30,7 @@ def filter_genes_dispersion(data,
               merely annotate the genes, tools like `pp.pca` will
               detect the annotation
             * you can now call: `sc.pl.highly_variable_genes(adata)`
-            * `copy` is replaced by `inplace` 
+            * `copy` is replaced by `inplace`
 
     If trying out parameters, pass the data matrix instead of AnnData.
 
@@ -79,17 +79,17 @@ def filter_genes_dispersion(data,
 
     Returns
     -------
-    If an AnnData `adata` is passed, returns or updates `adata` depending on \
+    If an AnnData `adata` is passed, returns or updates `adata` depending on
     `copy`. It filters the `adata` and adds the annotations
 
-    means : adata.var
+    **means** : adata.var
         Means per gene. Logarithmized when `log` is `True`.
-    dispersions : adata.var
+    **dispersions** : adata.var
         Dispersions per gene. Logarithmized when `log` is `True`.
-    dispersions_norm : adata.var
+    **dispersions_norm** : adata.var
         Normalized dispersions per gene. Logarithmized when `log` is `True`.
 
-    If a data matrix `X` is passed, the annotation is returned as `np.recarray` \
+    If a data matrix `X` is passed, the annotation is returned as `np.recarray`
     with the same information stored in fields: `gene_subset`, `means`, `dispersions`, `dispersion_norm`.
     """
     if n_top_genes is not None and not all([

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -1,7 +1,10 @@
-from anndata import AnnData
+import warnings
+from typing import Optional
+
 import numpy as np
 import pandas as pd
-import warnings
+from anndata import AnnData
+
 from .. import logging as logg
 from ._distributed import materialize_as_ndarray
 from ._utils import _get_mean_var
@@ -16,7 +19,7 @@ def highly_variable_genes(
     flavor='seurat',
     subset=False,
     inplace=True
-):
+) -> Optional[np.recarray]:
     """Annotate highly variable genes [Satija15]_ [Zheng17]_.
 
     Expects logarithmized data.
@@ -65,14 +68,13 @@ def highly_variable_genes(
 
     Returns
     -------
-    :class:`~numpy.recarray`, `None`
-        Depending on `inplace` returns calculated metrics (:class:`~numpy.recarray`) or
-        updates `.var` with the following fields
+    Depending on `inplace` returns calculated metrics (:class:`~numpy.recarray`) or
+    updates `.var` with the following fields
 
-        * `highly_variable` - boolean indicator of highly-variable genes
-        * `means` - means per gene
-        * `dispersions` - dispersions per gene
-        * `dispersions_norm` - normalized dispersions per gene
+    * `highly_variable` - boolean indicator of highly-variable genes
+    * `means` - means per gene
+    * `dispersions` - dispersions per gene
+    * `dispersions_norm` - normalized dispersions per gene
 
     Notes
     -----

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -71,10 +71,14 @@ def highly_variable_genes(
     Depending on `inplace` returns calculated metrics (:class:`~numpy.recarray`) or
     updates `.var` with the following fields
 
-    * `highly_variable` - boolean indicator of highly-variable genes
-    * `means` - means per gene
-    * `dispersions` - dispersions per gene
-    * `dispersions_norm` - normalized dispersions per gene
+    highly_variable : bool
+        boolean indicator of highly-variable genes
+    **means**
+        means per gene
+    **dispersions**
+        dispersions per gene
+    **dispersions_norm**
+        normalized dispersions per gene
 
     Notes
     -----

--- a/scanpy/preprocessing/_mnn_correct.py
+++ b/scanpy/preprocessing/_mnn_correct.py
@@ -81,12 +81,12 @@ def mnn_correct(*datas, var_index=None, var_subset=None, batch_key='batch', inde
 
     Returns
     -------
-    datas : `numpy.ndarray` or :class:`~anndata.AnnData`
+    **datas** : :class:`~numpy.ndarray` or :class:`~anndata.AnnData`
         Corrected matrix/matrices or AnnData object/objects, depending on the
         input type and `do_concatenate`.
-    mnn_list : `list`
+    **mnn_list** : ``List[pandas.DataFrame]``
         A list containing MNN pairing information as DataFrames in each iteration step.
-    angle_list : `list`
+    **angle_list** : ``List[Tuple[Optional[float], int]]`` or ``None``
         A list containing angles of each batch.
     """
     try:

--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -7,7 +7,8 @@ from sklearn.utils.sparsefuncs import mean_variance_axis
 
 def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", qc_vars=(),
                          percent_top=(50, 100, 200, 500), inplace=False):
-    """Calculate quality control metrics.
+    """\
+    Calculate quality control metrics.
 
     Calculates a number of qc metrics for an AnnData object, see section
     `Returns` for specifics. Largely based on `calculateQCMetrics` from scater

--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -1,3 +1,5 @@
+from typing import Optional, Tuple
+
 import numba
 import numpy as np
 import pandas as pd
@@ -5,10 +7,15 @@ from scipy.sparse import csr_matrix, issparse, isspmatrix_csr, isspmatrix_coo
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
 
-def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", qc_vars=(),
-                         percent_top=(50, 100, 200, 500), inplace=False):
-    """\
-    Calculate quality control metrics.
+def calculate_qc_metrics(
+    adata,
+    expr_type="counts",
+    var_type="genes",
+    qc_vars=(),
+    percent_top=(50, 100, 200, 500),
+    inplace=False,
+) -> Optional[Tuple[pd.DataFrame, pd.DataFrame]]:
+    """Calculate quality control metrics.
 
     Calculates a number of qc metrics for an AnnData object, see section
     `Returns` for specifics. Largely based on `calculateQCMetrics` from scater
@@ -34,40 +41,37 @@ def calculate_qc_metrics(adata, expr_type="counts", var_type="genes", qc_vars=()
 
     Returns
     -------
-    Union[NoneType, Tuple[pd.DataFrame, pd.DataFrame]]
-        Depending on `inplace` returns calculated metrics (`pd.DataFrame`) or
-        updates `adata`'s `obs` and `var`.
+    Depending on `inplace` returns calculated metrics (`pd.DataFrame`) or
+    updates `adata`'s `obs` and `var`.
 
-        Observation level metrics include:
+    Observation level metrics include:
 
-        * `total_{var_type}_by_{expr_type}`
-            E.g. "total_genes_by_counts". Number of genes with positive counts
-            in a cell.
-        * `total_{expr_type}`
-            E.g. "total_counts". Total number of counts for a cell.
-        * `pct_{expr_type}_in_top_{n}_{var_type}` - for `n` in `percent_top`
-            E.g. "pct_counts_in_top_50_genes". Cumulative percentage of counts
-            for 50 most expressed genes in a cell.
-        * `total_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
-            E.g. "total_counts_mito". Total number of counts for variabes in
-            `qc_vars`.
-        * `pct_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
-            E.g. "pct_counts_mito". Proportion of total counts for a cell which
-            are mitochondrial.
+    `total_{var_type}_by_{expr_type}`
+        E.g. "total_genes_by_counts". Number of genes with positive counts in a cell.
+    `total_{expr_type}`
+        E.g. "total_counts". Total number of counts for a cell.
+    `pct_{expr_type}_in_top_{n}_{var_type}` - for `n` in `percent_top`
+        E.g. "pct_counts_in_top_50_genes". Cumulative percentage of counts
+        for 50 most expressed genes in a cell.
+    `total_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
+        E.g. "total_counts_mito". Total number of counts for variabes in
+        `qc_vars`.
+    `pct_{expr_type}_{qc_var}` - for `qc_var` in `qc_vars`
+        E.g. "pct_counts_mito". Proportion of total counts for a cell which
+        are mitochondrial.
 
-        Variable level metrics include:
+    Variable level metrics include:
 
-        * `total_{expr_type}`
-            E.g. "total_counts". Sum of counts for a gene.
-        * `mean_{expr_type}`
-            E.g. "mean counts". Mean expression over all cells.
-        * `n_cells_by_{expr_type}`
-            E.g. "n_cells_by_counts". Number of cells this expression is
-            measured in.
-        * `pct_dropout_by_{expr_type}`
-            E.g. "pct_dropout_by_counts". Percentage of cells this feature does
-            not appear in.
-
+    `total_{expr_type}`
+        E.g. "total_counts". Sum of counts for a gene.
+    `mean_{expr_type}`
+        E.g. "mean counts". Mean expression over all cells.
+    `n_cells_by_{expr_type}`
+        E.g. "n_cells_by_counts". Number of cells this expression is
+        measured in.
+    `pct_dropout_by_{expr_type}`
+        E.g. "pct_dropout_by_counts". Percentage of cells this feature does
+        not appear in.
 
     Example
     -------

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -39,7 +39,7 @@ def filter_cells(
     max_genes:  Optional[int] = None,
     inplace: bool = True,
     copy: bool = False,
-):
+) -> Optional[Tuple[np.ndarray, np.ndarray]]:
     """Filter cell outliers based on counts and numbers of genes expressed.
 
     For instance, only keep cells with at least `min_counts` counts or
@@ -67,16 +67,15 @@ def filter_cells(
 
     Returns
     -------
-    `tuple`, `None`
-        Depending on `inplace`, returns the following arrays or directly subsets
-        and annotates the data matrix
+    Depending on ``inplace``, returns the following arrays or directly subsets
+    and annotates the data matrix:
 
-        cells_subset : :class:`~numpy.ndarray`
-            Boolean index mask that does filtering. `True` means that the
-            cell is kept. `False` means the cell is removed.
-        number_per_cell : :class:`~numpy.ndarray`
-            Depending on what was tresholded (`counts` or `genes`), the array stores
-            `n_counts` or `n_cells` per gene.
+    cells_subset : numpy.ndarray
+        Boolean index mask that does filtering. ``True`` means that the
+        cell is kept. ``False`` means the cell is removed.
+    number_per_cell : numpy.ndarray
+        Depending on what was tresholded (``counts`` or ``genes``), the array stores
+        ``n_counts`` or ``n_cells`` per gene.
 
     Examples
     --------

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -189,10 +189,10 @@ def filter_genes(
     Depending on `inplace`, returns the following arrays or directly subsets
     and annotates the data matrix
 
-    gene_subset : :class:`~numpy.ndarray`
+    gene_subset : numpy.ndarray
         Boolean index mask that does filtering. `True` means that the
         gene is kept. `False` means the gene is removed.
-    number_per_gene : :class:`~numpy.ndarray`
+    number_per_gene : numpy.ndarray
         Depending on what was tresholded (`counts` or `cells`), the array stores
         `n_counts` or `n_cells` per gene.
     """

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -158,7 +158,7 @@ def filter_genes(
     max_cells:  Optional[int] = None,
     inplace: bool = True,
     copy: bool = False,
-):
+) -> Union[AnnData, None, Tuple[np.ndarray, np.ndarray]]:
     """Filter genes based on number of cells or counts.
 
     Keep genes that have at least ``min_counts`` counts or are expressed in at
@@ -186,16 +186,15 @@ def filter_genes(
 
     Returns
     -------
-    `tuple`, `None`
-        Depending on `inplace`, returns the following arrays or directly subsets
-        and annotates the data matrix
+    Depending on `inplace`, returns the following arrays or directly subsets
+    and annotates the data matrix
 
-        gene_subset : :class:`~numpy.ndarray`
-            Boolean index mask that does filtering. `True` means that the
-            gene is kept. `False` means the gene is removed.
-        number_per_gene : :class:`~numpy.ndarray`
-            Depending on what was tresholded (`counts` or `cells`), the array stores
-            `n_counts` or `n_cells` per gene.
+    gene_subset : :class:`~numpy.ndarray`
+        Boolean index mask that does filtering. `True` means that the
+        gene is kept. `False` means the gene is removed.
+    number_per_gene : :class:`~numpy.ndarray`
+        Depending on what was tresholded (`counts` or `cells`), the array stores
+        `n_counts` or `n_cells` per gene.
     """
     if copy:
        logg.warn('`copy` is deprecated, use `inplace` instead.')
@@ -253,7 +252,7 @@ def log1p(
     copy: bool = False,
     chunked: bool = False,
     chunk_size: Optional[int] = None,
-):
+) -> Optional[AnnData]:
     """Logarithmize the data matrix.
 
     Computes :math:`X = \\log(X + 1)`, where :math:`log` denotes the natural logarithm.
@@ -274,8 +273,7 @@ def log1p(
 
     Returns
     -------
-    AnnData, `None`
-        Returns or updates ``data``, depending on ``copy``.
+    Returns or updates ``data``, depending on ``copy``.
     """
     if copy:
         if not isinstance(data, AnnData):
@@ -311,7 +309,7 @@ def sqrt(
     copy: bool = False,
     chunked: bool = False,
     chunk_size: Optional[int] = None,
-):
+) -> Optional[AnnData]:
     """Square root the data matrix.
 
     Computes :math:`X = \\sqrt(X)`.
@@ -332,8 +330,7 @@ def sqrt(
 
     Returns
     -------
-    AnnData, None
-        Returns or updates `data`, depending on `copy`.
+    Returns or updates `data`, depending on `copy`.
     """
     if isinstance(data, AnnData):
         adata = data.copy() if copy else data
@@ -417,11 +414,10 @@ def pca(
 
     Returns
     -------
-
     X_pca : :class:`scipy.sparse.spmatrix` or :class:`numpy.ndarray`
         If `data` is array-like and ``return_info=False`` was passed,
         this function only returns `X_pca`…
-    adata : :class:`~anndata.AnnData`
+    adata : anndata.AnnData
         …otherwise if ``copy=True`` it returns or else adds fields to ``adata``:
 
         ``.obsm['X_pca']``
@@ -531,9 +527,16 @@ def pca(
             return X_pca
 
 
-def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None,
-                       key_n_counts=None, copy=False, layers=[], use_rep=None,
-                       min_counts=1):
+def normalize_per_cell(
+    data,
+    counts_per_cell_after=None,
+    counts_per_cell=None,
+    key_n_counts=None,
+    copy=False,
+    layers=[],
+    use_rep=None,
+    min_counts=1,
+) -> Optional[AnnData]:
     """Normalize total counts per cell.
 
     .. warning::
@@ -575,9 +578,8 @@ def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None,
 
     Returns
     -------
-    AnnData, `None`
-        Returns or updates `adata` with normalized version of the original
-        `adata.X`, depending on `copy`.
+    Returns or updates `adata` with normalized version of the original
+    `adata.X`, depending on `copy`.
 
     Examples
     --------
@@ -653,8 +655,11 @@ def normalize_per_cell(data, counts_per_cell_after=None, counts_per_cell=None,
     return X if copy else None
 
 
-def normalize_per_cell_weinreb16_deprecated(X, max_fraction=1,
-                                            mult_with_mean=False):
+def normalize_per_cell_weinreb16_deprecated(
+    X,
+    max_fraction=1,
+    mult_with_mean=False,
+) -> np.ndarray:
     """Normalize each cell [Weinreb17]_.
 
     This is a deprecated version. See `normalize_per_cell` instead.
@@ -674,8 +679,7 @@ def normalize_per_cell_weinreb16_deprecated(X, max_fraction=1,
 
     Returns
     -------
-    X_norm : np.ndarray
-        Normalized version of the original expression matrix.
+    Normalized version of the original expression matrix.
     """
     if max_fraction < 0 or max_fraction > 1:
         raise ValueError('Choose max_fraction between 0 and 1.')
@@ -692,7 +696,7 @@ def normalize_per_cell_weinreb16_deprecated(X, max_fraction=1,
     return X_norm
 
 
-def regress_out(adata, keys, n_jobs=None, copy=False):
+def regress_out(adata, keys, n_jobs=None, copy=False) -> Optional[AnnData]:
     """Regress out unwanted sources of variation.
 
     Uses simple linear regression. This is inspired by Seurat's `regressOut`
@@ -712,8 +716,7 @@ def regress_out(adata, keys, n_jobs=None, copy=False):
 
     Returns
     -------
-    AnnData, None
-        Depending on `copy` returns or updates `adata` with the corrected data matrix.
+    Depending on `copy` returns or updates `adata` with the corrected data matrix.
     """
     logg.info('regressing out', keys, r=True)
     if issparse(adata.X):
@@ -817,7 +820,7 @@ def _regress_out_chunk(data):
     return np.vstack(responses_chunk_list)
 
 
-def scale(data, zero_center=True, max_value=None, copy=False):
+def scale(data, zero_center=True, max_value=None, copy=False) -> Optional[AnnData]:
     """Scale data to unit variance and zero mean.
 
     .. note::
@@ -841,8 +844,7 @@ def scale(data, zero_center=True, max_value=None, copy=False):
 
     Returns
     -------
-    AnnData, None
-        Depending on `copy` returns or updates `adata` with a scaled `adata.X`.
+    Depending on `copy` returns or updates `adata` with a scaled `adata.X`.
     """
     if isinstance(data, AnnData):
         adata = data.copy() if copy else data
@@ -873,7 +875,7 @@ def scale(data, zero_center=True, max_value=None, copy=False):
     return X if copy else None
 
 
-def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
+def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False) -> Optional[AnnData]:
     """Subsample to a fraction of the number of observations.
 
     Parameters
@@ -893,10 +895,9 @@ def subsample(data, fraction=None, n_obs=None, random_state=0, copy=False):
 
     Returns
     -------
-    AnnData, None
-        Returns `X[obs_indices], obs_indices` if data is array-like, otherwise
-        subsamples the passed :class:`~anndata.AnnData` (`copy == False`) or
-        returns a subsampled copy of it (`copy == True`).
+    Returns `X[obs_indices], obs_indices` if data is array-like, otherwise
+    subsamples the passed :class:`~anndata.AnnData` (`copy == False`) or
+    returns a subsampled copy of it (`copy == True`).
     """
     np.random.seed(random_state)
     old_n_obs = data.n_obs if isinstance(data, AnnData) else data.shape[0]
@@ -957,8 +958,7 @@ def downsample_counts(
 
     Returns
     -------
-    AnnData, None
-        Depending on `copy` returns or updates an `adata` with downsampled `.X`.
+    Depending on `copy` returns or updates an `adata` with downsampled `.X`.
     """
     # This logic is all dispatch
     total_counts_call = total_counts is not None
@@ -1060,7 +1060,7 @@ def _downsample_array(col: np.array, target: int, random_state: int=0,
     return col
 
 
-def zscore_deprecated(X):
+def zscore_deprecated(X: np.ndarray) -> np.ndarray:
     """Z-score standardize each variable/gene in X.
 
     Use `scale` instead.
@@ -1069,13 +1069,12 @@ def zscore_deprecated(X):
 
     Parameters
     ----------
-    X : np.ndarray
+    X
         Data matrix. Rows correspond to cells and columns to genes.
 
     Returns
     -------
-    XZ : np.ndarray
-        Z-score standardized version of the data matrix.
+    Z-score standardized version of the data matrix.
     """
     means = np.tile(np.mean(X, axis=0)[None, :], (X.shape[0], 1))
     stds = np.tile(np.std(X, axis=0)[None, :], (X.shape[0], 1))

--- a/scanpy/queries/__init__.py
+++ b/scanpy/queries/__init__.py
@@ -2,7 +2,7 @@ import pandas as pd
 from .. import logging as logg
 
 
-def mitochondrial_genes(host, org):
+def mitochondrial_genes(host, org) -> pd.Index:
     """Mitochondrial gene symbols for specific organism through BioMart.
 
     Parameters
@@ -15,7 +15,7 @@ def mitochondrial_genes(host, org):
 
     Returns
     -------
-    A `pd.Index` containing mitochondrial gene symbols.
+    A :class:`pandas.Index` containing mitochondrial gene symbols.
     """
     try:
         from bioservices import biomart
@@ -53,7 +53,7 @@ def mitochondrial_genes(host, org):
     return res.index
 
 
-def gene_coordinates(host, org, gene, chr_exclude=[]):
+def gene_coordinates(host, org, gene, chr_exclude=[]) -> pd.DataFrame:
     """Retrieve gene coordinates for specific organism through BioMart.
     Parameters
     ----------

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -4,7 +4,7 @@
 import sys
 import time
 from pathlib import Path, PurePath
-from typing import Union
+from typing import Union, Dict
 
 import numpy as np
 import pandas as pd
@@ -32,7 +32,7 @@ avail_exts = {'anndata', 'xlsx',
 
 
 def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
-         first_column_names=False, backup_url=None, cache=False, **kwargs):
+         first_column_names=False, backup_url=None, cache=False, **kwargs) -> AnnData:
     """Read file and return :class:`~anndata.AnnData` object.
 
     To speed up reading, consider passing `cache=True`, which creates an hdf5
@@ -70,7 +70,7 @@ def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
+    An :class:`~anndata.AnnData` object
     """
     filename = str(filename)  # allow passing pathlib.Path objects
     if is_valid_filename(filename):
@@ -90,7 +90,7 @@ def read(filename, backed=False, sheet=None, ext=None, delimiter=None,
     return read_h5ad(filename, backed=backed)
 
 
-def read_10x_h5(filename, genome=None, gex_only=True):
+def read_10x_h5(filename, genome=None, gex_only=True) -> AnnData:
     """Read 10x-Genomics-formatted hdf5 file.
 
     Parameters
@@ -106,12 +106,11 @@ def read_10x_h5(filename, genome=None, gex_only=True):
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix, where obsevations/cells are named by their
-        barcode and variables/genes by gene name. The data matrix is stored in
-        `adata.X`, cell names in `adata.obs_names` and gene names in
-        `adata.var_names`. The gene IDs are stored in `adata.var['gene_ids']`.
-        The feature types are stored in `adata.var['feature_types']`
+    Annotated data matrix, where obsevations/cells are named by their
+    barcode and variables/genes by gene name. The data matrix is stored in
+    `adata.X`, cell names in `adata.obs_names` and gene names in
+    `adata.var_names`. The gene IDs are stored in `adata.var['gene_ids']`.
+    The feature types are stored in `adata.var['feature_types']`
     """
     logg.info('reading', filename, r=True, end=' ')
     with tables.open_file(str(filename), 'r') as f:
@@ -215,7 +214,7 @@ def _read_v3_10x_h5(filename):
             raise Exception('File is missing one or more required datasets.')
 
 
-def read_10x_mtx(path, var_names='gene_symbols', make_unique=True, cache=False, gex_only=True):
+def read_10x_mtx(path, var_names='gene_symbols', make_unique=True, cache=False, gex_only=True) -> AnnData:
     """Read 10x-Genomics-formatted mtx directory.
 
     Parameters
@@ -236,7 +235,7 @@ def read_10x_mtx(path, var_names='gene_symbols', make_unique=True, cache=False, 
 
     Returns
     -------
-    An :class:`~anndata.AnnData`.
+    An :class:`~anndata.AnnData` object
     """
     path = Path(path)
     genefile_exists = (path / 'genes.tsv').is_file()
@@ -345,7 +344,7 @@ def write(filename, adata, ext=None, compression='gzip', compression_opts=None):
 # -------------------------------------------------------------------------------
 
 
-def read_params(filename, asheader=False, verbosity=0):
+def read_params(filename, asheader=False, verbosity=0) -> Dict[str, Union[int, float, bool, str, None]]:
     """Read parameter dictionary from text file.
 
     Assumes that parameters are specified in the format:
@@ -363,8 +362,7 @@ def read_params(filename, asheader=False, verbosity=0):
 
     Returns
     -------
-    params : dict
-        Dictionary that stores parameters.
+    Dictionary that stores parameters.
     """
     filename = str(filename)  # allow passing pathlib.Path objects
     from collections import OrderedDict
@@ -504,15 +502,11 @@ def _slugify(path: Union[str, PurePath]) -> str:
     return filename
 
 
-def _read_softgz(filename):
+def _read_softgz(filename) -> AnnData:
     """Read a SOFT format data file.
 
     The SOFT format is documented here
     http://www.ncbi.nlm.nih.gov/geo/info/soft2.html.
-
-    Returns
-    -------
-    adata
 
     Notes
     -----

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -29,10 +29,10 @@ def diffmap(adata, n_comps=15, copy=False):
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.
 
-    X_diffmap : `adata.obsm`
+    **X_diffmap** : :class:`numpy.ndarray` (`adata.obsm`)
         Diffusion map representation of data, which is the right eigen basis of
         the transition matrix with eigenvectors as columns.
-    diffmap_evals : `np.ndarray` (`adata.uns`)
+    **diffmap_evals** : :class:`numpy.ndarray` (`adata.uns`)
         Array of size (number of eigen vectors). Eigenvalues of transition matrix.
     """
     if 'neighbors' not in adata.uns:

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -1,3 +1,5 @@
+from typing import Tuple
+
 import numpy as np
 import pandas as pd
 import scipy as sp
@@ -79,10 +81,10 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
 
     If `n_branchings==0`, no field `dpt_groups` will be written.
 
-    dpt_pseudotime : `pd.Series` (`adata.obs`, dtype `float`)
+    **dpt_pseudotime** : :class:`pandas.Series` (`adata.obs`, dtype `float`)
         Array of dim (number of samples) that stores the pseudotime of each
         cell, that is, the DPT distance with respect to the root cell.
-    dpt_groups : `pd.Series` (`adata.obs`, dtype `category`)
+    **dpt_groups** : :class:`pandas.Series` (`adata.obs`, dtype `category`)
         Array of dim (number of samples) that stores the subgroup id ('0',
         '1', ...) for each cell. The groups  typically correspond to
         'progenitor cells', 'undecided cells' or 'branches' of a process.
@@ -284,7 +286,7 @@ class DPT(Neighbors):
                     # print(self.segs_adjacency)
         # self.segs_adjacency.eliminate_zeros()
 
-    def select_segment(self, segs, segs_tips, segs_undecided):
+    def select_segment(self, segs, segs_tips, segs_undecided) -> Tuple[int, int]:
         """Out of a list of line segments, choose segment that has the most
         distant second data point.
 
@@ -573,7 +575,7 @@ class DPT(Neighbors):
                     break
         segs_undecided += [False for i in range(n_add)]
 
-    def _detect_branching(self, Dseg, tips, seg_reference=None):
+    def _detect_branching(self, Dseg: np.ndarray, tips: np.ndarray, seg_reference=None):
         """Detect branching on given segment.
 
         Call function __detect_branching three times for all three orderings of
@@ -583,9 +585,9 @@ class DPT(Neighbors):
 
         Parameters
         ----------
-        Dseg : np.ndarray
+        Dseg
             Dchosen distance matrix restricted to segment.
-        tips : np.ndarray
+        tips
             The three tip points. They form a 'triangle' that contains the data.
 
         Returns
@@ -775,7 +777,7 @@ class DPT(Neighbors):
             ibranch = imax + 1
         return idcs[:ibranch]
 
-    def kendall_tau_split(self, a, b):
+    def kendall_tau_split(self, a, b) -> int:
         """Return splitting index that maximizes correlation in the sequences.
 
         Compute difference in Kendall tau for all splitted sequences.
@@ -794,8 +796,7 @@ class DPT(Neighbors):
 
         Returns
         -------
-        i : int
-            Splitting index according to above description.
+        Splitting index according to above description.
         """
         if a.size != b.size:
             raise ValueError('a and b need to have the same size')
@@ -871,20 +872,24 @@ class DPT(Neighbors):
         """
         return 2./(len_old-2)*(-float(diff_neg)/(len_old-1)+tau_old)
 
-    def _kendall_tau_diff(self, a, b, i):
+    def _kendall_tau_diff(self, a: np.ndarray, b: np.ndarray, i) -> Tuple[int, int]:
         """Compute difference in concordance of pairs in split sequences.
 
         Consider splitting a and b at index i.
 
         Parameters
         ----------
-        a, b : np.ndarray
+        a
+            ?
+        b
+            ?
 
         Returns
         -------
-        diff_pos, diff_neg : int, int
-            Difference between concordant and non-concordant pairs for both
-            subsequences.
+        diff_pos
+            Difference between concordant pairs for both subsequences.
+        diff_neg
+            Difference between non-concordant pairs for both subsequences.
         """
         # compute ordering relation of the single points a[i] and b[i]
         # with all previous points of the sequences a and b, respectively

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -68,7 +68,7 @@ def draw_graph(
     -------
     Depending on `copy`, returns or updates `adata` with the following field.
 
-    X_draw_graph_`layout` : `adata.obsm`
+    **X_draw_graph_layout** : `adata.obsm`
         Coordinates of graph layout. E.g. for layout='fa' (the default), the field is called 'X_draw_graph_fa'
     """
     logg.info('drawing single-cell graph using layout "{}"'.format(layout),

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -80,8 +80,10 @@ def leiden(
 
     Returns
     -------
-    * `adata.obs[key_added]`: Array of dim (number of samples) that stores the subgroup id (`'0'`, `'1'`, ...) for each cell.
-    * `adata.uns['leiden']['params']`: A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
+    `adata.obs[key_added]`
+        Array of dim (number of samples) that stores the subgroup id (`'0'`, `'1'`, ...) for each cell.
+    `adata.uns['leiden']['params']`
+        A dict with the values for the parameters `resolution`, `random_state`, and `n_iterations`.
     """
     try:
         import leidenalg

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -1,4 +1,5 @@
 from collections import namedtuple
+from typing import List
 
 import numpy as np
 import scipy as sp
@@ -61,10 +62,10 @@ def paga(
 
     Returns
     -------
-    connectivities : np.ndarray (adata.uns['connectivities'])
+    **connectivities** : :class:`numpy.ndarray` (adata.uns['connectivities'])
         The full adjacency matrix of the abstracted graph, weights correspond to
         confidence in the connectivities of partitions.
-    connectivities_tree : sc.sparse csr matrix (adata.uns['connectivities_tree'])
+    **connectivities_tree** : :class:`scipy.sparse.csr_matrix` (adata.uns['connectivities_tree'])
         The adjacency matrix of the tree-like subgraph that best explains
         the topology.
 
@@ -328,7 +329,7 @@ class PAGA():
         self.transitions_confidence = transitions_confidence.T
 
 
-def paga_degrees(adata):
+def paga_degrees(adata) -> List[int]:
     """Compute the degree of each node in the abstracted graph.
 
     Parameters
@@ -338,8 +339,7 @@ def paga_degrees(adata):
 
     Returns
     -------
-    degrees : list
-        List of degrees for each node.
+    List of degrees for each node.
     """
     import networkx as nx
     g = nx.Graph(adata.uns['paga']['connectivities'])
@@ -347,7 +347,7 @@ def paga_degrees(adata):
     return degrees
 
 
-def paga_expression_entropies(adata):
+def paga_expression_entropies(adata) -> List[float]:
     """Compute the median expression entropy for each node-group.
 
     Parameters
@@ -357,8 +357,7 @@ def paga_expression_entropies(adata):
 
     Returns
     -------
-    entropies : list
-        Entropies of median expressions for each node.
+    Entropies of median expressions for each node.
     """
     from scipy.stats import entropy
     groups_order, groups_masks = utils.select_groups(
@@ -370,7 +369,7 @@ def paga_expression_entropies(adata):
         x_probs = (x_median - np.nanmin(x_median)) / (np.nanmax(x_median) - np.nanmin(x_median))
         entropies.append(entropy(x_probs))
     return entropies
-    
+
 
 def paga_compare_paths(adata1, adata2,
                        adjacency_key='connectivities', adjacency_key2=None):

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -92,7 +92,7 @@ def phate(
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.
 
-    X_phate : `np.ndarray`, (`adata.obs`, shape=[n_samples, n_components], dtype `float`)
+    **X_phate** : `np.ndarray`, (`adata.obs`, shape=[n_samples, n_components], dtype `float`)
         PHATE coordinates of data.
 
     Examples

--- a/scanpy/tools/_pypairs.py
+++ b/scanpy/tools/_pypairs.py
@@ -47,23 +47,23 @@ def sandbag(
     try:
         from pypairs import __version__ as pypairsversion
         from distutils.version import LooseVersion
-        
+
         if LooseVersion(pypairsversion) < LooseVersion("v3.0.9"):
             raise ImportError('Please only use `pypairs` >= v3.0.9 ')
     except ImportError:
         raise ImportError('You need to install the package `pypairs`.')
-        
-    
+
+
     from pypairs.pairs import sandbag
     from . import settings
     from pypairs import settings as pp_settings
-    
+
     pp_settings.verbosity = settings.verbosity
     pp_settings.n_jobs = settings.n_jobs
     pp_settings.writedir = settings.writedir
     pp_settings.cachedir = settings.cachedir
     pp_settings.logfile = settings.logfile
-    
+
     return sandbag(
         data = adata,
         annotation = annotation,
@@ -113,28 +113,27 @@ def cyclone(
 
     Returns
     -------
-     A :class:`~pandas.DataFrame` with samples as index and categories as columns with scores for each category for each
+    A :class:`~pandas.DataFrame` with samples as index and categories as columns with scores for each category for each
     sample and a additional column with the name of the max scoring category for each sample.
-    
-        *
-            If marker pairs contain only the cell cycle categories G1, S and G2M an additional column
-            ``pypairs_cc_prediction`` will be added. Where category S is assigned to samples where G1 and G2M score are
-            below 0.5.
+
+    If marker pairs contain only the cell cycle categories G1, S and G2M an additional column
+    ``pypairs_cc_prediction`` will be added. Where category S is assigned to samples where G1 and G2M score are
+    below 0.5.
     """
     try:
         from pypairs import __version__ as pypairsversion
         from distutils.version import LooseVersion
-        
+
         if LooseVersion(pypairsversion) < LooseVersion("v3.0.9"):
             raise ImportError('Please only use `pypairs` >= v3.0.9 ')
     except ImportError:
         raise ImportError('You need to install the package `pypairs`.')
-        
-    
+
+
     from pypairs.pairs import cyclone
     from . import settings
     from pypairs import settings as pp_settings
-    
+
     pp_settings.verbosity = settings.verbosity
     pp_settings.n_jobs = settings.n_jobs
     pp_settings.writedir = settings.writedir

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -459,11 +459,9 @@ def filter_rank_genes_groups(adata, key=None, groupby=None, use_raw=True, log=Tr
     >>> adata = sc.datasets.pbmc68k_reduced()
     >>> sc.tl.rank_genes_groups(adata, 'bulk_labels', method='wilcoxon')
     >>> sc.tl.filter_rank_genes_groups(adata, min_fold_change=3)
-
-    # visualize results
+    >>> # visualize results
     >>> sc.pl.rank_genes_groups(adata, key='rank_genes_groups_filtered')
-
-    # visualize results using dotplot
+    >>> # visualize results using dotplot
     >>> sc.pl.rank_genes_groups_dotplot(adata, key='rank_genes_groups_filtered')
     """
     if key is None:

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -69,21 +69,21 @@ def rank_genes_groups(
 
     Returns
     -------
-    names : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    **names** : structured `np.ndarray` (`.uns['rank_genes_groups']`)
         Structured array to be indexed by group id storing the gene
         names. Ordered according to scores.
-    scores : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    **scores** : structured `np.ndarray` (`.uns['rank_genes_groups']`)
         Structured array to be indexed by group id storing the z-score
         underlying the computation of a p-value for each gene for each
         group. Ordered according to scores.
-    logfoldchanges : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    **logfoldchanges** : structured `np.ndarray` (`.uns['rank_genes_groups']`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
         scores. Only provided if method is 't-test' like.
         Note: this is an approximation calculated from mean-log values.
-    pvals : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    **pvals** : structured `np.ndarray` (`.uns['rank_genes_groups']`)
         p-values.
-    pvals_adj : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    **pvals_adj** : structured `np.ndarray` (`.uns['rank_genes_groups']`)
         Corrected p-values.
 
     Notes

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -164,11 +164,11 @@ def score_genes_cell_cycle(
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.
 
-    S_score : `adata.obs`, dtype `object`
+    **S_score** : `adata.obs`, dtype `object`
         The score for S phase for each cell.
-    G2M_score : `adata.obs`, dtype `object`
+    **G2M_score** : `adata.obs`, dtype `object`
         The score for G2M phase for each cell.
-    phase : `adata.obs`, dtype `object`
+    **phase** : `adata.obs`, dtype `object`
         The cell cycle phase (`S`, `G2M` or `G1`) for each cell.
 
     See also

--- a/scanpy/tools/_sim.py
+++ b/scanpy/tools/_sim.py
@@ -13,24 +13,29 @@ import os
 import itertools
 import collections
 from collections import OrderedDict as odict
+
 import numpy as np
 import scipy as sp
+from anndata import AnnData
+
 from .. import utils
 from .. import readwrite
 from .._settings import settings
 from .. import logging as logg
 
 
-def sim(model,
-        params_file=True,
-        tmax=None,
-        branching=None,
-        nrRealizations=None,
-        noiseObs=None,
-        noiseDyn=None,
-        step=None,
-        seed=None,
-        writedir=None):
+def sim(
+    model,
+    params_file=True,
+    tmax=None,
+    branching=None,
+    nrRealizations=None,
+    noiseObs=None,
+    noiseDyn=None,
+    step=None,
+    seed=None,
+    writedir=None,
+) -> AnnData:
     """Simulate dynamic gene expression data [Wittmann09]_ [Wolf18]_.
 
     Sample from a stochastic differential equation model built from
@@ -62,8 +67,7 @@ def sim(model,
 
     Returns
     -------
-    adata : :class:`~anndata.AnnData`
-        Annotated data matrix.
+    Annotated data matrix.
 
     Examples
     --------
@@ -818,17 +822,23 @@ class GRNsim:
                   boolRules=self.boolRules,invTimeStep=self.invTimeStep)
 
 def _check_branching(X,Xsamples,restart,threshold=0.25):
-    """ Check whether time series branches.
+    """\
+    Check whether time series branches.
 
-        Args:
-            X (np.array): current time series data.
-            Xsamples (np.array): list of previous branching samples.
-            restart (int): counts number of restart trials.
-            threshold (float, optional): sets threshold for attractor
-                identification.
+    Parameters
+    ----------
+    X (np.array): current time series data.
+    Xsamples (np.array): list of previous branching samples.
+    restart (int): counts number of restart trials.
+    threshold (float, optional): sets threshold for attractor
+        identification.
 
-        Returns:
-            check = true if branching realization, Xsamples = updated list
+    Returns
+    -------
+    check : bool
+        true if branching realization
+    Xsamples
+        updated list
     """
     check = True
     if restart == 0:
@@ -853,13 +863,16 @@ def _check_branching(X,Xsamples,restart,threshold=0.25):
     return check, Xsamples
 
 def check_nocycles(Adj, verbosity=2):
-    """ Checks that there are no cycles in graph described by adjacancy matrix.
+    """\
+    Checks that there are no cycles in graph described by adjacancy matrix.
 
-        Args:
-            Adj (np.array): adjancancy matrix of dimension (dim, dim)
+    Parameters
+    ----------
+    Adj (np.array): adjancancy matrix of dimension (dim, dim)
 
-        Returns:
-            True if there is no cycle, False otherwise.
+    Returns
+    -------
+    True if there is no cycle, False otherwise.
     """
     dim = Adj.shape[0]
     for g in range(dim):
@@ -878,19 +891,24 @@ def check_nocycles(Adj, verbosity=2):
 
 
 def sample_coupling_matrix(dim=3,connectivity=0.5):
-    """ Sample coupling matrix.
+    """\
+    Sample coupling matrix.
 
-        Checks that returned graphs contain no self-cycles.
+    Checks that returned graphs contain no self-cycles.
 
-        Args:
-            dim (int): dimension of coupling matrix.
-            connectivity (float): fraction of connectivity, fully connected means 1.,
-                not-connected means 0, in the case of fully connected, one has
-                dim*(dim-1)/2 edges in the graph.
+    Parameters
+    ----------
+    dim : int
+        dimension of coupling matrix.
+    connectivity : float
+        fraction of connectivity, fully connected means 1.,
+        not-connected means 0, in the case of fully connected, one has
+        dim*(dim-1)/2 edges in the graph.
 
-        Returns:
-            Tuple (Coupl,Adj,Adj_signed) of coupling matrix, adjancancy and
-            signed adjacancy matrix.
+    Returns
+    -------
+    Tuple (Coupl,Adj,Adj_signed) of coupling matrix, adjancancy and
+    signed adjacancy matrix.
     """
     max_trial = 10
     check = False
@@ -946,17 +964,21 @@ class StaticCauseEffect:
             'tanh': lambda x: np.tanh(2*x),
         }
 
-    def sim_givenAdj(self,Adj,model='line'):
-        """ Simulate data given only an adjacancy matrix and a model.
+    def sim_givenAdj(self, Adj: np.array, model='line'):
+        """\
+        Simulate data given only an adjacancy matrix and a model.
 
         The model is a bivariate funtional dependence. The adjacancy matrix
         needs to be acyclic.
 
-        Args:
-           Adj (np.array): adjacancy matrix of shape (dim,dim).
+        Parameters
+        ----------
+        Adj
+            adjacancy matrix of shape (dim,dim).
 
-        Returns:
-           Data array of shape (n_samples,dim).
+        Returns
+        -------
+        Data array of shape (n_samples,dim).
         """
         # nice examples
         examples = [{'func' : 'sawtooth', 'gdist' : 'uniform',
@@ -1031,11 +1053,6 @@ class StaticCauseEffect:
 
     def sim_combi(self):
         """ Simulate data to model combi regulation.
-
-        Args:
-
-        Returns:
-
         """
         n_samples = 500
         sigma_glob = 1.8

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -70,7 +70,7 @@ def tsne(
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.
 
-    X_tsne : `np.ndarray` (`adata.obs`, dtype `float`)
+    **X_tsne** : `np.ndarray` (`adata.obs`, dtype `float`)
         tSNE coordinates of data.
     """
     logg.info('computing tSNE', r=True)

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -10,16 +10,17 @@ from ..logging import (
 
 @doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)
 def tsne(
-        adata,
-        n_pcs=None,
-        use_rep=None,
-        perplexity=30,
-        early_exaggeration=12,
-        learning_rate=1000,
-        random_state=0,
-        use_fast_tsne=True,
-        n_jobs=None,
-        copy=False):
+    adata,
+    n_pcs=None,
+    use_rep=None,
+    perplexity=30,
+    early_exaggeration=12,
+    learning_rate=1000,
+    random_state=0,
+    use_fast_tsne=True,
+    n_jobs=None,
+    copy=False,
+):
     """\
     t-SNE [Maaten08]_ [Amir13]_ [Pedregosa11]_.
 

--- a/scanpy/tools/_tsne_fix.py
+++ b/scanpy/tools/_tsne_fix.py
@@ -63,7 +63,7 @@ def _gradient_descent(objective, p0, it, n_iter, objective_error=None,
         Keyword arguments to pass to objective function.
     Returns
     -------
-    p : array, shape (n_params,)
+    **p** : array, shape (n_params,)
         Optimum parameters.
     error : float
         Optimum.

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -7,19 +7,20 @@ from ..logging import (
 )
 
 def umap(
-        adata,
-        min_dist=0.5,
-        spread=1.0,
-        n_components=2,
-        maxiter=None,
-        alpha=1.0,
-        gamma=1.0,
-        negative_sample_rate=5,
-        init_pos='spectral',
-        random_state=0,
-        a=None,
-        b=None,
-        copy=False):
+    adata,
+    min_dist=0.5,
+    spread=1.0,
+    n_components=2,
+    maxiter=None,
+    alpha=1.0,
+    gamma=1.0,
+    negative_sample_rate=5,
+    init_pos='spectral',
+    random_state=0,
+    a=None,
+    b=None,
+    copy=False,
+):
     """Embed the neighborhood graph using UMAP [McInnes18]_.
 
     UMAP (Uniform Manifold Approximation and Projection) is a manifold learning
@@ -92,6 +93,7 @@ def umap(
     -------
     X_umap : `adata.obsm` field
         UMAP coordinates of data.
+    \\
     """
     adata = adata.copy() if copy else adata
     if 'neighbors' not in adata.uns:

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -91,9 +91,10 @@ def umap(
 
     Returns
     -------
-    X_umap : `adata.obsm` field
+    Depending on `copy`, returns or updates `adata` with the following fields.
+
+    **X_umap** : `adata.obsm` field
         UMAP coordinates of data.
-    \\
     """
     adata = adata.copy() if copy else adata
     if 'neighbors' not in adata.uns:


### PR DESCRIPTION
Everything looks like it should:

- https://scanpy.readthedocs.io/en/return-formatting/api/scanpy.pp.calculate_qc_metrics.html

    Here the rst is weird. Just get rid of the `*`!

- https://scanpy.readthedocs.io/en/return-formatting/api/scanpy.pp.normalize_total.html

    Short prose, looks fine.

- https://scanpy.readthedocs.io/en/return-formatting/api/scanpy.tl.leiden.html

    This should be converted into a definition list as well.

- https://scanpy.readthedocs.io/en/return-formatting/api/scanpy.tl.dpt.html

    Mixed. Looks great.

No rtype interfering anywhere
