### PR TITLE
Add a batch_key option to HVG function to reduce the batch effects

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -131,7 +131,7 @@ def highly_variable_genes(
                                      'highly_variable': np.nansum})
         if n_top_genes is not None:
             # sort genes by how often they selected as hvg within each batch and
-            # break ties with minimum normalized dispersion across batches
+            # break ties with normalized dispersion across batches
             df.sort_values(['highly_variable', 'dispersions_norm'],
                            ascending=False, na_position='last', inplace=True)
             df['highly_variable'] = False

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -125,9 +125,9 @@ def highly_variable_genes(
             df.append(hvg)
 
         df = pd.concat(df, axis=0)
-        df = df.groupby('gene').agg({'means': np.nanmin,
-                                     'dispersions': np.nanmin,
-                                     'dispersions_norm': np.nanmin,
+        df = df.groupby('gene').agg({'means': np.nanmean,
+                                     'dispersions': np.nanmean,
+                                     'dispersions_norm': np.nanmean,
                                      'highly_variable': np.nansum})
         if n_top_genes is not None:
             # sort genes by how often they selected as hvg within each batch and

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -8,6 +8,7 @@ from anndata import AnnData
 from .. import logging as logg
 from ._distributed import materialize_as_ndarray
 from ._utils import _get_mean_var
+from ..utils import sanitize_anndata
 
 
 def highly_variable_genes(
@@ -18,7 +19,8 @@ def highly_variable_genes(
     n_bins=20,
     flavor='seurat',
     subset=False,
-    inplace=True
+    inplace=True,
+    batch_key=None,
 ) -> Optional[np.recarray]:
     """Annotate highly variable genes [Satija15]_ [Zheng17]_.
 
@@ -65,6 +67,10 @@ def highly_variable_genes(
         highly variable genes.
     inplace : `bool`, optional (default: `True`)
         Whether to place calculated metrics in `.var` or return them.
+    batch_key : `str`, optional (default: `None`)
+        If specified, highly-variable genes are selected within each batch separately and merged.
+        This simple process avoids the selection of batch-specific genes and acts as a
+        lightweight batch correction method.
 
     Returns
     -------
@@ -97,90 +103,133 @@ def highly_variable_genes(
     if min_disp is None: min_disp = 0.5
     if min_mean is None: min_mean = 0.0125
     if max_mean is None: max_mean = 3
+    if max_disp is None: max_disp = np.inf
 
-    X = np.expm1(adata.X) if flavor == 'seurat' else adata.X
+    if batch_key is not None:
+        sanitize_anndata(adata)
+        batches = adata.obs[batch_key].cat.categories
+        df = []
+        for batch in batches:
+            adata_subset = adata[adata.obs[batch_key] == batch]
+            hvg = highly_variable_genes(adata_subset,
+                                        min_disp=min_disp, max_disp=min_disp,
+                                        min_mean=min_mean, max_mean=max_mean,
+                                        n_top_genes=n_top_genes,
+                                        n_bins=n_bins,
+                                        flavor=flavor,
+                                        inplace=False,
+                                        subset=False,
+                                        batch_key=None)
+            hvg = pd.DataFrame(hvg)
+            hvg['gene'] = adata.var_names.values
+            df.append(hvg)
 
-    mean, var = materialize_as_ndarray(_get_mean_var(X))
-    # now actually compute the dispersion
-    mean[mean == 0] = 1e-12  # set entries equal to zero to small value
-    dispersion = var / mean
-    if flavor == 'seurat':  # logarithmized mean as in Seurat
-        dispersion[dispersion == 0] = np.nan
-        dispersion = np.log(dispersion)
-        mean = np.log1p(mean)
-    # all of the following quantities are "per-gene" here
-    df = pd.DataFrame()
-    df['mean'] = mean
-    df['dispersion'] = dispersion
-    if flavor == 'seurat':
-        df['mean_bin'] = pd.cut(df['mean'], bins=n_bins)
-        disp_grouped = df.groupby('mean_bin')['dispersion']
-        disp_mean_bin = disp_grouped.mean()
-        disp_std_bin = disp_grouped.std(ddof=1)
-        # retrieve those genes that have nan std, these are the ones where
-        # only a single gene fell in the bin and implicitly set them to have
-        # a normalized disperion of 1
-        one_gene_per_bin = disp_std_bin.isnull()
-        gen_indices = np.where(one_gene_per_bin[df['mean_bin'].values])[0].tolist()
-        if len(gen_indices) > 0:
-            logg.msg(
-                'Gene indices {} fell into a single bin: their '
-                'normalized dispersion was set to 1.\n    '
-                'Decreasing `n_bins` will likely avoid this effect.'
-                .format(gen_indices),
-                v=4
+        df = pd.concat(df, axis=0)
+        df = df.groupby('gene').agg({'means': np.nanmin,
+                                     'dispersions': np.nanmin,
+                                     'dispersions_norm': np.nanmin,
+                                     'highly_variable': np.nansum})
+        if n_top_genes is not None:
+            # sort genes by how often they selected as hvg within each batch and
+            # break ties with minimum normalized dispersion across batches
+            df.sort_values(['highly_variable', 'dispersions_norm'],
+                           ascending=False, na_position='last', inplace=True)
+            df['highly_variable'] = False
+            df.loc[:n_top_genes, 'highly_variable'] = True
+            df = df.loc[adata.var_names]
+            gene_subset = df.highly_variable.values
+        else:
+            df = df.loc[adata.var_names]
+            dispersion_norm = df.dispersions_norm.values
+            dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
+            gene_subset = np.logical_and.reduce((
+                df.means > min_mean, df.means < max_mean,
+                df.dispersions_norm > min_disp,
+                df.dispersions_norm < max_disp,
+            ))
+            df['highly_variable'] = gene_subset
+    else:
+        X = np.expm1(adata.X) if flavor == 'seurat' else adata.X
+        mean, var = materialize_as_ndarray(_get_mean_var(X))
+        # now actually compute the dispersion
+        mean[mean == 0] = 1e-12  # set entries equal to zero to small value
+        dispersion = var / mean
+        if flavor == 'seurat':  # logarithmized mean as in Seurat
+            dispersion[dispersion == 0] = np.nan
+            dispersion = np.log(dispersion)
+            mean = np.log1p(mean)
+        # all of the following quantities are "per-gene" here
+        df = pd.DataFrame()
+        df['means'] = mean
+        df['dispersions'] = dispersion
+        if flavor == 'seurat':
+            df['mean_bin'] = pd.cut(df['means'], bins=n_bins)
+            disp_grouped = df.groupby('mean_bin')['dispersions']
+            disp_mean_bin = disp_grouped.mean()
+            disp_std_bin = disp_grouped.std(ddof=1)
+            # retrieve those genes that have nan std, these are the ones where
+            # only a single gene fell in the bin and implicitly set them to have
+            # a normalized disperion of 1
+            one_gene_per_bin = disp_std_bin.isnull()
+            gen_indices = np.where(one_gene_per_bin[df['mean_bin'].values])[0].tolist()
+            if len(gen_indices) > 0:
+                logg.msg(
+                    'Gene indices {} fell into a single bin: their '
+                    'normalized dispersion was set to 1.\n    '
+                    'Decreasing `n_bins` will likely avoid this effect.'
+                    .format(gen_indices),
+                    v=4
+                )
+            # Circumvent pandas 0.23 bug. Both sides of the assignment have dtype==float32,
+            # but there’s still a dtype error without “.value”.
+            disp_std_bin[one_gene_per_bin.values] = disp_mean_bin[one_gene_per_bin.values].values
+            disp_mean_bin[one_gene_per_bin.values] = 0
+            # actually do the normalization
+            df['dispersions_norm'] = (
+                (
+                    df['dispersions'].values  # use values here as index differs
+                    - disp_mean_bin[df['mean_bin'].values].values
+                ) / disp_std_bin[df['mean_bin'].values].values
             )
-        # Circumvent pandas 0.23 bug. Both sides of the assignment have dtype==float32,
-        # but there’s still a dtype error without “.value”.
-        disp_std_bin[one_gene_per_bin.values] = disp_mean_bin[one_gene_per_bin.values].values
-        disp_mean_bin[one_gene_per_bin.values] = 0
-        # actually do the normalization
-        df['dispersion_norm'] = (
-            (
-                df['dispersion'].values  # use values here as index differs
-                - disp_mean_bin[df['mean_bin'].values].values
-            ) / disp_std_bin[df['mean_bin'].values].values
-        )
-    elif flavor == 'cell_ranger':
-        from statsmodels import robust
-        df['mean_bin'] = pd.cut(df['mean'], np.r_[
-            -np.inf,
-            np.percentile(df['mean'], np.arange(10, 105, 5)),
-            np.inf
-        ])
-        disp_grouped = df.groupby('mean_bin')['dispersion']
-        disp_median_bin = disp_grouped.median()
-        # the next line raises the warning: "Mean of empty slice"
-        with warnings.catch_warnings():
-            warnings.simplefilter('ignore')
-            disp_mad_bin = disp_grouped.apply(robust.mad)
-        df['dispersion_norm'] = (
-            np.abs(
-                df['dispersion'].values
-                - disp_median_bin[df['mean_bin'].values].values
-            ) / disp_mad_bin[df['mean_bin'].values].values
-        )
-    else:
-        raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
-    dispersion_norm = df['dispersion_norm'].values.astype('float32')
-    if n_top_genes is not None:
-        dispersion_norm = dispersion_norm[~np.isnan(dispersion_norm)]
-        dispersion_norm[::-1].sort()  # interestingly, np.argpartition is slightly slower
-        disp_cut_off = dispersion_norm[n_top_genes-1]
-        gene_subset = np.nan_to_num(df['dispersion_norm'].values) >= disp_cut_off
-        logg.msg(
-            'the {} top genes correspond to a normalized dispersion cutoff of'
-            .format(n_top_genes, disp_cut_off),
-            v=5,
-        )
-    else:
-        max_disp = np.inf if max_disp is None else max_disp
-        dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
-        gene_subset = np.logical_and.reduce((
-            mean > min_mean, mean < max_mean,
-            dispersion_norm > min_disp,
-            dispersion_norm < max_disp,
-        ))
+        elif flavor == 'cell_ranger':
+            from statsmodels import robust
+            df['mean_bin'] = pd.cut(df['means'], np.r_[
+                -np.inf,
+                np.percentile(df['means'], np.arange(10, 105, 5)),
+                np.inf
+            ])
+            disp_grouped = df.groupby('mean_bin')['dispersions']
+            disp_median_bin = disp_grouped.median()
+            # the next line raises the warning: "Mean of empty slice"
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore')
+                disp_mad_bin = disp_grouped.apply(robust.mad)
+            df['dispersions_norm'] = (
+                np.abs(
+                    df['dispersions'].values
+                    - disp_median_bin[df['mean_bin'].values].values
+                ) / disp_mad_bin[df['mean_bin'].values].values
+            )
+        else:
+            raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
+        dispersion_norm = df['dispersions_norm'].values.astype('float32')
+        if n_top_genes is not None:
+            dispersion_norm = dispersion_norm[~np.isnan(dispersion_norm)]
+            dispersion_norm[::-1].sort()  # interestingly, np.argpartition is slightly slower
+            disp_cut_off = dispersion_norm[n_top_genes-1]
+            gene_subset = np.nan_to_num(df['dispersions_norm'].values) >= disp_cut_off
+            logg.msg(
+                'the {} top genes correspond to a normalized dispersion cutoff of {}'
+                .format(n_top_genes, disp_cut_off),
+                v=5,
+            )
+        else:
+            dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
+            gene_subset = np.logical_and.reduce((
+                mean > min_mean, mean < max_mean,
+                dispersion_norm > min_disp,
+                dispersion_norm < max_disp,
+            ))
 
     logg.msg('    finished', time=True, v=4)
 
@@ -193,17 +242,17 @@ def highly_variable_genes(
             '    \'dispersions_norm\', float vector (adata.var)'
         )
         adata.var['highly_variable'] = gene_subset
-        adata.var['means'] = df['mean'].values
-        adata.var['dispersions'] = df['dispersion'].values
-        adata.var['dispersions_norm'] = df['dispersion_norm'].values.astype('float32', copy=False)
+        adata.var['means'] = df['means'].values
+        adata.var['dispersions'] = df['dispersions'].values
+        adata.var['dispersions_norm'] = df['dispersions_norm'].values.astype('float32', copy=False)
         if subset:
             adata._inplace_subset_var(gene_subset)
     else:
         arrays = (
              gene_subset,
-             df['mean'].values,
-             df['dispersion'].values,
-             df['dispersion_norm'].values.astype('float32', copy=False)
+             df['means'].values,
+             df['dispersions'].values,
+             df['dispersions_norm'].values.astype('float32', copy=False)
         )
         dtypes = [
             ('highly_variable', np.bool_),

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -11,6 +11,161 @@ from ._utils import _get_mean_var
 from ..utils import sanitize_anndata
 
 
+def _highly_variable_genes_single_batch(
+    adata,
+    min_disp=None, max_disp=None,
+    min_mean=None, max_mean=None,
+    n_top_genes=None,
+    n_bins=20,
+    flavor='seurat',
+) -> pd.DataFrame:
+    """Internal function for annotating highly variable genes [Satija15]_ [Zheng17]_.
+
+    Expects logarithmized data.
+
+    Depending on `flavor`, this reproduces the R-implementations of Seurat
+    [Satija15]_ and Cell Ranger [Zheng17]_.
+
+    The normalized dispersion is obtained by scaling with the mean and standard
+    deviation of the dispersions for genes falling into a given bin for mean
+    expression of genes. This means that for each bin of mean expression, highly
+    variable genes are selected.
+
+    Parameters
+    ----------
+    adata : :class:`~anndata.AnnData`
+        The annotated data matrix of shape `n_obs` × `n_vars`. Rows correspond
+        to cells and columns to genes.
+    min_mean : `float`, optional (default: 0.0125)
+        If `n_top_genes` unequals `None`, this and all other cutoffs for the means and the
+        normalized dispersions are ignored.
+    max_mean : `float`, optional (default: 3)
+        If `n_top_genes` unequals `None`, this and all other cutoffs for the means and the
+        normalized dispersions are ignored.
+    min_disp : `float`, optional (default: 0.5)
+        If `n_top_genes` unequals `None`, this and all other cutoffs for the means and the
+        normalized dispersions are ignored.
+    max_disp : `float`, optional (default: `None`)
+        If `n_top_genes` unequals `None`, this and all other cutoffs for the means and the
+        normalized dispersions are ignored.
+    n_top_genes : `int` or `None`, optional (default: `None`)
+        Number of highly-variable genes to keep.
+    n_bins : `int`, optional (default: 20)
+        Number of bins for binning the mean gene expression. Normalization is
+        done with respect to each bin. If just a single gene falls into a bin,
+        the normalized dispersion is artificially set to 1. You'll be informed
+        about this if you set `settings.verbosity = 4`.
+    flavor : `{'seurat', 'cell_ranger'}`, optional (default: 'seurat')
+        Choose the flavor for computing normalized dispersion. In their default
+        workflows, Seurat passes the cutoffs whereas Cell Ranger passes
+        `n_top_genes`.
+
+    Returns
+    -------
+    highly_variable_data_frame
+        A DataFrame that contains colums highly_variable, means, dispersions and dispersions_norm.
+    """
+
+    if n_top_genes is not None and not all([
+            min_disp is None, max_disp is None, min_mean is None, max_mean is None]):
+        logg.info('If you pass `n_top_genes`, all cutoffs are ignored.')
+
+    if min_disp is None: min_disp = 0.5
+    if min_mean is None: min_mean = 0.0125
+    if max_mean is None: max_mean = 3
+    if max_disp is None: max_disp = np.inf
+
+    X = np.expm1(adata.X) if flavor == 'seurat' else adata.X
+    mean, var = materialize_as_ndarray(_get_mean_var(X))
+    # now actually compute the dispersion
+    mean[mean == 0] = 1e-12  # set entries equal to zero to small value
+    dispersion = var / mean
+    if flavor == 'seurat':  # logarithmized mean as in Seurat
+        dispersion[dispersion == 0] = np.nan
+        dispersion = np.log(dispersion)
+        mean = np.log1p(mean)
+    # all of the following quantities are "per-gene" here
+    df = pd.DataFrame()
+    df['means'] = mean
+    df['dispersions'] = dispersion
+    if flavor == 'seurat':
+        df['mean_bin'] = pd.cut(df['means'], bins=n_bins)
+        disp_grouped = df.groupby('mean_bin')['dispersions']
+        disp_mean_bin = disp_grouped.mean()
+        disp_std_bin = disp_grouped.std(ddof=1)
+        # retrieve those genes that have nan std, these are the ones where
+        # only a single gene fell in the bin and implicitly set them to have
+        # a normalized disperion of 1
+        one_gene_per_bin = disp_std_bin.isnull()
+        gen_indices = np.where(one_gene_per_bin[df['mean_bin'].values])[0].tolist()
+        if len(gen_indices) > 0:
+            logg.msg(
+                'Gene indices {} fell into a single bin: their '
+                'normalized dispersion was set to 1.\n    '
+                'Decreasing `n_bins` will likely avoid this effect.'
+                .format(gen_indices),
+                v=4
+            )
+        # Circumvent pandas 0.23 bug. Both sides of the assignment have dtype==float32,
+        # but there’s still a dtype error without “.value”.
+        disp_std_bin[one_gene_per_bin.values] = disp_mean_bin[one_gene_per_bin.values].values
+        disp_mean_bin[one_gene_per_bin.values] = 0
+        # actually do the normalization
+        df['dispersions_norm'] = (
+            (
+                df['dispersions'].values  # use values here as index differs
+                - disp_mean_bin[df['mean_bin'].values].values
+            ) / disp_std_bin[df['mean_bin'].values].values
+        )
+    elif flavor == 'cell_ranger':
+        from statsmodels import robust
+        df['mean_bin'] = pd.cut(df['means'], np.r_[
+            -np.inf,
+            np.percentile(df['means'], np.arange(10, 105, 5)),
+            np.inf
+        ])
+        disp_grouped = df.groupby('mean_bin')['dispersions']
+        disp_median_bin = disp_grouped.median()
+        # the next line raises the warning: "Mean of empty slice"
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore')
+            disp_mad_bin = disp_grouped.apply(robust.mad)
+        df['dispersions_norm'] = (
+            np.abs(
+                df['dispersions'].values
+                - disp_median_bin[df['mean_bin'].values].values
+            ) / disp_mad_bin[df['mean_bin'].values].values
+        )
+    else:
+        raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
+    dispersion_norm = df['dispersions_norm'].values.astype('float32')
+    if n_top_genes is not None:
+        dispersion_norm = dispersion_norm[~np.isnan(dispersion_norm)]
+        dispersion_norm[::-1].sort()  # interestingly, np.argpartition is slightly slower
+        disp_cut_off = dispersion_norm[n_top_genes-1]
+        gene_subset = np.nan_to_num(df['dispersions_norm'].values) >= disp_cut_off
+        logg.msg(
+            'the {} top genes correspond to a normalized dispersion cutoff of {}'
+            .format(n_top_genes, disp_cut_off),
+            v=5,
+        )
+    else:
+        dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
+        gene_subset = np.logical_and.reduce((
+            mean > min_mean, mean < max_mean,
+            dispersion_norm > min_disp,
+            dispersion_norm < max_disp,
+        ))
+        print((mean > min_mean).sum())
+        print((mean < max_mean).sum())
+        print((dispersion_norm > min_disp).sum())
+        print((dispersion_norm < max_disp).sum())
+        print(gene_subset.sum())
+
+    df['highly_variable'] = gene_subset
+    print(df.head())
+    return df
+
 def highly_variable_genes(
     adata,
     min_disp=None, max_disp=None,
@@ -92,6 +247,7 @@ def highly_variable_genes(
     -----
     This function replaces :func:`~scanpy.pp.filter_genes_dispersion`.
     """
+
     logg.msg('extracting highly variable genes', r=True, v=4)
 
     if not isinstance(adata, AnnData):
@@ -99,30 +255,27 @@ def highly_variable_genes(
             '`pp.highly_variable_genes` expects an `AnnData` argument, '
             'pass `inplace=False` if you want to return a `np.recarray`.')
 
-    if n_top_genes is not None and not all([
-            min_disp is None, max_disp is None, min_mean is None, max_mean is None]):
-        logg.info('If you pass `n_top_genes`, all cutoffs are ignored.')
-    if min_disp is None: min_disp = 0.5
-    if min_mean is None: min_mean = 0.0125
-    if max_mean is None: max_mean = 3
-    if max_disp is None: max_disp = np.inf
-
-    if batch_key is not None:
+    if batch_key is None:
+        df = _highly_variable_genes_single_batch(adata,
+                                                 min_disp=min_disp, max_disp=min_disp,
+                                                 min_mean=min_mean, max_mean=max_mean,
+                                                 n_top_genes=n_top_genes,
+                                                 n_bins=n_bins,
+                                                 flavor=flavor)
+        print(df)
+        #print(df.highly_variable.sum())
+    else:
         sanitize_anndata(adata)
         batches = adata.obs[batch_key].cat.categories
         df = []
         for batch in batches:
             adata_subset = adata[adata.obs[batch_key] == batch]
-            hvg = highly_variable_genes(adata_subset,
-                                        min_disp=min_disp, max_disp=min_disp,
-                                        min_mean=min_mean, max_mean=max_mean,
-                                        n_top_genes=n_top_genes,
-                                        n_bins=n_bins,
-                                        flavor=flavor,
-                                        inplace=False,
-                                        subset=False,
-                                        batch_key=None)
-            hvg = pd.DataFrame(hvg)
+            hvg = _highly_variable_genes_single_batch(adata_subset,
+                                                      min_disp=min_disp, max_disp=min_disp,
+                                                      min_mean=min_mean, max_mean=max_mean,
+                                                      n_top_genes=n_top_genes,
+                                                      n_bins=n_bins,
+                                                      flavor=flavor)
             hvg['gene'] = adata.var_names.values
             df.append(hvg)
 
@@ -143,7 +296,6 @@ def highly_variable_genes(
             df['highly_variable'] = False
             df.loc[:n_top_genes, 'highly_variable'] = True
             df = df.loc[adata.var_names]
-            gene_subset = df.highly_variable.values
         else:
             df = df.loc[adata.var_names]
             dispersion_norm = df.dispersions_norm.values
@@ -154,88 +306,6 @@ def highly_variable_genes(
                 df.dispersions_norm < max_disp,
             ))
             df['highly_variable'] = gene_subset
-    else:
-        X = np.expm1(adata.X) if flavor == 'seurat' else adata.X
-        mean, var = materialize_as_ndarray(_get_mean_var(X))
-        # now actually compute the dispersion
-        mean[mean == 0] = 1e-12  # set entries equal to zero to small value
-        dispersion = var / mean
-        if flavor == 'seurat':  # logarithmized mean as in Seurat
-            dispersion[dispersion == 0] = np.nan
-            dispersion = np.log(dispersion)
-            mean = np.log1p(mean)
-        # all of the following quantities are "per-gene" here
-        df = pd.DataFrame()
-        df['means'] = mean
-        df['dispersions'] = dispersion
-        if flavor == 'seurat':
-            df['mean_bin'] = pd.cut(df['means'], bins=n_bins)
-            disp_grouped = df.groupby('mean_bin')['dispersions']
-            disp_mean_bin = disp_grouped.mean()
-            disp_std_bin = disp_grouped.std(ddof=1)
-            # retrieve those genes that have nan std, these are the ones where
-            # only a single gene fell in the bin and implicitly set them to have
-            # a normalized disperion of 1
-            one_gene_per_bin = disp_std_bin.isnull()
-            gen_indices = np.where(one_gene_per_bin[df['mean_bin'].values])[0].tolist()
-            if len(gen_indices) > 0:
-                logg.msg(
-                    'Gene indices {} fell into a single bin: their '
-                    'normalized dispersion was set to 1.\n    '
-                    'Decreasing `n_bins` will likely avoid this effect.'
-                    .format(gen_indices),
-                    v=4
-                )
-            # Circumvent pandas 0.23 bug. Both sides of the assignment have dtype==float32,
-            # but there’s still a dtype error without “.value”.
-            disp_std_bin[one_gene_per_bin.values] = disp_mean_bin[one_gene_per_bin.values].values
-            disp_mean_bin[one_gene_per_bin.values] = 0
-            # actually do the normalization
-            df['dispersions_norm'] = (
-                (
-                    df['dispersions'].values  # use values here as index differs
-                    - disp_mean_bin[df['mean_bin'].values].values
-                ) / disp_std_bin[df['mean_bin'].values].values
-            )
-        elif flavor == 'cell_ranger':
-            from statsmodels import robust
-            df['mean_bin'] = pd.cut(df['means'], np.r_[
-                -np.inf,
-                np.percentile(df['means'], np.arange(10, 105, 5)),
-                np.inf
-            ])
-            disp_grouped = df.groupby('mean_bin')['dispersions']
-            disp_median_bin = disp_grouped.median()
-            # the next line raises the warning: "Mean of empty slice"
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore')
-                disp_mad_bin = disp_grouped.apply(robust.mad)
-            df['dispersions_norm'] = (
-                np.abs(
-                    df['dispersions'].values
-                    - disp_median_bin[df['mean_bin'].values].values
-                ) / disp_mad_bin[df['mean_bin'].values].values
-            )
-        else:
-            raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
-        dispersion_norm = df['dispersions_norm'].values.astype('float32')
-        if n_top_genes is not None:
-            dispersion_norm = dispersion_norm[~np.isnan(dispersion_norm)]
-            dispersion_norm[::-1].sort()  # interestingly, np.argpartition is slightly slower
-            disp_cut_off = dispersion_norm[n_top_genes-1]
-            gene_subset = np.nan_to_num(df['dispersions_norm'].values) >= disp_cut_off
-            logg.msg(
-                'the {} top genes correspond to a normalized dispersion cutoff of {}'
-                .format(n_top_genes, disp_cut_off),
-                v=5,
-            )
-        else:
-            dispersion_norm[np.isnan(dispersion_norm)] = 0  # similar to Seurat
-            gene_subset = np.logical_and.reduce((
-                mean > min_mean, mean < max_mean,
-                dispersion_norm > min_disp,
-                dispersion_norm < max_disp,
-            ))
 
     logg.msg('    finished', time=True, v=4)
 
@@ -247,7 +317,7 @@ def highly_variable_genes(
             '    \'dispersions\', float vector (adata.var)\n'
             '    \'dispersions_norm\', float vector (adata.var)'
         )
-        adata.var['highly_variable'] = gene_subset
+        adata.var['highly_variable'] = df['highly_variable'].values
         adata.var['means'] = df['means'].values
         adata.var['dispersions'] = df['dispersions'].values
         adata.var['dispersions_norm'] = df['dispersions_norm'].values.astype('float32', copy=False)
@@ -255,10 +325,10 @@ def highly_variable_genes(
             adata.var['highly_variable_nbatches'] = df['highly_variable_nbatches'].values
             adata.var['highly_variable_intersection'] = df['highly_variable_intersection'].values
         if subset:
-            adata._inplace_subset_var(gene_subset)
+            adata._inplace_subset_var(df['highly_variable'])
     else:
         arrays = [
-             gene_subset,
+             df['highly_variable'].values,
              df['means'].values,
              df['dispersions'].values,
              df['dispersions_norm'].values.astype('float32', copy=False),

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -156,14 +156,8 @@ def _highly_variable_genes_single_batch(
             dispersion_norm > min_disp,
             dispersion_norm < max_disp,
         ))
-        print((mean > min_mean).sum())
-        print((mean < max_mean).sum())
-        print((dispersion_norm > min_disp).sum())
-        print((dispersion_norm < max_disp).sum())
-        print(gene_subset.sum())
 
     df['highly_variable'] = gene_subset
-    print(df.head())
     return df
 
 def highly_variable_genes(
@@ -257,13 +251,11 @@ def highly_variable_genes(
 
     if batch_key is None:
         df = _highly_variable_genes_single_batch(adata,
-                                                 min_disp=min_disp, max_disp=min_disp,
+                                                 min_disp=min_disp, max_disp=max_disp,
                                                  min_mean=min_mean, max_mean=max_mean,
                                                  n_top_genes=n_top_genes,
                                                  n_bins=n_bins,
                                                  flavor=flavor)
-        print(df)
-        #print(df.highly_variable.sum())
     else:
         sanitize_anndata(adata)
         batches = adata.obs[batch_key].cat.categories
@@ -271,7 +263,7 @@ def highly_variable_genes(
         for batch in batches:
             adata_subset = adata[adata.obs[batch_key] == batch]
             hvg = _highly_variable_genes_single_batch(adata_subset,
-                                                      min_disp=min_disp, max_disp=min_disp,
+                                                      min_disp=min_disp, max_disp=max_disp,
                                                       min_mean=min_mean, max_mean=max_mean,
                                                       n_top_genes=n_top_genes,
                                                       n_bins=n_bins,
@@ -325,7 +317,7 @@ def highly_variable_genes(
             adata.var['highly_variable_nbatches'] = df['highly_variable_nbatches'].values
             adata.var['highly_variable_intersection'] = df['highly_variable_intersection'].values
         if subset:
-            adata._inplace_subset_var(df['highly_variable'])
+            adata._inplace_subset_var(df['highly_variable'].values)
     else:
         arrays = [
              df['highly_variable'].values,

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -10,6 +10,14 @@ def test_highly_variable_genes_basic():
     adata = sc.datasets.blobs()
     sc.pp.highly_variable_genes(adata)
 
+    adata = sc.datasets.blobs()
+    sc.pp.highly_variable_genes(adata, batch_key='blobs')
+    assert 'highly_variable_nbatches' in adata.var.columns
+
+    adata = sc.datasets.blobs()
+    sc.pp.highly_variable_genes(adata, batch_key='blobs', n_top_genes=3)
+    assert 'highly_variable_nbatches' in adata.var.columns
+    assert adata.var['highly_variable'].sum() == 3
 
 def test_higly_variable_genes_compare_to_seurat():
     seurat_hvg_info = pd.read_csv(FILE, sep=' ')

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -13,6 +13,7 @@ def test_highly_variable_genes_basic():
     adata = sc.datasets.blobs()
     sc.pp.highly_variable_genes(adata, batch_key='blobs')
     assert 'highly_variable_nbatches' in adata.var.columns
+    assert 'highly_variable_intersection' in adata.var.columns
 
     adata = sc.datasets.blobs()
     sc.pp.highly_variable_genes(adata, batch_key='blobs', n_top_genes=3)


### PR DESCRIPTION
(sorry, I messed up my branch, so sending a new PR)

I added a new batch_key option to HVG function. If specified, it runs the HVG selection in every batch separately and then merges the list in order to reduce the batch effects by avoiding the selection of batch-specific genes. This doesn't fully correct the batch effect but reduces it.

Running the function for each batch is trivial but merging is trickier than I thought. How I do it now is as follows:

- hvg is run on each batch and resulting hvg lists are first concatenated into a single dataframe.
The data frame is grouped by genes. mean, dispersion and normalized dispersion values are aggregated via `np.nanmean`. Two new columns are created 1) "in how many batches a gene is detected as hvg". 2) intersection of all HVGs across batches.

- if n_top_genes is given, combined hvg lists are sorted by 1) in how many batches a gene is detected as hvg 2) normalized dispersion. normalized dispersion is used to break the ties. Then top n genes are selected as the final hvg list.

- if n_top_genes is not given, same mean and dispersion thresholds are applied to the combined hvg list.

Here is the code to see the improvement of this approach:

```python
import scanpy as sc
import numpy as np
import pandas as pd

ad = sc.read("pancreas.h5ad", backup_url="https://goo.gl/V29FNk") # adapted from scGen repo
ad.obs["cell_type"] = ad.obs["celltype"].tolist()

ad = sc.AnnData(ad.raw.X, var=ad.raw.var, obs=ad.obs)
sc.pp.normalize_per_cell(ad)
sc.pp.log1p(ad)

sc.pp.highly_variable_genes(ad, batch_key='batch')
sc.pp.pca(ad)
sc.pp.neighbors(ad)
sc.tl.umap(ad)
sc.pl.umap(ad, color=["batch", "cell_type"])
```