### PR TITLE
Minor fixes grab-bag

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -121,7 +121,6 @@ def insert_function_images(app, what, name, obj, options, lines):
     path = Path(__file__).parent / 'api' / f'{name}.png'
     if what != 'function' or not path.is_file(): return
     lines[0:0] = [f'.. image:: {path.name}', '   :width: 200', '   :align: right', '']
-    print(*lines, sep='\n')
 
 
 # -- Test for new scanpydoc functionality --------------------------------------

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -211,7 +211,7 @@ class ScanpyConfig(object):
     @datasetdir.setter
     def datasetdir(self, datasetdir):
         _type_check(datasetdir, "datasetdir", [str, Path])
-        self._datasetdir = Path(datasetdir).absolute()
+        self._datasetdir = Path(datasetdir).resolve()
 
     @property
     def figdir(self):

--- a/scanpy/tests/test_embedding_density.py
+++ b/scanpy/tests/test_embedding_density.py
@@ -18,9 +18,6 @@ def test_embedding_density():
 
 def test_embedding_density_plot():
     # Test that sc.pl.embedding_density() runs without error
-    adata = sc.datasets.blobs()
-    sc.pp.pca(adata)
-    sc.pp.neighbors(adata)
-    sc.tl.umap(adata)
+    adata = sc.datasets.pbmc68k_reduced()
     sc.tl.embedding_density(adata, 'umap')
     sc.pl.embedding_density(adata, 'umap', 'umap_density')


### PR DESCRIPTION
Three minor fixes:

1. Remove noisy print statement from doc builds. Looked like it might have been left over from debugging, and doesn't seem to break anything. @flying-sheep, does that sound right?
2. When setting `sc.settings.datasetdir`, I'd meant to use `Path.resolve` instead of `Path.absolute`.
3. Sped up embedding density test by using a dataset where umap was precomputed. Is this fine @LuckyMD?