### PR TITLE
Add extra covariate support to combat.

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -13,6 +13,7 @@ On master :small:`April 27, 2019`
 Bug fixes:
 
 - :func:`~scanpy.tl.rank_genes_groups` t-test implementation doesn't return NaN when variance is 0, also changed to scipy's implementation, see `PR <https://github.com/theislab/scanpy/pull/621>`__ :smaller:`thanks to I Virshup`
+- :func:`~scanpy.pp.combat` ComBat function now supports additional covariates which may include adjustment variables or biological condition, see `PR <https://github.com/theislab/scanpy/pull/618>`__ :smaller:`thanks to G Eraslan`
 
 Version 1.4.1 :small:`April 27, 2019`
 -------------------------------------

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -170,6 +170,9 @@ def combat(adata: AnnData, key: str = 'batch', covariates: Optional[Collection[s
         if key in covariates:
             raise ValueError('Batch key and covariates cannot overlap')
 
+        if len(covariates) != len(set(covariates)):
+            raise ValueError('Covariates must be unique')
+
     # only works on dense matrices so far
     if issparse(adata.X):
         X = adata.X.A.T

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -147,7 +147,9 @@ def combat(adata: AnnData, key: str = 'batch', covariates: Optional[Collection[s
     key: `str`, optional (default: `"batch"`)
         Key to a categorical annotation from adata.obs that will be used for batch effect removal
     covariates
-        Additional covariates which could be causing batch effects.
+        Additional covariates such as adjustment variables or biological condition. Note that
+        not including covariates may introduce bias or lead to the removal of biological signal 
+        in unbalanced designs.
     inplace: bool, optional (default: `True`)
         Wether to replace adata.X or to return the corrected data
 

--- a/scanpy/tests/test_combat.py
+++ b/scanpy/tests/test_combat.py
@@ -3,43 +3,66 @@ import pandas as pd
 from sklearn.metrics import silhouette_score
 
 import scanpy as sc
-from scanpy.preprocessing._combat import stand_data
+from scanpy.preprocessing._combat import _standardize_data, _design_matrix
 
 
 def test_norm():
-    # this test trivially checks wether mean normalisation worked
-    
+    # this test trivially checks whether mean normalisation worked
+
     # load in data
     adata = sc.datasets.blobs()
     key = 'blobs'
     data = pd.DataFrame(data=adata.X.T, index=adata.var_names,
                         columns=adata.obs_names)
-    
+
     # construct a pandas series of the batch annotation
     batch = pd.Series(adata.obs[key])
     model = pd.DataFrame({'batch': batch})
-    
+
     # standardize the data
-    s_data, design, var_pooled,  stand_mean = stand_data(model, data) 
+    s_data, design, var_pooled,  stand_mean = _standardize_data(model, data, 'batch')
 
     assert np.allclose(s_data.mean(axis = 1), np.zeros(s_data.shape[0]))
 
 
-def test_shilhouette():
+def test_covariates():
+    adata = sc.datasets.blobs()
+    key = 'blobs'
+
+    X1 = sc.pp.combat(adata, key=key, inplace=False)
+
+    np.random.seed(0)
+    adata.obs['cat1'] = np.random.binomial(3, 0.5, size=(adata.n_obs))
+    adata.obs['cat2'] = np.random.binomial(2, 0.1, size=(adata.n_obs))
+    adata.obs['num1'] = np.random.normal(size=(adata.n_obs))
+
+    X2 = sc.pp.combat(adata, key=key, covariates=['cat1', 'cat2', 'num1'], inplace=False)
+    sc.pp.combat(adata, key=key, covariates=['cat1', 'cat2', 'num1'], inplace=True)
+
+    assert X1.shape == X2.shape
+
+    df = adata.obs[['cat1', 'cat2', 'num1', key]]
+    batch_cats = adata.obs[key].cat.categories
+    design = _design_matrix(df, key, batch_cats)
+
+    assert len(design.columns) == 4 + len(batch_cats) - 1
+
+
+def test_silhouette():
     # this test checks wether combat can align data from several gaussians
     # it checks this by computing the silhouette coefficient in a pca embedding
-    
+
     # load in data
     adata = sc.datasets.blobs()
-    
+
     # apply combat
     sc.pp.combat(adata, 'blobs')
-    
+
     # compute pca
     sc.tl.pca(adata)
     X_pca = adata.obsm['X_pca']
-    
+
     # compute silhouette coefficient in pca
     sh = silhouette_score(X_pca[:, :2], adata.obs['blobs'].values )
-    
+
     assert sh < 0.1


### PR DESCRIPTION
It's convenient to be able to specify multiple variables in combat in the R package. So I added the support for extra covariates (categorical or numeric) and converted some methods to private. There are tests for the new covariate option and also the private _design_matrix function now.