### PR TITLE
Add outline to the legend text in scatterplots

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -9,8 +9,8 @@ from scipy.sparse import issparse
 from matplotlib import pyplot as pl
 from matplotlib import rcParams
 from matplotlib import gridspec
+from matplotlib import patheffects
 from matplotlib.colors import is_color_like
-import matplotlib.patheffects as patheffects
 import seaborn as sns
 
 from .._settings import settings

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -10,6 +10,7 @@ from matplotlib import pyplot as pl
 from matplotlib import rcParams
 from matplotlib import gridspec
 from matplotlib.colors import is_color_like
+import matplotlib.patheffects as patheffects
 import seaborn as sns
 
 from .._settings import settings
@@ -43,6 +44,7 @@ def scatter(
         legend_loc='right margin',
         legend_fontsize=None,
         legend_fontweight=None,
+        legend_fontoutline=None,
         color_map=None,
         palette=None,
         frameon=None,
@@ -102,6 +104,7 @@ def scatter(
             legend_loc=legend_loc,
             legend_fontsize=legend_fontsize,
             legend_fontweight=legend_fontweight,
+            legend_fontoutline=legend_fontoutline,
             color_map=color_map,
             palette=palette,
             frameon=frameon,
@@ -132,6 +135,7 @@ def scatter(
                 legend_loc=legend_loc,
                 legend_fontsize=legend_fontsize,
                 legend_fontweight=legend_fontweight,
+                legend_fontoutline=legend_fontoutline,
                 color_map=color_map,
                 palette=palette,
                 frameon=frameon,
@@ -161,6 +165,7 @@ def scatter(
                 legend_loc=legend_loc,
                 legend_fontsize=legend_fontsize,
                 legend_fontweight=legend_fontweight,
+                legend_fontoutline=legend_fontoutline,
                 color_map=color_map,
                 palette=palette,
                 frameon=frameon,
@@ -195,6 +200,7 @@ def _scatter_var(
         legend_loc='right margin',
         legend_fontsize=None,
         legend_fontweight=None,
+        legend_fontoutline=None,
         color_map=None,
         palette=None,
         frameon=None,
@@ -224,6 +230,7 @@ def _scatter_var(
         legend_loc=legend_loc,
         legend_fontsize=legend_fontsize,
         legend_fontweight=legend_fontweight,
+        legend_fontoutline=legend_fontoutline,
         color_map=color_map,
         palette=palette,
         frameon=frameon,
@@ -257,6 +264,7 @@ def _scatter_obs(
         legend_loc='right margin',
         legend_fontsize=None,
         legend_fontweight=None,
+        legend_fontoutline=None,
         color_map=None,
         palette=None,
         frameon=None,
@@ -455,12 +463,17 @@ def _scatter_obs(
         if legend_loc.startswith('on data'):
             if legend_fontweight is None:
                 legend_fontweight = 'bold'
+            if legend_fontoutline is not None:
+                legend_fontoutline = [patheffects.withStroke(linewidth=legend_fontoutline,
+                                                             foreground='w')]
             for name, pos in centroids.items():
                 axs[ikey].text(pos[0], pos[1], name,
                                weight=legend_fontweight,
                                verticalalignment='center',
                                horizontalalignment='center',
-                               fontsize=legend_fontsize)
+                               fontsize=legend_fontsize,
+                               path_effects=legend_fontoutline)
+
             all_pos = np.zeros((len(adata.obs[key].cat.categories), 2))
             for iname, name in enumerate(adata.obs[key].cat.categories):
                 if name in centroids:

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -58,6 +58,9 @@ legend_fontweight : {'normal', 'bold', ...}, optional (default: `None`)
     Legend font weight. Defaults to 'bold' if `legend_loc == 'on data'`,
     otherwise to 'normal'. Available are `['light', 'normal', 'medium',
     'semibold', 'bold', 'heavy', 'black']`.
+legend_fontoutline
+    Linewidth of the legend font outline. This uses `matplotlib.patheffects` to
+    draw a white outline around the legend text.
 size
     Point size. If `None`, is automatically computed.
 color_map

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -10,6 +10,7 @@ from pandas.api.types import is_categorical_dtype
 from matplotlib import pyplot as pl
 from matplotlib import rcParams
 from matplotlib.colors import is_color_like, Colormap
+import matplotlib.patheffects as patheffects
 
 from .. import _utils as utils
 from .._docs import doc_adata_color_etc, doc_edges_arrows, doc_scatter_bulk, doc_show_save_ax
@@ -42,6 +43,7 @@ def plot_scatter(
     legend_fontsize: Optional[int] = None,
     legend_fontweight: str = 'bold',
     legend_loc: str = 'right margin',
+    legend_fontoutline: Optional[int] = None,
     ncols: int = 4,
     hspace: float = 0.25,
     wspace: Optional[float] = None,
@@ -234,9 +236,14 @@ def plot_scatter(
             # there is not need to plot a legend or a colorbar
             continue
 
+        if legend_fontoutline is not None:
+            legend_fontoutline = [patheffects.withStroke(linewidth=legend_fontoutline,
+                                                         foreground='w')]
+
         _add_legend_or_colorbar(
             adata, ax, cax, categorical, value_to_plot, legend_loc,
-            _data_points, legend_fontweight, legend_fontsize, groups, multi_panel,
+            _data_points, legend_fontweight, legend_fontsize, legend_fontoutline,
+            groups, multi_panel,
         )
 
     if return_fig is True:
@@ -492,7 +499,7 @@ def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndar
 
 def _add_legend_or_colorbar(adata, ax, cax, categorical, value_to_plot, legend_loc,
                             scatter_array, legend_fontweight, legend_fontsize,
-                            groups, multi_panel):
+                            legend_fontoutline, groups, multi_panel):
     """
     Adds a color bar or a legend to the given ax. A legend is added when the
     data is categorical and a color bar is added when a continuous value was used.
@@ -538,7 +545,8 @@ def _add_legend_or_colorbar(adata, ax, cax, categorical, value_to_plot, legend_l
                         weight=legend_fontweight,
                         verticalalignment='center',
                         horizontalalignment='center',
-                        fontsize=legend_fontsize)
+                        fontsize=legend_fontsize,
+                        path_effects=legend_fontoutline)
 
                 all_pos[ilabel] = [x_pos, y_pos]
             # this is temporary storage for access by other tools

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -9,8 +9,8 @@ from matplotlib.figure import Figure
 from pandas.api.types import is_categorical_dtype
 from matplotlib import pyplot as pl
 from matplotlib import rcParams
+from matplotlib import patheffects
 from matplotlib.colors import is_color_like, Colormap
-import matplotlib.patheffects as patheffects
 
 from .. import _utils as utils
 from .._docs import doc_adata_color_etc, doc_edges_arrows, doc_scatter_bulk, doc_show_save_ax


### PR DESCRIPTION
This PR adds support to add an outline around the legend text in scatterplots. Its effect is similar to fontweight='bold' but arguably more elegant and readable.

Before:

`sc.pl.umap(adata, color='paul15_clusters', legend_loc='on data') `

![image](https://user-images.githubusercontent.com/1140359/57564012-448c7600-7373-11e9-8f8f-21385e560739.png)

After:

`sc.pl.umap(adata, color='paul15_clusters', legend_loc='on data', legend_fontoutline=1, legend_fontweight='normal')`

![image](https://user-images.githubusercontent.com/1140359/57564018-62f27180-7373-11e9-96dc-a38bc709fc2b.png)
