### PR TITLE
Fixed filter_cells() for inplace=False

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -121,7 +121,7 @@ def filter_cells(
         adata = data.copy() if copy else data
         cell_subset, number = materialize_as_ndarray(filter_cells(adata.X, min_counts, min_genes, max_counts, max_genes))
         if not inplace:
-            return gene_subset, number
+            return cell_subset, number
         if min_genes is None and max_genes is None: adata.obs['n_counts'] = number
         else: adata.obs['n_genes'] = number
         adata._inplace_subset_obs(cell_subset)


### PR DESCRIPTION
For `inplace=False,` the function tried to return `gene_subsets`, which is not defined here, instead of `cell_subsets`.