### PR TITLE
Use pynndescent dependency to support threaded nearest neighbors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ natsort
 joblib
 numba>=0.41.0
 umap-learn>=0.3.0
+pynndescent>=0.3.0


### PR DESCRIPTION
Pynndescent 0.3.0 was released yesterday with support for multi-threading. This change allows scanpy to take advantage of multi-threading for computing nearest neighbors.

To use it, wrap the call to scanpy in a `joblib.parallel_backend` context manager:

```python
from joblib import parallel_backend
with parallel_backend('threading', n_jobs=16):
        sc.pp.neighbors(adata)
```

Running on the 130K dataset on a 16 core machine before the change:

```
computing neighbors
    using 'X_pca' with n_pcs = 50
    finished (0:01:31.54)
```
 and with the change:

```
computing neighbors
    using 'X_pca' with n_pcs = 50
    finished (0:00:32.02)
```

A threefold speedup.

(Note that there is a small [bug](https://github.com/lmcinnes/pynndescent/pull/58) in pynndescent 0.3.0, which means that `n_jobs` needs to be set explicitly. When that's fixed you'll be able to leave it out to use all cores on a machine.)

