### PR TITLE
Logging overhaul

### DIFF
--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -28,7 +28,7 @@ check_versions()
 del get_versions, check_versions
 
 # the actual API
-from ._settings import settings  # start with settings as several tools are using it
+from ._settings import settings, Verbosity  # start with settings as several tools are using it
 from . import tools as tl
 from . import preprocessing as pp
 from . import plotting as pl

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -2,7 +2,22 @@ import inspect
 import sys
 from pathlib import Path
 from time import time
-from typing import Tuple, Union, Any, List, Iterable, TextIO
+from typing import Tuple, Union, Any, List, Iterable, TextIO, Optional
+
+from . import logging
+from .logging import _set_log_level, _set_log_file, RootLogger
+
+_VERBOSITY_TO_LOGLEVEL = {
+    'error': 'ERROR',
+    'warn': 'WARNING',
+    'info': 'INFO',
+    'hint': 'HINT',
+    'debug': 'DEBUG',
+}
+verbosity_names = list(_VERBOSITY_TO_LOGLEVEL.keys())
+# Python 3.7 ensures iteration order
+for v, level in enumerate(list(_VERBOSITY_TO_LOGLEVEL.values())):
+    _VERBOSITY_TO_LOGLEVEL[v] = level
 
 
 def _type_check(var: Any, varname: str, types: Union[type, Tuple[type, ...]]):
@@ -43,7 +58,11 @@ class ScanpyConfig:
         _vector_friendly: bool = False,
         _low_resolution_warning: bool = True
     ):
+        # logging
+        self._root_logger = RootLogger('INFO')  # level will be replaced
+        self.logfile = logfile
         self.verbosity = verbosity
+        # rest
         self.plot_suffix = plot_suffix
         self.file_format_data = file_format_data
         self.file_format_figs = file_format_figs
@@ -55,7 +74,6 @@ class ScanpyConfig:
         self.figdir = figdir
         self.max_memory = max_memory
         self.n_jobs = n_jobs
-        self.logfile = logfile
         self.categories_to_ignore = categories_to_ignore
         self._frameon = _frameon
         """bool: See set_figure_params."""
@@ -76,6 +94,9 @@ class ScanpyConfig:
         self._previous_memory_usage = -1
         """Stores the previous memory usage."""
 
+        for fn in verbosity_names:
+            setattr(logging, fn, getattr(self._root_logger, fn))
+
     @property
     def verbosity(self) -> int:
         """
@@ -93,7 +114,10 @@ class ScanpyConfig:
 
     @verbosity.setter
     def verbosity(self, verbosity):
-        verbosity_str_options = ["error", "warn", "info", "hint"]
+        verbosity_str_options = [
+            v for v in _VERBOSITY_TO_LOGLEVEL
+            if isinstance(v, str)
+        ]
         if isinstance(verbosity, int):
             self._verbosity = verbosity
         elif isinstance(verbosity, str):
@@ -107,6 +131,8 @@ class ScanpyConfig:
                 self._verbosity = verbosity_str_options.index(verbosity)
         else:
             _type_check(verbosity, "verbosity", (str, int))
+        from .logging import _set_log_level
+        _set_log_level(self, _VERBOSITY_TO_LOGLEVEL[self._verbosity])
 
     @property
     def plot_suffix(self) -> str:
@@ -248,8 +274,22 @@ class ScanpyConfig:
         self._n_jobs = n_jobs
 
     @property
-    def logfile(self) -> Union[Path, TextIO]:
-        """:class:`~pathlib.Path` of logfile or writable object.
+    def logpath(self) -> Optional[Path]:
+        """The file path `logfile` was set to."""
+        return self._logpath
+
+    @logpath.setter
+    def logpath(self, logpath: Union[str, Path, None]):
+        _type_check(logpath, "logfile", (str, Path))
+        self._logpath = Path(logpath)
+        # set via “file object” branch of logfile.setter
+        self.logfile = self._logpath.open('a')
+
+    @property
+    def logfile(self) -> TextIO:
+        """The open file to write logs to.
+
+        Set it to a :class:`~pathlib.Path` or :class:`str: to open a new one.
         The default `None` corresponds to :obj:`sys.stdout` in jupyter notebooks
         and to :obj:`sys.stderr` otherwise.
         
@@ -259,9 +299,15 @@ class ScanpyConfig:
 
     @logfile.setter
     def logfile(self, logfile: Union[str, Path, TextIO, None]):
-        _type_check(logfile, "logfile", (str, Path, type(None)))
-        stream = sys.stdout if self._is_run_from_ipython() else sys.stderr
-        self._logfile = Path(logfile) if logfile else stream
+        if not hasattr(logfile, 'write') and logfile:
+            self.logpath = logfile
+        else:  # file object
+            if not logfile:  # None or ''
+                logfile = sys.stdout if self._is_run_from_ipython() else sys.stderr
+            self._logfile = logfile
+            self._logpath = None
+            from .logging import _set_log_file
+            _set_log_file(self)
 
     @property
     def categories_to_ignore(self) -> List[str]:

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -1,5 +1,6 @@
 import inspect
 import sys
+from enum import IntEnum
 from pathlib import Path
 from time import time
 from typing import Tuple, Union, Any, List, Iterable, TextIO, Optional
@@ -18,6 +19,14 @@ verbosity_names = list(_VERBOSITY_TO_LOGLEVEL.keys())
 # Python 3.7 ensures iteration order
 for v, level in enumerate(list(_VERBOSITY_TO_LOGLEVEL.values())):
     _VERBOSITY_TO_LOGLEVEL[v] = level
+
+
+class Verbosity(IntEnum):
+    error = 0
+    warn = 1
+    info = 2
+    hint = 3
+    debug = 4
 
 
 def _type_check(var: Any, varname: str, types: Union[type, Tuple[type, ...]]):
@@ -98,7 +107,7 @@ class ScanpyConfig:
             setattr(logging, fn, getattr(self._root_logger, fn))
 
     @property
-    def verbosity(self) -> int:
+    def verbosity(self) -> Verbosity:
         """
         Set global verbosity level.
 
@@ -106,20 +115,20 @@ class ScanpyConfig:
         Level 1: also show 'warn' messages.
         Level 2: also show 'info' messages.
         Level 3: also show 'hint' messages.
-        Level 4: also show very detailed progress.
-        Level 5: also show even more detailed progress.
-        etc.
+        Level 4: also show very detailed progress for 'debug'ging.
         """
         return self._verbosity
 
     @verbosity.setter
-    def verbosity(self, verbosity):
+    def verbosity(self, verbosity: Union[Verbosity, int, str]):
         verbosity_str_options = [
             v for v in _VERBOSITY_TO_LOGLEVEL
             if isinstance(v, str)
         ]
-        if isinstance(verbosity, int):
+        if isinstance(verbosity, Verbosity):
             self._verbosity = verbosity
+        elif isinstance(verbosity, int):
+            self._verbosity = Verbosity(verbosity)
         elif isinstance(verbosity, str):
             verbosity = verbosity.lower()
             if verbosity not in verbosity_str_options:
@@ -128,7 +137,7 @@ class ScanpyConfig:
                     f"Accepted string values are: {verbosity_str_options}"
                 )
             else:
-                self._verbosity = verbosity_str_options.index(verbosity)
+                self._verbosity = Verbosity(verbosity_str_options.index(verbosity))
         else:
             _type_check(verbosity, "verbosity", (str, int))
         from .logging import _set_log_level
@@ -281,9 +290,9 @@ class ScanpyConfig:
     @logpath.setter
     def logpath(self, logpath: Union[str, Path, None]):
         _type_check(logpath, "logfile", (str, Path))
-        self._logpath = Path(logpath)
         # set via “file object” branch of logfile.setter
-        self.logfile = self._logpath.open('a')
+        self.logfile = Path(logpath).open('a')
+        self._logpath = Path(logpath)
 
     @property
     def logfile(self) -> TextIO:
@@ -292,7 +301,7 @@ class ScanpyConfig:
         Set it to a :class:`~pathlib.Path` or :class:`str: to open a new one.
         The default `None` corresponds to :obj:`sys.stdout` in jupyter notebooks
         and to :obj:`sys.stderr` otherwise.
-        
+
         For backwards compatibility, setting it to `''` behaves like setting it to `None`.
         """
         return self._logfile

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -10,7 +10,7 @@ from .logging import _set_log_level, _set_log_file, RootLogger
 
 _VERBOSITY_TO_LOGLEVEL = {
     'error': 'ERROR',
-    'warn': 'WARNING',
+    'warning': 'WARNING',
     'info': 'INFO',
     'hint': 'HINT',
     'debug': 'DEBUG',
@@ -49,7 +49,7 @@ class ScanpyConfig:
     def __init__(
         self,
         *,
-        verbosity: str = "warn",
+        verbosity: str = "warning",
         plot_suffix: str = "",
         file_format_data: str = "h5ad",
         file_format_figs: str = "pdf",
@@ -112,7 +112,7 @@ class ScanpyConfig:
         Set global verbosity level.
 
         Level 0: only show 'error' messages.
-        Level 1: also show 'warn' messages.
+        Level 1: also show 'warning' messages.
         Level 2: also show 'info' messages.
         Level 3: also show 'hint' messages.
         Level 4: also show very detailed progress for 'debug'ging.

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -59,7 +59,7 @@ class ScanpyConfig:
         _low_resolution_warning: bool = True
     ):
         # logging
-        self._root_logger = RootLogger('INFO')  # level will be replaced
+        self._root_logger = RootLogger(logging.INFO)  # level will be replaced
         self.logfile = logfile
         self.verbosity = verbosity
         # rest

--- a/scanpy/datasets/__init__.py
+++ b/scanpy/datasets/__init__.py
@@ -139,7 +139,7 @@ def paul15() -> AnnData:
     -------
     Annotated data matrix.
     """
-    logg.warn(
+    logg.warning(
         'In Scanpy 0.*, this returned logarithmized data. '
         'Now it returns non-logarithmized data.'
     )

--- a/scanpy/datasets/__init__.py
+++ b/scanpy/datasets/__init__.py
@@ -139,8 +139,10 @@ def paul15() -> AnnData:
     -------
     Annotated data matrix.
     """
-    logg.warn('In Scanpy 0.*, this returned logarithmized data. '
-              'Now it returns non-logarithmized data.')
+    logg.warn(
+        'In Scanpy 0.*, this returned logarithmized data. '
+        'Now it returns non-logarithmized data.'
+    )
     import h5py
     filename = settings.datasetdir / 'paul15/paul15.h5'
     backup_url = 'http://falexwolf.de/data/paul15.h5'

--- a/scanpy/external/_tools/_palantir.py
+++ b/scanpy/external/_tools/_palantir.py
@@ -133,7 +133,7 @@ def palantir(adata: AnnData):
 
     """
 
-    logg.info('Palantir diffusion maps', r=True)
+    logg.info('Palantir diffusion maps')
 
     class _wrapper_cls(object):
         """
@@ -185,12 +185,11 @@ def palantir(adata: AnnData):
                 self.data_df = self.adata.to_df()
             except AttributeError:
                 # assume the data is a cell X genes Dataframe
-                logg.info('Assuming the data is a cell X genes Dataframe',
-                	      r=True)
+                logg.info('Assuming the data is a cell X genes Dataframe')
 
             # load palantir
             self.__call__()
-            logg.info('palantir loaded ...', r=True)
+            logg.info('palantir loaded ...')
 
         def __call__(self):
             """
@@ -206,7 +205,7 @@ def palantir(adata: AnnData):
             """
 
             # Principal component analysis
-            logg.info('PCA in progress ...', r=True)
+            logg.info('PCA in progress ...')
 
             self.pca_projections, self.var_r = self.palantir.utils.run_pca(self.data_df)
 
@@ -215,7 +214,7 @@ def palantir(adata: AnnData):
             adata.uns['palantir_pca_results']['variance_ratio'] = self.var_r
 
             # Diffusion maps
-            logg.info('Diffusion maps in progress ...', r=True)
+            logg.info('Diffusion maps in progress ...')
 
             self.dm_res = self.palantir.utils.run_diffusion_maps(self.pca_projections)
             self.ms_data = self.palantir.utils.determine_multiscale_space(self.dm_res)
@@ -224,20 +223,20 @@ def palantir(adata: AnnData):
             adata.uns['palantir_ms_data'] = self.ms_data
 
             # tSNE visualization
-            logg.info('tSNE in progress ...', r=True)
+            logg.info('tSNE in progress ...')
 
             self.tsne = self.palantir.utils.run_tsne(self.ms_data)
 
             adata.uns['palantir_tsne'] = self.tsne
 
             # MAGIC imputation
-            logg.info('imputation in progress ...', r=True)
+            logg.info('imputation in progress ...')
 
             self.imp_df = self.palantir.utils.run_magic_imputation(self.data_df, self.dm_res)
 
             adata.uns['palantir_imp_df'] = self.imp_df
 
-            logg.info('End of processing, start plotting.', r=True)
+            logg.info('End of processing, start plotting.')
 
         @property
         def normalize(self):
@@ -247,7 +246,7 @@ def palantir(adata: AnnData):
             if value is True:
                 self.data_df = self.palantir.preprocess.normalize_counts(self.data_df)
                 adata.uns['palantir_norm_data'] = self.data_df
-                logg.info('data normalized ...', r=True)
+                logg.info('data normalized ...')
 
         @property
         def log_transform(self):
@@ -257,7 +256,7 @@ def palantir(adata: AnnData):
             if value is True:
                 self.data_df = self.palantir.preprocess.log_transform(self.data_df)
                 adata.uns['palantir_norm_data'] = self.data_df
-                logg.info('data log transformed ...', r=True)
+                logg.info('data log transformed ...')
 
         @property
         def filter_low(self):
@@ -267,9 +266,11 @@ def palantir(adata: AnnData):
             if value is True:
                 self.data_df = self.palantir.preprocess.filter_counts_data(self.data_df)
                 adata.uns['palantir_norm_data'] = self.data_df
-                logg.info('data filtered for low counts:\n\t' +\
-                          'cell_min_molecules=1000\n\tgenes_min_cells=10',
-                          r=True)
+                logg.info(
+                    'data filtered for low counts:\n'
+                    '\tcell_min_molecules=1000\n'
+                    '\tgenes_min_cells=10'
+                )
 
 
     def wrapper_cls(adata, func=None):

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -74,12 +74,14 @@ class LogFormatter(logging.Formatter):
 
     def format(self, record: logging.LogRecord):
         format_orig = self._style._fmt
-        if record.levelno == logging.INFO:
+        if record.levelno == INFO:
             self._style._fmt = '{asctime} | {message}'
             if '{time_passed}' not in record.msg and record.time_passed:
                 self._style._fmt += ' ({time_passed})'
-        if record.levelno == logging.DEBUG:
-            self._style._fmt = '{message}'
+        elif record.levelno == HINT:
+            self._style._fmt = '--> {message}'
+        elif record.levelno == DEBUG:
+            self._style._fmt = '    {message}'
         result = logging.Formatter.format(self, record)
         self._style._fmt = format_orig
         return result

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -3,7 +3,7 @@
 import logging
 import time as time_
 from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import anndata.logging
 
@@ -36,8 +36,9 @@ class RootLogger(logging.RootLogger):
         current_time = time_.time()
         time_passed = None
         if time:
-            time_passed = time_.strftime('%H:%M:%S', time_.gmtime(current_time - self.last_time))
+            time_passed = timedelta(seconds=current_time - self.last_time)
         self.log(INFO, msg, time_passed=time_passed, deep=deep, extra=extra)
+        # Always reset on info calls. TODO: Maybe change to a kwarg?
         self.last_time = time_.time()
 
     def hint(self, msg, *, deep=None, extra=None):

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -1,14 +1,14 @@
 """Logging and Profiling
 """
 import logging
-import time
+import time as time_
 from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
 from datetime import datetime
 
 import anndata.logging
 
 
-HINT = (INFO + DEBUG) / 2
+HINT = (INFO + DEBUG) // 2
 logging.addLevelName(HINT, 'HINT')
 
 
@@ -16,9 +16,35 @@ class RootLogger(logging.RootLogger):
     def __init__(self, level):
         super().__init__(level)
         self.propagate = False
+        self.last_time = time_.time()
 
-    def hint(self, msg, *args, **kwargs):
-        return self.log(HINT, msg, *args, **kwargs)
+    def log(self, level, msg, *, extra=None, deep=None, time_passed=None):
+        extra = {
+            **(extra or {}),
+            'deep': deep,
+            'time_passed': time_passed,
+        }
+        super().log(level, msg, extra=extra)
+
+    def error(self, msg, *, deep=None, extra=None):
+        self.log(ERROR, msg, deep=deep, extra=extra)
+
+    def warning(self, msg, *, deep=None, extra=None):
+        self.log(WARNING, msg, deep=deep, extra=extra)
+
+    def info(self, msg, *, time=False, deep=None, extra=None):
+        current_time = time_.time()
+        time_passed = None
+        if time:
+            time_passed = time_.strftime('%H:%M:%S', time_.gmtime(current_time - self.last_time))
+        self.log(INFO, msg, time_passed=time_passed, deep=deep, extra=extra)
+        self.last_time = time_.time()
+
+    def hint(self, msg, *, deep=None, extra=None):
+        self.log(HINT, msg, deep=deep, extra=extra)
+
+    def debug(self, msg, *, deep=None, extra=None):
+        self.log(DEBUG, msg, deep=deep, extra=extra)
 
 
 def _set_log_file(settings):
@@ -43,23 +69,17 @@ def _set_log_level(settings, level: int):
 
 
 class LogFormatter(logging.Formatter):
-    def __init__(self, fmt='%(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M', style='%', passed_time=False):
+    def __init__(self, fmt='{levelname}: {message}', datefmt='%Y-%m-%d %H:%M', style='{'):
         super().__init__(fmt, datefmt, style)
-        self.passed_time = passed_time
-        self.last_time = time.time()
 
     def format(self, record: logging.LogRecord):
         format_orig = self._style._fmt
         if record.levelno == logging.INFO:
-            current_time = time.time()
-            passed_time_str = time.strftime('%H:%M:%S', time.gmtime(current_time - self.last_time))
-            if self.passed_time:
-                self._style._fmt = passed_time_str + ' - %(message)s'
-            else:
-                self._style._fmt = f'%(asctime)s | {passed_time_str} - %(message)s'
-            self.last_time = time.time()
+            self._style._fmt = '{asctime} | {message}'
+            if '{time_passed}' not in record.msg and record.time_passed:
+                self._style._fmt += ' ({time_passed})'
         if record.levelno == logging.DEBUG:
-            self._style._fmt = '%(message)s'
+            self._style._fmt = '{message}'
         result = logging.Formatter.format(self, record)
         self._style._fmt = format_orig
         return result
@@ -120,8 +140,8 @@ def print_version_and_date():
 
 
 # will be replaced in settings
-def error(msg, *args, **kwargs): pass
-def warn(msg, *args, **kwargs): pass
-def info(msg, *args, **kwargs): pass
-def hint(msg, *args, **kwargs): pass
-def debug(msg, *args, **kwargs): pass
+def error(msg, *, deep=None): pass
+def warn(msg, *, deep=None): pass
+def info(msg, *, deep=None, time=False): pass
+def hint(msg, *, deep=None): pass
+def debug(msg, *, deep=None): pass

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -150,8 +150,8 @@ def print_version_and_date():
 
 
 # will be replaced in settings
-def error(msg, *, time=None, deep=None, extra=None) -> datetime: pass
-def warning(msg, *, time=None, deep=None, extra=None) -> datetime: pass
-def info(msg, *, time=None, deep=None, extra=None) -> datetime: pass
-def hint(msg, *, time=None, deep=None, extra=None) -> datetime: pass
-def debug(msg, *, time=None, deep=None, extra=None) -> datetime: pass
+def error(msg, *, time=None, deep=None, extra=None) -> datetime: return datetime.now()
+def warning(msg, *, time=None, deep=None, extra=None) -> datetime: return datetime.now()
+def info(msg, *, time=None, deep=None, extra=None) -> datetime: return datetime.now()
+def hint(msg, *, time=None, deep=None, extra=None) -> datetime: return datetime.now()
+def debug(msg, *, time=None, deep=None, extra=None) -> datetime: return datetime.now()

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -152,11 +152,10 @@ _DEPENDENCIES_PLOTTING = ['matplotlib', 'seaborn']
 def _versions_dependencies(dependencies):
     # this is not the same as the requirements!
     for mod in dependencies:
-        mod_name = mod[0] if isinstance(mod, tuple) else mod
-        mod_install = mod[1] if isinstance(mod, tuple) else mod
+        mod_name, dist_name = mod if isinstance(mod, tuple) else (mod, mod)
         try:
             imp = __import__(mod_name)
-            yield mod_install, imp.__version__
+            yield dist_name, imp.__version__
         except (ImportError, AttributeError):
             pass
 

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -143,7 +143,7 @@ def print_version_and_date():
 
 # will be replaced in settings
 def error(msg, *, deep=None): pass
-def warn(msg, *, deep=None): pass
+def warning(msg, *, deep=None): pass
 def info(msg, *, deep=None, time=False): pass
 def hint(msg, *, deep=None): pass
 def debug(msg, *, deep=None): pass

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -1,136 +1,72 @@
 """Logging and Profiling
 """
+import logging
+import time
+from logging import CRITICAL, ERROR, WARNING, INFO, DEBUG, NOTSET
+from datetime import datetime
 
-import time as time_module
-from datetime import timedelta, datetime
-from typing import Union
-
-from anndata import logging
-from ._settings import settings
-
-
-_VERBOSITY_LEVELS_FROM_STRINGS = {
-    'error': 0,
-    'warn': 1,
-    'info': 2,
-    'hint': 3,
-    'debug': 4,
-}
+import anndata.logging
 
 
-def info(*args, **kwargs):
-    return _msg(*args, v='info', **kwargs)
+HINT = (INFO + DEBUG) / 2
+logging.addLevelName(HINT, 'HINT')
 
 
-def error(*args, **kwargs):
-    args = ('Error:',) + args
-    return _msg(*args, v='error', **kwargs)
+class RootLogger(logging.RootLogger):
+    def __init__(self, level):
+        super().__init__(level)
+        self.propagate = False
+
+    def hint(self, msg, *args, **kwargs):
+        return self.log(HINT, msg, *args, **kwargs)
 
 
-def warn(*args, **kwargs):
-    args = ('WARNING:',) + args
-    return _msg(*args, v='warn', **kwargs)
+def _set_log_file(settings):
+    file = settings.logfile
+    name = settings.logpath
+    root = settings._root_logger
+    h = logging.StreamHandler(file) if name is None else logging.FileHandler(name)
+    h.setFormatter(LogFormatter())
+    h.setLevel(root.level)
+    if len(root.handlers) == 1:
+        root.removeHandler(root.handlers[0])
+    elif len(root.handlers) > 1:
+        raise RuntimeError('Scanpy’s root logger somehow got more than one handler')
+    root.addHandler(h)
 
 
-def hint(*args, **kwargs):
-    return _msg(*args, v='hint', **kwargs)
+def _set_log_level(settings, level: int):
+    root = settings._root_logger
+    root.setLevel(level)
+    h, = root.handlers  # may only be 1
+    h.setLevel(level)
 
 
-def debug(*args, **kwargs):
-    return _msg(*args, v='debug', **kwargs)
+class LogFormatter(logging.Formatter):
+    def __init__(self, fmt='%(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M', style='%', passed_time=False):
+        super().__init__(fmt, datefmt, style)
+        self.passed_time = passed_time
+        self.last_time = time.time()
+
+    def format(self, record: logging.LogRecord):
+        format_orig = self._style._fmt
+        if record.levelno == logging.INFO:
+            current_time = time.time()
+            passed_time_str = time.strftime('%H:%M:%S', time.gmtime(current_time - self.last_time))
+            if self.passed_time:
+                self._style._fmt = passed_time_str + ' - %(message)s'
+            else:
+                self._style._fmt = f'%(asctime)s | {passed_time_str} - %(message)s'
+            self.last_time = time.time()
+        if record.levelno == logging.DEBUG:
+            self._style._fmt = '%(message)s'
+        result = logging.Formatter.format(self, record)
+        self._style._fmt = format_orig
+        return result
 
 
-def _settings_verbosity_greater_or_equal_than(v):
-    if isinstance(settings.verbosity, str):
-        settings_v = _VERBOSITY_LEVELS_FROM_STRINGS[settings.verbosity]
-    else:
-        settings_v = settings.verbosity
-    return settings_v >= v
-
-
-def _msg(
-    *msg,
-    v: Union[str, int],
-    time: bool = False,
-    reset: bool = False,
-    end: str = '\n',
-    no_indent: bool = False,
-    t: bool = None,
-    r: bool = None,
-):
-    """Write message to logging output.
-
-    Log output defaults to standard output but can be set to a file
-    by setting `sc.settings.log_file = 'mylogfile.txt'`.
-
-    v : {'error', 'warn', 'info', 'hint'} or int
-        0/'error', 1/'warn', 2/'info', 3/'hint', 4/'debug'
-    time, t
-        Print timing information; restart the clock.
-    reset, r
-        Reset timing and memory measurement. Is automatically reset
-        when passing one of ``time`` or ``memory``.
-    end
-        Same meaning as in builtin ``print()`` function.
-    no_indent
-        Do not indent for ``v >= 4``.
-    """
-    # variable shortcuts
-    if t is not None: time = t
-    if r is not None: reset = r
-    if isinstance(v, str):
-        v = _VERBOSITY_LEVELS_FROM_STRINGS[v]
-    if v == 3:  # insert "--> " before hints
-        msg = ('-->',) + msg
-    if v >= 4 and not no_indent:
-        msg = ('   ',) + msg
-    if _settings_verbosity_greater_or_equal_than(v):
-        if not time and len(msg) > 0:
-            _write_log(*msg, end=end)
-        if reset:
-            try:
-                settings._previous_memory_usage, _ = get_memory_usage()
-            except:
-                pass
-            settings._previous_time = time_module.time()
-        if time:
-            elapsed = get_passed_time()
-            msg = msg + (f'({timedelta(seconds=elapsed)})',)
-            _write_log(*msg, end=end)
-
-
-def _write_log(*msg, end='\n'):
-    """Write message to log output, ignoring the verbosity level.
-
-    This is the most basic function.
-
-    Parameters
-    ----------
-    *msg :
-        One or more arguments to be formatted as string. Same behavior as print
-        function.
-    """
-    out = ' '.join(map(str, msg))
-    if hasattr(settings.logfile, 'open'):
-        with settings.logfile.open('a') as f:
-            f.write(out + end)
-    elif hasattr(settings.logfile, 'write'):
-        settings.logfile.write(out + end)
-    else:
-        raise TypeError(f'settings.logfile of unknown type {type(settings.logfile)}')
-
-
-print_memory_usage = logging.print_memory_usage
-
-
-get_memory_usage = logging.get_memory_usage
-
-
-def get_passed_time():
-    now = time_module.time()
-    elapsed = now - settings._previous_time
-    settings._previous_time = now
-    return elapsed
+print_memory_usage = anndata.logging.print_memory_usage
+get_memory_usage = anndata.logging.get_memory_usage
 
 
 _DEPENDENCIES_NUMERICS = [
@@ -165,13 +101,27 @@ def print_versions():
 
     Matplotlib and Seaborn are excluded from this.
     """
+    from ._settings import settings
     modules = ['scanpy'] + _DEPENDENCIES_NUMERICS
-    _write_log(' '.join(
+    print(' '.join(
         f'{mod}=={ver}'
         for mod, ver in _versions_dependencies(modules)
-    ))
+    ), file=settings.logfile)
 
 
 def print_version_and_date():
     from . import __version__
-    _write_log(f'Running Scanpy {__version__}, on {datetime.now():%Y-%m-%d %H:%M}.')
+    from ._settings import settings
+    print(
+        f'Running Scanpy {__version__}, '
+        f'on {datetime.now():%Y-%m-%d %H:%M}.',
+        file=settings.logfile,
+    )
+
+
+# will be replaced in settings
+def error(msg, *args, **kwargs): pass
+def warn(msg, *args, **kwargs): pass
+def info(msg, *args, **kwargs): pass
+def hint(msg, *args, **kwargs): pass
+def debug(msg, *args, **kwargs): pass

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -639,13 +639,13 @@ class Neighbors:
         logg.info('Computing neighbors')
         if n_neighbors > self._adata.shape[0]:  # very small datasets
             n_neighbors = 1 + int(0.5*self._adata.shape[0])
-            logg.warn(f'n_obs too small: adjusting to `n_neighbors = {n_neighbors}`')
+            logg.warning(f'n_obs too small: adjusting to `n_neighbors = {n_neighbors}`')
         if method == 'umap' and not knn:
             raise ValueError('`method = \'umap\' only with `knn = True`.')
         if method not in {'umap', 'gauss'}:
             raise ValueError('`method` needs to be \'umap\' or \'gauss\'.')
         if self._adata.shape[0] >= 10000 and not knn:
-            logg.warn('Using high n_obs without `knn=True` takes a lot of memory...')
+            logg.warning('Using high n_obs without `knn=True` takes a lot of memory...')
         self.n_neighbors = n_neighbors
         self.knn = knn
         X = choose_representation(self._adata, use_rep=use_rep, n_pcs=n_pcs)
@@ -847,7 +847,7 @@ class Neighbors:
         logg.info('    eigenvalues of transition matrix\n'
                   '    {}'.format(str(evals).replace('\n', '\n    ')))
         if self._number_connected_components > len(evals)/2:
-            logg.warn('Transition matrix has many disconnected components!')
+            logg.warning('Transition matrix has many disconnected components!')
         self._eigen_values = evals
         self._eigen_basis = evecs
 
@@ -856,7 +856,7 @@ class Neighbors:
         # set iroot directly
         if 'iroot' in self._adata.uns:
             if self._adata.uns['iroot'] >= self._adata.n_obs:
-                logg.warn(
+                logg.warning(
                     f'Root cell index {self._adata.uns["iroot"]} does not '
                     f'exist for {self._adata.n_obs} samples. It’s ignored.'
                 )
@@ -933,5 +933,5 @@ class Neighbors:
                 if np.sqrt(dsqroot) < 1e-10: break
         logg.debug(f'setting root index to {iroot}')
         if self.iroot is not None and iroot != self.iroot:
-            logg.warn(f'Changing index of iroot from {self.iroot} to {iroot}.')
+            logg.warning(f'Changing index of iroot from {self.iroot} to {iroot}.')
         self.iroot = iroot

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -11,7 +11,6 @@ from sklearn.utils import check_random_state
 from .. import logging as logg
 from .. import utils
 from ..utils import doc_params
-from ..logging import _settings_verbosity_greater_or_equal_than
 from ..tools._utils import choose_representation, doc_use_rep, doc_n_pcs
 
 N_DCS = 15  # default number of diffusion components

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -84,7 +84,7 @@ def neighbors(
         Instead of decaying weights, this stores distances for each pair of
         neighbors.
     """
-    logg.info('computing neighbors')
+    start = logg.info('computing neighbors')
     adata = adata.copy() if copy else adata
     if adata.isview:  # we shouldn't need this here...
         adata._init_as_actual(adata.copy())
@@ -109,7 +109,7 @@ def neighbors(
         adata.uns['neighbors']['rp_forest'] = neighbors.rp_forest
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added to `.uns[\'neighbors\']`\n'
             '    \'distances\', distances for each pair of neighbors\n'
@@ -636,7 +636,7 @@ class Neighbors:
         Also writes `.knn_indices` and `.knn_distances` if
         `write_knn_indices==True`.
         """
-        logg.info('Computing neighbors')
+        start_neighbors = logg.info('Computing neighbors')
         if n_neighbors > self._adata.shape[0]:  # very small datasets
             n_neighbors = 1 + int(0.5*self._adata.shape[0])
             logg.warning(f'n_obs too small: adjusting to `n_neighbors = {n_neighbors}`')
@@ -672,7 +672,7 @@ class Neighbors:
         if write_knn_indices:
             self.knn_indices = knn_indices
             self.knn_distances = knn_distances
-        logg.info('computed neighbors', time=True)
+        start_connect = logg.info('computed neighbors', time=start_neighbors)
         if not use_dense_distances or method == 'umap':
             # we need self._distances also for method == 'gauss' if we didn't
             # use dense distances
@@ -686,7 +686,7 @@ class Neighbors:
         # self._distances is unaffected by this
         if method == 'gauss':
             self._compute_connectivities_diffmap()
-        logg.info('computed connectivities', time=True)
+        logg.info('computed connectivities', time=start_connect)
         self._number_connected_components = 1
         if issparse(self._connectivities):
             from scipy.sparse.csgraph import connected_components
@@ -771,7 +771,7 @@ class Neighbors:
         -------
         Makes attributes `.transitions_sym` and `.transitions` available.
         """
-        logg.info('Computing transitions')
+        start = logg.info('Computing transitions')
         W = self._connectivities
         # density normalization as of Coifman et al. (2005)
         # ensures that kernel matrix is independent of sampling density
@@ -794,7 +794,7 @@ class Neighbors:
         else:
             self.Z = scipy.sparse.spdiags(1.0/z, 0, K.shape[0], K.shape[0])
         self._transitions_sym = self.Z @ K @ self.Z
-        logg.info('computed transitions', time=True)
+        logg.info('computed transitions', time=start)
 
     def compute_eigen(self, n_comps=15, sym=None, sort='decrease'):
         """Compute eigen decomposition of transition matrix.

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -482,7 +482,7 @@ def _scatter_obs(
             utils._tmp_cluster_pos = all_pos
             if legend_loc == 'on data export':
                 filename = settings.writedir / 'pos.csv'
-                logg.warn(f'exporting label positions to {filename}')
+                logg.warning(f'exporting label positions to {filename}')
                 settings.writedir.mkdir(parents=True, exist_ok=True)
                 np.savetxt(filename, all_pos, delimiter=',')
         elif legend_loc == 'right margin':
@@ -851,7 +851,7 @@ def stacked_violin(adata, var_names, groupby=None, log=False, use_raw=None, num_
     elif standard_scale is None:
         pass
     else:
-        logg.warn('Unknown type for standard_scale, ignored')
+        logg.warning('Unknown type for standard_scale, ignored')
 
     if 'color' in kwds:
         row_palette = kwds['color']
@@ -1148,7 +1148,7 @@ def heatmap(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     elif standard_scale is None:
         pass
     else:
-        logg.warn('Unknown type for standard_scale, ignored')
+        logg.warning('Unknown type for standard_scale, ignored')
 
     if groupby is None or len(categories) <= 1:
         categorical = False
@@ -1188,7 +1188,7 @@ def heatmap(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
             show_gene_labels = True
         else:
             show_gene_labels = False
-            logg.warn(
+            logg.warning(
                 'Gene labels are not shown when more than 50 genes are visualized. '
                 'To show gene labels set `show_gene_labels=True`'
             )
@@ -1455,7 +1455,7 @@ def dotplot(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
     elif standard_scale is None:
         pass
     else:
-        logg.warn('Unknown type for standard_scale, ignored')
+        logg.warning('Unknown type for standard_scale, ignored')
 
     dendro_width = 0.8 if dendrogram else 0
     colorbar_width = 0.2
@@ -1723,7 +1723,7 @@ def matrixplot(adata, var_names, groupby=None, use_raw=None, log=False, num_cate
     elif standard_scale is None:
         pass
     else:
-        logg.warn('Unknown type for standard_scale, ignored')
+        logg.warning('Unknown type for standard_scale, ignored')
 
     if dendrogram:
         dendro_data = _reorder_categories_after_dendrogram(adata, groupby, dendrogram,
@@ -2492,7 +2492,7 @@ def _reorder_categories_after_dendrogram(adata, groupby, dendrogram,
             var_group_labels = labels_ordered
             var_group_positions = positions_ordered
         else:
-            logg.warn(
+            logg.warning(
                 "Groups are not reordered because the `groupby` categories "
                 "and the `var_group_labels` are different.\n"
                 f"categories: {_format_first_three_categories(categories)}\n"
@@ -2524,7 +2524,7 @@ def _get_dendrogram_key(adata, dendrogram_key, groupby):
 
     if dendrogram_key not in adata.uns:
         from ..tools._dendrogram import dendrogram
-        logg.warn(
+        logg.warning(
             f"dendrogram data not found (using key={dendrogram_key}). Running `sc.tl.dendrogram` "
             "with default parameters. For fine tuning it is recommended to run `sc.tl.dendrogram` "
             "independently."
@@ -2601,7 +2601,7 @@ def _plot_dendrogram(dendro_ax, adata, groupby, dendrogram_key=None, orientation
     orig_ticks = np.arange(5, len(leaves) * 10 + 5, 10).astype(float)
     # check that ticks has the same length as orig_ticks
     if ticks is not None and len(orig_ticks) != len(ticks):
-        logg.warn("ticks argument does not have the same size as orig_ticks. The argument will be ignored")
+        logg.warning("ticks argument does not have the same size as orig_ticks. The argument will be ignored")
         ticks = None
 
     for xs, ys in zip(icoord, dcoord):
@@ -2775,7 +2775,7 @@ def _check_var_names_type(var_names, var_group_labels, var_group_positions):
 
     if isinstance(var_names, Mapping):
         if var_group_labels is not None or var_group_positions is not None:
-            logg.warn(
+            logg.warning(
                 "`var_names` is a dictionary. This will reset the current value of "
                 "`var_group_labels` and `var_group_positions`."
             )

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1188,8 +1188,10 @@ def heatmap(adata, var_names, groupby=None, use_raw=None, log=False, num_categor
             show_gene_labels = True
         else:
             show_gene_labels = False
-            logg.warn('Gene labels are not shown when more than 50 genes are visualized. To show '
-                      'gene labels set `show_gene_labels=True`')
+            logg.warn(
+                'Gene labels are not shown when more than 50 genes are visualized. '
+                'To show gene labels set `show_gene_labels=True`'
+            )
     if categorical:
         obs_tidy = obs_tidy.sort_index()
 
@@ -2267,7 +2269,7 @@ def _prepare_dataframe(adata, var_names, groupby=None, use_raw=None, log=False,
         translated_var_names = []
         for symbol in var_names:
             if symbol not in adata.var[gene_symbols].values:
-                logg.error("Gene symbol {!r} not found in given gene_symbols column: {!r}".format(symbol, gene_symbols))
+                logg.error(f"Gene symbol {symbol!r} not found in given gene_symbols column: {gene_symbols!r}")
                 return
             translated_var_names.append(adata.var[adata.var[gene_symbols] == symbol].index[0])
         symbols = var_names
@@ -2490,11 +2492,12 @@ def _reorder_categories_after_dendrogram(adata, groupby, dendrogram,
             var_group_labels = labels_ordered
             var_group_positions = positions_ordered
         else:
-            logg.warn("Groups are not reordered because the `groupby` categories "
-                      "and the `var_group_labels` are different.\n"
-                      "categories: {}\nvar_group_labels: {}".format(
-                        _format_first_three_categories(categories),
-                        _format_first_three_categories(var_group_labels)))
+            logg.warn(
+                "Groups are not reordered because the `groupby` categories "
+                "and the `var_group_labels` are different.\n"
+                f"categories: {_format_first_three_categories(categories)}\n"
+                f"var_group_labels: {_format_first_three_categories(var_group_labels)}"
+            )
     else:
         var_names_idx_ordered = None
 
@@ -2521,9 +2524,11 @@ def _get_dendrogram_key(adata, dendrogram_key, groupby):
 
     if dendrogram_key not in adata.uns:
         from ..tools._dendrogram import dendrogram
-        logg.warn("dendrogram data not found (using key={}). Running `sc.tl.dendrogram` "
-                  "with default parameters. For fine tuning it is recommended to run `sc.tl.dendrogram` "
-                  "independently.".format(dendrogram_key))
+        logg.warn(
+            f"dendrogram data not found (using key={dendrogram_key}). Running `sc.tl.dendrogram` "
+            "with default parameters. For fine tuning it is recommended to run `sc.tl.dendrogram` "
+            "independently."
+        )
         dendrogram(adata, groupby, key_added=dendrogram_key)
 
     if 'dendrogram_info' not in adata.uns[dendrogram_key]:
@@ -2770,8 +2775,10 @@ def _check_var_names_type(var_names, var_group_labels, var_group_positions):
 
     if isinstance(var_names, Mapping):
         if var_group_labels is not None or var_group_positions is not None:
-            logg.warn("`var_names` is a dictionary. This will reset the current value of "
-                      "`var_group_labels` and `var_group_positions`.")
+            logg.warn(
+                "`var_names` is a dictionary. This will reset the current value of "
+                "`var_group_labels` and `var_group_positions`."
+            )
         var_group_labels = []
         _var_names = []
         var_group_positions = []

--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -116,8 +116,10 @@ def dpt_timeseries(adata, color_map=None, show=None, save=None, as_heatmap=True)
         Plot the timeseries as heatmap.
     """
     if adata.n_vars > 100:
-        logg.warn('Plotting more than 100 genes might take some while,'
-                  'consider selecting only highly variable genes, for example.')
+        logg.warn(
+            'Plotting more than 100 genes might take some while, '
+            'consider selecting only highly variable genes, for example.'
+        )
     # only if number of genes is not too high
     if as_heatmap:
         # plot time series as heatmap, as in Haghverdi et al. (2016), Fig. 1d
@@ -300,7 +302,7 @@ def _rank_genes_groups_plot(adata, plot_type='heatmap', groups=None,
         # get all genes that are 'not-nan'
         genes_list = [gene for gene in adata.uns[key]['names'][group] if not pd.isnull(gene)][:n_genes]
         if len(genes_list) == 0:
-            logg.warn("No genes found for group {}".format(group))
+            logg.warn(f'No genes found for group {group}')
             continue
         gene_names.extend(genes_list)
         end = start + len(genes_list)
@@ -731,8 +733,10 @@ def embedding_density(
         raise ValueError('Please run `sc.tl.embedding_density()` first and specify the correct key.')
 
     if 'components' in kwargs:
-        logg.warn('Components were specified, but will be ignored. Only the '
-                  'components used to calculate the density can be plotted.')
+        logg.warn(
+            'Components were specified, but will be ignored. Only the '
+            'components used to calculate the density can be plotted.'
+        )
         del kwargs['components']
 
     components = adata.uns[key+'_params']['components']
@@ -752,7 +756,7 @@ def embedding_density(
                          'Please specify a group from this covariate to plot.')
 
     if (group is not None) and (groupby is None):
-        logg.warn('value of \'group\' is ignored because densities were not calculated for an `.obs` covariate.')
+        logg.warn("value of 'group' is ignored because densities were not calculated for an `.obs` covariate.")
         group = None
 
     if (np.min(adata.obs[key]) < 0) or (np.max(adata.obs[key]) > 1):

--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -116,7 +116,7 @@ def dpt_timeseries(adata, color_map=None, show=None, save=None, as_heatmap=True)
         Plot the timeseries as heatmap.
     """
     if adata.n_vars > 100:
-        logg.warn(
+        logg.warning(
             'Plotting more than 100 genes might take some while, '
             'consider selecting only highly variable genes, for example.'
         )
@@ -302,7 +302,7 @@ def _rank_genes_groups_plot(adata, plot_type='heatmap', groups=None,
         # get all genes that are 'not-nan'
         genes_list = [gene for gene in adata.uns[key]['names'][group] if not pd.isnull(gene)][:n_genes]
         if len(genes_list) == 0:
-            logg.warn(f'No genes found for group {group}')
+            logg.warning(f'No genes found for group {group}')
             continue
         gene_names.extend(genes_list)
         end = start + len(genes_list)
@@ -733,7 +733,7 @@ def embedding_density(
         raise ValueError('Please run `sc.tl.embedding_density()` first and specify the correct key.')
 
     if 'components' in kwargs:
-        logg.warn(
+        logg.warning(
             'Components were specified, but will be ignored. Only the '
             'components used to calculate the density can be plotted.'
         )
@@ -756,7 +756,7 @@ def embedding_density(
                          'Please specify a group from this covariate to plot.')
 
     if (group is not None) and (groupby is None):
-        logg.warn("value of 'group' is ignored because densities were not calculated for an `.obs` covariate.")
+        logg.warning("value of 'group' is ignored because densities were not calculated for an `.obs` covariate.")
         group = None
 
     if (np.min(adata.obs[key]) < 0) or (np.max(adata.obs[key]) > 1):

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -138,9 +138,11 @@ def _compute_pos(adjacency_solid, layout=None, random_state=0, init_pos=None, ad
         try:
             from fa2 import ForceAtlas2
         except:
-            logg.warn('Package \'fa2\' is not installed, falling back to layout \'fr\'.'
-                      'To use the faster and better ForceAtlas2 layout, '
-                      'install package \'fa2\' (`pip install fa2`).')
+            logg.warn(
+                "Package 'fa2' is not installed, falling back to layout 'fr'."
+                'To use the faster and better ForceAtlas2 layout, '
+                "install package 'fa2' (`pip install fa2`)."
+            )
             layout = 'fr'
     if layout == 'fa':
         np.random.seed(random_state)
@@ -502,7 +504,7 @@ def paga(
                                  cax=ax_cb)
     if add_pos:
         adata.uns['paga']['pos'] = pos
-        logg.hint('added \'pos\', the PAGA positions (adata.uns[\'paga\'])')
+        logg.hint("added 'pos', the PAGA positions (adata.uns['paga'])")
     if plot:
         utils.savefig_or_show('paga', show=show, save=save)
         if len(colors) == 1 and isinstance(axs, list): axs = axs[0]
@@ -654,10 +656,11 @@ def _paga_graph(
         adjacency_solid = adjacency_solid.tocsc()[:, labels == largest_component]
         colors = np.array(colors)[labels == largest_component]
         node_labels = np.array(node_labels)[labels == largest_component]
+        cats_dropped = adata.obs[groups_key].cat.categories[labels != largest_component].tolist()
         logg.info(
             'Restricting graph to largest connected component by dropping categories\n'
-            '{}'.format(
-                adata.obs[groups_key].cat.categories[labels != largest_component].tolist()))
+            f'{cats_dropped}'
+        )
         nx_g_solid = nx.Graph(adjacency_solid)
         if dashed_edges is not None:
             raise ValueError('`single_component` only if `dashed_edges` is `None`.')
@@ -708,7 +711,7 @@ def _paga_graph(
                              'y': 1000*pos[count][1],
                              'z': 0}}
         filename = settings.writedir / 'paga_graph.gexf'
-        logg.warn('exporting to', filename)
+        logg.warn(f'exporting to {filename}')
         settings.writedir.mkdir(parents=True, exist_ok=True)
         nx.write_gexf(nx_g_solid, settings.writedir / 'paga_graph.gexf')
 

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -138,7 +138,7 @@ def _compute_pos(adjacency_solid, layout=None, random_state=0, init_pos=None, ad
         try:
             from fa2 import ForceAtlas2
         except:
-            logg.warn(
+            logg.warning(
                 "Package 'fa2' is not installed, falling back to layout 'fr'."
                 'To use the faster and better ForceAtlas2 layout, '
                 "install package 'fa2' (`pip install fa2`)."
@@ -385,7 +385,7 @@ def paga(
     """
     if groups is not None:  # backwards compat
         labels = groups
-        logg.warn('`groups` is deprecated in `pl.paga`: use `labels` instead')
+        logg.warning('`groups` is deprecated in `pl.paga`: use `labels` instead')
     if colors is None:
         colors = color
     # colors is a list that contains no lists
@@ -711,7 +711,7 @@ def _paga_graph(
                              'y': 1000*pos[count][1],
                              'z': 0}}
         filename = settings.writedir / 'paga_graph.gexf'
-        logg.warn(f'exporting to {filename}')
+        logg.warning(f'exporting to {filename}')
         settings.writedir.mkdir(parents=True, exist_ok=True)
         nx.write_gexf(nx_g_solid, settings.writedir / 'paga_graph.gexf')
 

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -182,7 +182,7 @@ def plot_scatter(
             try:
                 ax.set_title(title[count])
             except IndexError:
-                logg.warn(
+                logg.warning(
                     "The title list is shorter than the number of panels. "
                     "Using 'color' value instead for some plots."
                 )
@@ -445,7 +445,7 @@ def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndar
         # check if the data has a third dimension
         if adata.obsm['X_' + basis].shape[1] == 2:
             if settings._low_resolution_warning:
-                logg.warn(
+                logg.warning(
                     'Selected projections is "3d" but only two dimensions '
                     'are available. Only these two dimensions will be plotted'
                 )
@@ -594,7 +594,7 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
         # it doesnt matter if the list is shorter than the categories length:
         if isinstance(palette, abc.Sequence):
             if len(palette) < len(categories):
-                logg.warn(
+                logg.warning(
                     "Length of palette colors is smaller than the number of "
                     f"categories (palette length: {len(palette)}, "
                     f"categories length: {len(categories)}. "
@@ -704,7 +704,7 @@ def _get_color_values(adata, value_to_plot, groups=None, palette=None, use_raw=F
                             if color in utils.additional_colors:
                                 color = utils.additional_colors[color]
                             else:
-                                logg.warn(
+                                logg.warning(
                                     f"The following color value found in adata.uns['{value_to_plot}_colors'] "
                                     f"is not valid: '{color}'. Default colors are used."
                                 )

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -182,8 +182,10 @@ def plot_scatter(
             try:
                 ax.set_title(title[count])
             except IndexError:
-                logg.warn("The title list is shorter than the number of panels. Using 'color' value instead for"
-                          "some plots.")
+                logg.warn(
+                    "The title list is shorter than the number of panels. "
+                    "Using 'color' value instead for some plots."
+                )
                 ax.set_title(value_to_plot)
 
         if 's' not in kwargs:
@@ -443,8 +445,10 @@ def _get_data_points(adata, basis, projection, components) -> Tuple[List[np.ndar
         # check if the data has a third dimension
         if adata.obsm['X_' + basis].shape[1] == 2:
             if settings._low_resolution_warning:
-                logg.warn('Selected projections is "3d" but only two dimensions '
-                          'are available. Only these two dimensions will be plotted')
+                logg.warn(
+                    'Selected projections is "3d" but only two dimensions '
+                    'are available. Only these two dimensions will be plotted'
+                )
         else:
             n_dims = 3
 
@@ -590,10 +594,12 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
         # it doesnt matter if the list is shorter than the categories length:
         if isinstance(palette, abc.Sequence):
             if len(palette) < len(categories):
-                logg.warn("Length of palette colors is smaller than the number of "
-                          "categories (palette length: {}, categories length: {}. "
-                          "Some categories will have the same color."
-                          .format(len(palette), len(categories)))
+                logg.warn(
+                    "Length of palette colors is smaller than the number of "
+                    f"categories (palette length: {len(palette)}, "
+                    f"categories length: {len(categories)}. "
+                    "Some categories will have the same color."
+                )
             # check that colors are valid
             _color_list = []
             for color in palette:
@@ -649,9 +655,11 @@ def _set_default_colors_for_categorical_obs(adata, value_to_plot):
         elif length <= len(palettes.default_64):  # 103 colors
             palette = palettes.default_64
         else:
-            palette = ['grey' for i in range(length)]
-            logg.info('the obs value: "{}" has more than 103 categories. Uniform '
-                      '\'grey\' color will be used for all categories.')
+            palette = ['grey' for _ in range(length)]
+            logg.info(
+                f'the obs value {value_to_plot!r} has more than 103 categories. Uniform '
+                "'grey' color will be used for all categories."
+            )
 
     adata.uns[value_to_plot + '_colors'] = palette[:length]
 
@@ -696,8 +704,10 @@ def _get_color_values(adata, value_to_plot, groups=None, palette=None, use_raw=F
                             if color in utils.additional_colors:
                                 color = utils.additional_colors[color]
                             else:
-                                logg.warn("The following color value found in adata.uns['{}'] "
-                                          " is not valid: '{}'. Default colors are used.".format(value_to_plot + '_colors', color))
+                                logg.warn(
+                                    f"The following color value found in adata.uns['{value_to_plot}_colors'] "
+                                    f"is not valid: '{color}'. Default colors are used."
+                                )
                                 _set_default_colors_for_categorical_obs(adata, value_to_plot)
                                 _palette = None
                                 break
@@ -723,8 +733,10 @@ def _get_color_values(adata, value_to_plot, groups=None, palette=None, use_raw=F
     else:
         if gene_symbols is not None and gene_symbols in adata.var.columns:
             if value_to_plot not in adata.var[gene_symbols].values:
-                logg.error("Gene symbol {!r} not found in given gene_symbols "
-                           "column: {!r}".format(value_to_plot, gene_symbols))
+                logg.error(
+                    f"Gene symbol {value_to_plot!r} not found in given "
+                    f"gene_symbols column: {gene_symbols!r}"
+                )
                 return
             value_to_plot = adata.var[adata.var[gene_symbols] == value_to_plot].index[0]
         if layer is not None and value_to_plot in adata.var_names:

--- a/scanpy/plotting/_top_genes_visual.py
+++ b/scanpy/plotting/_top_genes_visual.py
@@ -279,7 +279,7 @@ def _zero_inflation_estimate(adata, mask, model='rough'):
     # Method ZINB will be implemented soon
     if model not in {'rough', 'zinb'}:
         model = 'rough'
-        logg.warn('Model should be either rough or zinb (zero-inflated negative binomial)')
+        logg.warning('Model should be either rough or zinb (zero-inflated negative binomial)')
     if adata.X.shape is int:
         X = adata.X[mask]
     else:
@@ -302,7 +302,7 @@ def _tail_mean_estimate(adata, mask, model='rough'):
     # Method ZINB will be implemented soon
     if model not in {'rough', 'zinb'}:
         model = 'rough'
-        logg.warn('Model should be either rough or zinb (zero-inflated negative binomial)')
+        logg.warning('Model should be either rough or zinb (zero-inflated negative binomial)')
     X = adata.X[mask, :]
     n_cells = X.shape[0]
     n_genes = X.shape[1]
@@ -333,7 +333,7 @@ def _tail_var_estimate(adata, mask, model='rough'):
     # Method ZINB will be implemented soon
     if model not in {'rough', 'zinb'}:
         model = 'rough'
-        logg.warn('Model should be either rough or zinb (zero-inflated negative binomial)')
+        logg.warning('Model should be either rough or zinb (zero-inflated negative binomial)')
     X = adata.X[mask, :]
     n_cells = X.shape[0]
     n_genes = X.shape[1]

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -222,7 +222,8 @@ def savefig(writekey, dpi=None, ext=None):
                 logg.warn(
                     'You are using a low resolution (dpi<150) for saving figures.\n'
                     'Consider running `set_figure_params(dpi_save=...)`, which will '
-                    'adjust `matplotlib.rcParams[\'savefig.dpi\']`')
+                    "adjust `matplotlib.rcParams['savefig.dpi']`"
+                )
                 settings._low_resolution_warning = False
         else:
             dpi = rcParams['savefig.dpi']
@@ -230,7 +231,7 @@ def savefig(writekey, dpi=None, ext=None):
     if ext is None: ext = settings.file_format_figs
     filename = settings.figdir / f'{writekey}{settings.plot_suffix}.{ext}'
     # output the following msg at warning level; it's really important for the user
-    logg.warn('saving figure to file', filename)
+    logg.warn(f'saving figure to file {filename}')
     pl.savefig(filename, dpi=dpi, bbox_inches='tight')
 
 
@@ -271,7 +272,7 @@ def adjust_palette(palette, length):
             palette = palettes.default_64
         else:
             palette = ['grey' for i in range(length)]
-            logg.info('more than 103 colors would be required, initializing as \'grey\'')
+            logg.info("more than 103 colors would be required, initializing as 'grey'")
         return palette if islist else cycler(color=palette)
     elif islist:
         return palette
@@ -284,8 +285,10 @@ def adjust_palette(palette, length):
 def add_colors_for_categorical_sample_annotation(adata, key, palette=None, force_update_colors=False):
     if key + '_colors' in adata.uns and not force_update_colors:
         if len(adata.obs[key].cat.categories) > len(adata.uns[key + '_colors']):
-            logg.info('    number of colors in `.uns[{}\'_colors\']` smaller than number of categories,'
-                      ' falling back to palette'.format(key))
+            logg.info(
+                f"    number of colors in `.uns[{key}'_colors']` smaller "
+                'than number of categories, falling back to palette'
+            )
         else:
             # make sure that these are valid colors
             adata.uns[key + '_colors'] = [
@@ -293,7 +296,7 @@ def add_colors_for_categorical_sample_annotation(adata, key, palette=None, force
                 for c in adata.uns[key + '_colors']]
             return
     else:
-        logg.debug('generating colors for {} using palette'.format(key))
+        logg.debug(f'generating colors for {key} using palette')
     palette = default_palette(palette)
     palette_adjusted = adjust_palette(palette,
                                       length=len(adata.obs[key].cat.categories))
@@ -306,9 +309,9 @@ def add_colors_for_categorical_sample_annotation(adata, key, palette=None, force
     for iname, name in enumerate(adata.obs[key].cat.categories):
         if name in settings.categories_to_ignore:
             logg.info(
-                '    setting color of group \'{}\' in \'{}\' to \'grey\' '
+                f"    setting color of group {name!r} in {key!r} to 'grey' "
                 '(`sc.settings.categories_to_ignore`)'
-                .format(name, key))
+            )
             adata.uns[key + '_colors'][iname] = 'grey'
 
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -219,7 +219,7 @@ def savefig(writekey, dpi=None, ext=None):
         # we need this as in notebooks, the internal figures are also influenced by 'savefig.dpi' this...
         if not isinstance(rcParams['savefig.dpi'], str) and rcParams['savefig.dpi'] < 150:
             if settings._low_resolution_warning:
-                logg.warn(
+                logg.warning(
                     'You are using a low resolution (dpi<150) for saving figures.\n'
                     'Consider running `set_figure_params(dpi_save=...)`, which will '
                     "adjust `matplotlib.rcParams['savefig.dpi']`"
@@ -231,7 +231,7 @@ def savefig(writekey, dpi=None, ext=None):
     if ext is None: ext = settings.file_format_figs
     filename = settings.figdir / f'{writekey}{settings.plot_suffix}.{ext}'
     # output the following msg at warning level; it's really important for the user
-    logg.warn(f'saving figure to file {filename}')
+    logg.warning(f'saving figure to file {filename}')
     pl.savefig(filename, dpi=dpi, bbox_inches='tight')
 
 

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -42,7 +42,7 @@ def _design_matrix(
     model = model.drop([batch_key], axis=1)
     numerical_covariates = model.select_dtypes('number').columns.values
 
-    logg.info("Found {} batches\n".format(design.shape[1]))
+    logg.info(f"Found {design.shape[1]} batches\n")
     other_cols = [c for c in model.columns.values if c not in numerical_covariates]
 
     if other_cols:
@@ -52,11 +52,11 @@ def _design_matrix(
                                       return_type="dataframe")
 
         design = pd.concat((design, factor_matrix), axis=1)
-        logg.info("Found {} categorical variables:".format(len(other_cols)))
+        logg.info(f"Found {len(other_cols)} categorical variables:")
         logg.info("\t" + ", ".join(other_cols) + '\n')
 
     if numerical_covariates is not None:
-        logg.info("Found {} numerical variables:".format(len(numerical_covariates)))
+        logg.info(f"Found {len(numerical_covariates)} numerical variables:")
         logg.info("\t" + ", ".join(numerical_covariates) + '\n')
 
         for nC in numerical_covariates:

--- a/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -113,7 +113,7 @@ def filter_genes_dispersion(data,
         else:
             adata.var['highly_variable'] = result['gene_subset']
         return adata if copy else None
-    logg.info('extracting highly variable genes')
+    start = logg.info('extracting highly variable genes')
     X = data  # no copy necessary, X remains unchanged in the following
     mean, var = materialize_as_ndarray(_get_mean_var(X))
     # now actually compute the dispersion
@@ -183,7 +183,7 @@ def filter_genes_dispersion(data,
         gene_subset = np.logical_and.reduce((mean > min_mean, mean < max_mean,
                                              dispersion_norm > min_disp,
                                              dispersion_norm < max_disp))
-    logg.info('    finished', time=True)
+    logg.info('    finished', time=start)
     return np.rec.fromarrays((
         gene_subset,
         df['mean'].values,

--- a/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -113,7 +113,7 @@ def filter_genes_dispersion(data,
         else:
             adata.var['highly_variable'] = result['gene_subset']
         return adata if copy else None
-    logg.debug('extracting highly variable genes', r=True)
+    logg.info('extracting highly variable genes')
     X = data  # no copy necessary, X remains unchanged in the following
     mean, var = materialize_as_ndarray(_get_mean_var(X))
     # now actually compute the dispersion
@@ -183,7 +183,7 @@ def filter_genes_dispersion(data,
         gene_subset = np.logical_and.reduce((mean > min_mean, mean < max_mean,
                                              dispersion_norm > min_disp,
                                              dispersion_norm < max_disp))
-    logg.debug('    finished', time=True)
+    logg.info('    finished', time=True)
     return np.rec.fromarrays((
         gene_subset,
         df['mean'].values,

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -241,7 +241,7 @@ def highly_variable_genes(
     This function replaces :func:`~scanpy.pp.filter_genes_dispersion`.
     """
 
-    logg.info('extracting highly variable genes')
+    start = logg.info('extracting highly variable genes')
 
     if not isinstance(adata, AnnData):
         raise ValueError(
@@ -298,7 +298,7 @@ def highly_variable_genes(
             ))
             df['highly_variable'] = gene_subset
 
-    logg.info('    finished', time=True)
+    logg.info('    finished', time=start)
 
     if inplace or subset:
         logg.hint(

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -100,10 +100,9 @@ def _highly_variable_genes_single_batch(
         gen_indices = np.where(one_gene_per_bin[df['mean_bin'].values])[0].tolist()
         if len(gen_indices) > 0:
             logg.debug(
-                'Gene indices {} fell into a single bin: their '
+                f'Gene indices {gen_indices} fell into a single bin: their '
                 'normalized dispersion was set to 1.\n    '
                 'Decreasing `n_bins` will likely avoid this effect.'
-                .format(gen_indices),
             )
         # Circumvent pandas 0.23 bug. Both sides of the assignment have dtype==float32,
         # but there’s still a dtype error without “.value”.
@@ -242,7 +241,7 @@ def highly_variable_genes(
     This function replaces :func:`~scanpy.pp.filter_genes_dispersion`.
     """
 
-    logg.debug('extracting highly variable genes', r=True)
+    logg.info('extracting highly variable genes')
 
     if not isinstance(adata, AnnData):
         raise ValueError(
@@ -299,7 +298,7 @@ def highly_variable_genes(
             ))
             df['highly_variable'] = gene_subset
 
-    logg.debug('    finished', time=True)
+    logg.info('    finished', time=True)
 
     if inplace or subset:
         logg.hint(

--- a/scanpy/preprocessing/_magic.py
+++ b/scanpy/preprocessing/_magic.py
@@ -3,7 +3,6 @@
 
 from .._settings import settings
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 
 
 def magic(adata,

--- a/scanpy/preprocessing/_magic.py
+++ b/scanpy/preprocessing/_magic.py
@@ -102,7 +102,7 @@ def magic(adata,
             'Please install magic package via `pip install --user '
             'git+git://github.com/KrishnaswamyLab/MAGIC.git#subdirectory=python`')
 
-    logg.info('computing PHATE', r=True)
+    logg.info('computing PHATE')
     needs_copy = not (name_list is None or
                       (isinstance(name_list, str) and
                        name_list in ["all_genes", "pca_only"]))
@@ -114,9 +114,6 @@ def magic(adata,
             "`name_list=='pca_only'` (got {}). Consider setting "
             "`copy=True`".format(name_list))
     adata = adata.copy() if copy else adata
-    verbose = settings.verbosity if verbose is None else verbose
-    if isinstance(verbose, (str, int)):
-        verbose = _settings_verbosity_greater_or_equal_than(2)
     n_jobs = settings.n_jobs if n_jobs is None else n_jobs
 
     X_magic = MAGIC(k=k,
@@ -129,14 +126,18 @@ def magic(adata,
                     verbose=verbose,
                     **kwargs).fit_transform(adata,
                                             genes=name_list)
-    logg.info('    finished', time=True,
-              end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            "added\n    'X_magic', PCA on MAGIC coordinates (adata.obsm)"
+            if name_list == "pca_only" else ''
+        )
+    )
     # update AnnData instance
     if name_list == "pca_only":
         # special case - update adata.obsm with smoothed values
         adata.obsm["X_magic"] = X_magic.X
-        logg.hint('added\n'
-                  '    \'X_magic\', PCA on MAGIC coordinates (adata.obsm)')
     elif copy:
         # just return X_magic
         X_magic.raw = adata

--- a/scanpy/preprocessing/_magic.py
+++ b/scanpy/preprocessing/_magic.py
@@ -102,7 +102,7 @@ def magic(adata,
             'Please install magic package via `pip install --user '
             'git+git://github.com/KrishnaswamyLab/MAGIC.git#subdirectory=python`')
 
-    logg.info('computing PHATE')
+    start = logg.info('computing PHATE')
     needs_copy = not (name_list is None or
                       (isinstance(name_list, str) and
                        name_list in ["all_genes", "pca_only"]))
@@ -128,7 +128,7 @@ def magic(adata,
                                             genes=name_list)
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             "added\n    'X_magic', PCA on MAGIC coordinates (adata.obsm)"
             if name_list == "pca_only" else ''

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -149,7 +149,7 @@ def normalize_total(
 
     cell_subset = counts_per_cell > 0
     if not np.all(cell_subset):
-        logg.warn('Some cells have total count of genes equal to zero')
+        logg.warning('Some cells have total count of genes equal to zero')
 
     if layer_norm == 'after':
         after = target_sum

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -139,7 +139,7 @@ def normalize_total(
             ' The following highly-expressed genes are not considered during '
             f'normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}'
         )
-    logg.info(msg)
+    start = logg.info(msg)
 
     # counts per cell for subset, if max_fraction!=1
     X = adata.X if gene_subset is None else adata[:, gene_subset].X
@@ -189,7 +189,7 @@ def normalize_total(
     logg.info(
         '    finished ({time_passed}):'
         'normalized adata.X',
-        time=True,
+        time=start,
     )
     if key_added is not None:
         logg.debug(f'and added {key_added!r}, counts per cell before normalization (adata.obs)')

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -126,6 +126,7 @@ def normalize_total(
         )
 
     gene_subset = None
+    msg = 'Normalizing counts per cell.'
     if exclude_highly_expressed:
         counts_per_cell = adata.X.sum(1)  # original counts per cell
         counts_per_cell = np.ravel(counts_per_cell)
@@ -133,9 +134,12 @@ def normalize_total(
         # at least one cell as more than max_fraction of counts per cell
         gene_subset = (adata.X > counts_per_cell[:, None]*max_fraction).sum(0)
         gene_subset = (np.ravel(gene_subset) == 0)
-        logg.info(
-            'The following highly-expressed genes are not considered during normalization factor computation:\n{}'
-            .format(adata.var_names[~gene_subset].tolist()))
+
+        msg += (
+            ' The following highly-expressed genes are not considered during '
+            f'normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}'
+        )
+    logg.info(msg)
 
     # counts per cell for subset, if max_fraction!=1
     X = adata.X if gene_subset is None else adata[:, gene_subset].X
@@ -182,8 +186,11 @@ def normalize_total(
         else:
             dat[layer_name] = _normalize_data(layer, counts, after, copy=True)
 
-    logg.debug('    finished', t=True, end=': ')
-    logg.debug('normalized adata.X')
+    logg.info(
+        '    finished ({time_passed}):'
+        'normalized adata.X',
+        time=True,
+    )
     if key_added is not None:
         logg.debug(f'and added {key_added!r}, counts per cell before normalization (adata.obs)')
 

--- a/scanpy/preprocessing/_recipes.py
+++ b/scanpy/preprocessing/_recipes.py
@@ -99,7 +99,7 @@ def recipe_zheng17(adata, n_top_genes=1000, log=True, plot=False, copy=False):
     -------
     Returns or updates `adata` depending on `copy`.
     """
-    logg.info('running recipe zheng17', reset=True)
+    logg.info('running recipe zheng17')
     if copy: adata = adata.copy()
     pp.filter_genes(adata, min_counts=1)  # only consider genes with more than 1 count
     pp.normalize_per_cell(adata,  # normalize with total UMI count per cell

--- a/scanpy/preprocessing/_recipes.py
+++ b/scanpy/preprocessing/_recipes.py
@@ -99,7 +99,7 @@ def recipe_zheng17(adata, n_top_genes=1000, log=True, plot=False, copy=False):
     -------
     Returns or updates `adata` depending on `copy`.
     """
-    logg.info('running recipe zheng17')
+    start = logg.info('running recipe zheng17')
     if copy: adata = adata.copy()
     pp.filter_genes(adata, min_counts=1)  # only consider genes with more than 1 count
     pp.normalize_per_cell(adata,  # normalize with total UMI count per cell
@@ -115,5 +115,5 @@ def recipe_zheng17(adata, n_top_genes=1000, log=True, plot=False, copy=False):
     pp.normalize_per_cell(adata)  # renormalize after filtering
     if log: pp.log1p(adata)  # log transform: X = log(X + 1)
     pp.scale(adata)
-    logg.info('    finished', time=True)
+    logg.info('    finished', time=start)
     return adata if copy else None

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -445,7 +445,7 @@ def pca(
     else:
         adata = AnnData(data)
 
-    logg.info(f'computing PCA with n_comps = {n_comps}')
+    start = logg.info(f'computing PCA with n_comps = {n_comps}')
 
     if adata.n_vars < n_comps:
         n_comps = adata.n_vars - 1
@@ -520,7 +520,7 @@ def pca(
         adata.uns['pca'] = {}
         adata.uns['pca']['variance'] = pca_.explained_variance_
         adata.uns['pca']['variance_ratio'] = pca_.explained_variance_ratio_
-        logg.info('    finished', time=True)
+        logg.info('    finished', time=start)
         logg.debug(
             'and added\n'
             '    \'X_pca\', the PCA coordinates (adata.obs)\n'
@@ -530,7 +530,7 @@ def pca(
         )
         return adata if copy else None
     else:
-        logg.info('    finished', time=True)
+        logg.info('    finished', time=start)
         if return_info:
             return X_pca, pca_.components_, pca_.explained_variance_ratio_, pca_.explained_variance_
         else:
@@ -617,7 +617,7 @@ def normalize_per_cell(
     """
     if key_n_counts is None: key_n_counts = 'n_counts'
     if isinstance(data, AnnData):
-        logg.info('normalizing by total count per cell')
+        start = logg.info('normalizing by total count per cell')
         adata = data.copy() if copy else data
         if counts_per_cell is None:
             cell_subset, counts_per_cell = materialize_as_ndarray(
@@ -644,7 +644,7 @@ def normalize_per_cell(
         logg.info(
             '    finished ({time_passed}): normalized adata.X and added'
             f'    {key_n_counts!r}, counts per cell before normalization (adata.obs)',
-            time=True,
+            time=start,
         )
         return adata if copy else None
     # proceed with data matrix
@@ -729,7 +729,7 @@ def regress_out(adata, keys, n_jobs=None, copy=False) -> Optional[AnnData]:
     -------
     Depending on `copy` returns or updates `adata` with the corrected data matrix.
     """
-    logg.info(f'regressing out {keys}')
+    start = logg.info(f'regressing out {keys}')
     if issparse(adata.X):
         logg.info(
             '    sparse input is densified and may '
@@ -801,7 +801,7 @@ def regress_out(adata, keys, n_jobs=None, copy=False) -> Optional[AnnData]:
     # res is a list of vectors (each corresponding to a regressed gene column).
     # The transpose is needed to get the matrix in the shape needed
     adata.X = np.vstack(res).T.astype(adata.X.dtype)
-    logg.info('    finished', time=True)
+    logg.info('    finished', time=start)
     return adata if copy else None
 
 

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -108,7 +108,7 @@ def filter_cells(
     3
     """
     if copy:
-       logg.warn('`copy` is deprecated, use `inplace` instead.')
+       logg.warning('`copy` is deprecated, use `inplace` instead.')
     n_given_options = sum(
         option is not None for option in
         [min_genes, min_counts, max_genes, max_counts])
@@ -196,7 +196,7 @@ def filter_genes(
         `n_counts` or `n_cells` per gene.
     """
     if copy:
-       logg.warn('`copy` is deprecated, use `inplace` instead.')
+       logg.warning('`copy` is deprecated, use `inplace` instead.')
     n_given_options = sum(
         option is not None for option in
         [min_cells, min_counts, max_cells, max_counts])
@@ -825,7 +825,7 @@ def _regress_out_chunk(data):
             result = sm.GLM(data_chunk[:, col_index], regres, family=sm.families.Gaussian()).fit()
             new_column = result.resid_response
         except PerfectSeparationError:  # this emulates R's behavior
-            logg.warn('Encountered PerfectSeparationError, setting to 0 as in R.')
+            logg.warning('Encountered PerfectSeparationError, setting to 0 as in R.')
             new_column = np.zeros(data_chunk.shape[0])
 
         responses_chunk_list.append(new_column)

--- a/scanpy/queries/__init__.py
+++ b/scanpy/queries/__init__.py
@@ -37,7 +37,7 @@ def mitochondrial_genes(host, org) -> pd.Index:
         s.add_dataset_to_xml('drerio_gene_ensembl')
         s.add_attribute_to_xml('zfin_id_symbol')
     else:
-        logg.debug('organism ', str(org), ' is unavailable', no_indent=True)
+        logg.debug(f'organism {org} is unavailable')
         return None
     s.add_attribute_to_xml('chromosome_name')
     xml = s.get_xml()
@@ -91,7 +91,7 @@ def gene_coordinates(host, org, gene, chr_exclude=[]) -> pd.DataFrame:
         s.add_dataset_to_xml('drerio_gene_ensembl')
         s.add_attribute_to_xml('zfin_id_symbol')
     else:
-        logg.debug('organism ', str(org), ' is unavailable', no_indent=True)
+        logg.debug(f'organism {org} is unavailable')
         return None
     s.add_attribute_to_xml('chromosome_name')
     s.add_attribute_to_xml('start_position')

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -137,11 +137,11 @@ def read_10x_h5(
     `adata.var_names`. The gene IDs are stored in `adata.var['gene_ids']`.
     The feature types are stored in `adata.var['feature_types']`
     """
-    logg.info(f'reading {filename}')
+    start = logg.info(f'reading {filename}')
     with tables.open_file(str(filename), 'r') as f:
         v3 = '/matrix' in f
     if v3:
-        adata = _read_v3_10x_h5(filename)
+        adata = _read_v3_10x_h5(filename, start=start)
         if genome:
             if genome not in adata.var['genome'].values:
                 raise ValueError(
@@ -153,10 +153,10 @@ def read_10x_h5(
             adata = adata[:, list(map(lambda x: x == 'Gene Expression', adata.var['feature_types']))]
         return adata
     else:
-        return _read_legacy_10x_h5(filename, genome=genome)
+        return _read_legacy_10x_h5(filename, genome=genome, start=start)
 
 
-def _read_legacy_10x_h5(filename, genome=None):
+def _read_legacy_10x_h5(filename, *, genome=None, start=None):
     """
     Read hdf5 file from Cell Ranger v2 or earlier versions.
     """
@@ -201,13 +201,13 @@ def _read_legacy_10x_h5(filename, genome=None):
                     gene_ids=dsets['genes'].astype(str),
                 ),
             )
-            logg.info('', time=True)
+            logg.info('', time=start)
             return adata
         except KeyError:
             raise Exception('File is missing one or more required datasets.')
 
 
-def _read_v3_10x_h5(filename):
+def _read_v3_10x_h5(filename, *, start=None):
     """
     Read hdf5 file from Cell Ranger v3 or later versions.
     """
@@ -236,7 +236,7 @@ def _read_v3_10x_h5(filename):
                     genome=dsets['genome'].astype(str),
                 ),
             )
-            logg.info('', time=True)
+            logg.info('', time=start)
             return adata
         except KeyError:
             raise Exception('File is missing one or more required datasets.')

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -137,7 +137,7 @@ def read_10x_h5(
     `adata.var_names`. The gene IDs are stored in `adata.var['gene_ids']`.
     The feature types are stored in `adata.var['feature_types']`
     """
-    logg.info('reading', filename, r=True, end=' ')
+    logg.info(f'reading {filename}')
     with tables.open_file(str(filename), 'r') as f:
         v3 = '/matrix' in f
     if v3:
@@ -201,7 +201,7 @@ def _read_legacy_10x_h5(filename, genome=None):
                     gene_ids=dsets['genes'].astype(str),
                 ),
             )
-            logg.info(t=True)
+            logg.info('', time=True)
             return adata
         except KeyError:
             raise Exception('File is missing one or more required datasets.')
@@ -236,7 +236,7 @@ def _read_v3_10x_h5(filename):
                     genome=dsets['genome'].astype(str),
                 ),
             )
-            logg.info(t=True)
+            logg.info('', time=True)
             return adata
         except KeyError:
             raise Exception('File is missing one or more required datasets.')
@@ -492,7 +492,7 @@ def _read(
         filename,
         backup_url=backup_url,
     )
-    if not is_present: logg.debug('... did not find original file', filename)
+    if not is_present: logg.debug(f'... did not find original file {filename}')
     # read hdf5 files
     if ext in {'h5', 'h5ad'}:
         if sheet is None:
@@ -505,12 +505,12 @@ def _read(
     if path_cache.suffix in {'.gz', '.bz2'}:
         path_cache = path_cache.with_suffix('')
     if cache and path_cache.is_file():
-        logg.info('... reading from cache file', path_cache)
+        logg.info(f'... reading from cache file {path_cache}')
         adata = read_h5ad(path_cache)
     else:
         if not is_present:
             raise FileNotFoundError('Did not find file {}.'.format(filename))
-        logg.debug('reading', filename)
+        logg.debug(f'reading {filename}')
         if not cache and not suppress_cache_warning:
             logg.hint(
                 'This might be very slow. Consider passing `cache=True`, '

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -753,7 +753,7 @@ def is_valid_filename(filename: Path, return_ext=False):
     ext = filename.suffixes
 
     if len(ext) > 2:
-        logg.warn(
+        logg.warning(
             f'Your filename has more than two extensions: {ext}.\n'
             f'Only considering the two last: {ext[-2:]}.'
         )

--- a/scanpy/tests/test_logging.py
+++ b/scanpy/tests/test_logging.py
@@ -1,0 +1,29 @@
+import sys
+from io import StringIO
+
+from scanpy import Verbosity, settings as s, logging as l
+
+
+def test_defaults():
+    pass
+
+
+def test_logfile(tmp_path):
+    s.verbosity = Verbosity.hint
+    assert s.logfile is sys.stderr
+    assert s.logpath is None
+
+    io = StringIO()
+    s.logfile = io
+    assert s.logfile is io
+    assert s.logpath is None
+    l.error('test!')
+    assert io.getvalue() == 'ERROR: test!\n'
+
+    p = tmp_path / 'test.log'
+    s.logpath = p
+    assert s.logpath == p
+    assert s.logfile.name == str(p)
+    l.hint('test2')
+    l.debug('invisible')
+    assert s.logpath.read_text() == '--> test2\n'

--- a/scanpy/tests/test_logging.py
+++ b/scanpy/tests/test_logging.py
@@ -1,17 +1,53 @@
+import logging
 import sys
 from io import StringIO
+from typing import Generator, List, Tuple
+
+import pytest
 
 from scanpy import Verbosity, settings as s, logging as l
 
 
+@pytest.fixture
+def logging_state():
+    verbosity_orig = s.verbosity
+    yield
+    s.logfile = sys.stderr
+    s.verbosity = verbosity_orig
+
+
 def test_defaults():
-    pass
-
-
-def test_logfile(tmp_path):
-    s.verbosity = Verbosity.hint
+    # This is only true when not in IPython,
+    # But I hope we’ll never run tests from there
     assert s.logfile is sys.stderr
     assert s.logpath is None
+
+
+def test_formats(logging_state):
+    io = StringIO()
+
+    def pop():
+        v = io.getvalue()
+        io.truncate(0)
+        io.seek(0)
+        return v
+
+    s.verbosity = Verbosity.debug
+    s.logfile = io
+    l.error('0')
+    assert pop() == 'ERROR: 0\n'
+    l.warning('1')
+    assert pop() == 'WARNING: 1\n'
+    l.info('2')
+    assert pop().endswith(' | 2\n')
+    l.hint('3')
+    assert pop() == '--> 3\n'
+    l.debug('4')
+    assert pop() == '    4\n'
+
+
+def test_logfile(tmp_path, logging_state):
+    s.verbosity = Verbosity.hint
 
     io = StringIO()
     s.logfile = io

--- a/scanpy/tests/test_logging.py
+++ b/scanpy/tests/test_logging.py
@@ -15,38 +15,23 @@ def logging_state():
     s.verbosity = verbosity_orig
 
 
-class Recorder:
-    def __init__(self):
-        self.records = []
-
-    def write(self, s: str):
-        self.records.append(s)
-
-    def pop(self):
-        return self.records.pop()
-
-
 def test_defaults():
-    # This is only true when not in IPython,
-    # But I hope we’ll never run tests from there
-    assert s.logfile is sys.stderr
     assert s.logpath is None
 
 
-def test_formats(logging_state):
+def test_formats(capsys, logging_state):
+    s.logfile = sys.stderr
     s.verbosity = Verbosity.debug
-    rec = Recorder()
-    s.logfile = rec
     l.error('0')
-    assert rec.pop() == 'ERROR: 0\n'
+    assert capsys.readouterr().err == 'ERROR: 0\n'
     l.warning('1')
-    assert rec.pop() == 'WARNING: 1\n'
+    assert capsys.readouterr().err == 'WARNING: 1\n'
     l.info('2')
-    assert rec.pop().endswith(' | 2\n')
+    assert capsys.readouterr().err.endswith(' | 2\n')
     l.hint('3')
-    assert rec.pop() == '--> 3\n'
+    assert capsys.readouterr().err == '--> 3\n'
     l.debug('4')
-    assert rec.pop() == '    4\n'
+    assert capsys.readouterr().err == '    4\n'
 
 
 def test_logfile(tmp_path, logging_state):
@@ -68,7 +53,8 @@ def test_logfile(tmp_path, logging_state):
     assert s.logpath.read_text() == '--> test2\n'
 
 
-def test_timing(monkeypatch, logging_state):
+def test_timing(monkeypatch, capsys, logging_state):
+    s.logfile = sys.stderr
     counter = 0
 
     class IncTime:
@@ -80,14 +66,12 @@ def test_timing(monkeypatch, logging_state):
 
     monkeypatch.setattr(l, 'datetime', IncTime)
     s.verbosity = Verbosity.debug
-    rec = Recorder()
-    s.logfile = rec
 
     l.hint('1')
-    assert counter == 1 and rec.pop() == '--> 1\n'
+    assert counter == 1 and capsys.readouterr().err == '--> 1\n'
     start = l.info('2')
-    assert counter == 2 and rec.pop().endswith(' | 2\n')
+    assert counter == 2 and capsys.readouterr().err.endswith(' | 2\n')
     l.hint('3')
-    assert counter == 3 and rec.pop() == '--> 3\n'
+    assert counter == 3 and capsys.readouterr().err == '--> 3\n'
     l.info('4', time=start)
-    assert counter == 4 and rec.pop().endswith(' | 4 (0:00:02)\n')
+    assert counter == 4 and capsys.readouterr().err.endswith(' | 4 (0:00:02)\n')

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -95,7 +95,7 @@ def dendrogram(adata: AnnData, groupby: str,
     if key_added is None:
         key_added = 'dendrogram_' + groupby
 
-    logg.info('Storing dendrogram info using `.uns[{!r}]`'.format(key_added))
+    logg.info(f'Storing dendrogram info using `.uns[{key_added!r}]`')
     # aggregate values within categories using 'mean'
     mean_df = rep_df.groupby(level=0).mean()
 
@@ -108,11 +108,8 @@ def dendrogram(adata: AnnData, groupby: str,
     # order of groupby categories
     categories_idx_ordered = dendro_info['leaves']
 
-    adata.uns[key_added] = {'linkage': z_var,
-                            'groupby': groupby,
-                            'use_rep': use_rep,
-                            'cor_method': cor_method,
-                            'linkage_method': linkage_method,
-                            'categories_idx_ordered': categories_idx_ordered,
-                            'dendrogram_info': dendro_info,
-                            'correlation_matrix': corr_matrix.values}
+    adata.uns[key_added] = dict(
+        linkage=z_var, groupby=groupby, use_rep=use_rep, cor_method=cor_method,
+        linkage_method=linkage_method, categories_idx_ordered=categories_idx_ordered,
+        dendrogram_info=dendro_info, correlation_matrix=corr_matrix.values,
+    )

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -7,7 +7,6 @@ import networkx as nx
 from natsort import natsorted
 
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 from ..neighbors import Neighbors, OnFlySymMatrix
 
 

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -11,7 +11,7 @@ from ..neighbors import Neighbors, OnFlySymMatrix
 
 
 def _diffmap(adata, n_comps=15):
-    logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
+    start = logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
     dpt = DPT(adata)
     dpt.compute_transitions()
     dpt.compute_eigen(n_comps=n_comps)
@@ -19,7 +19,7 @@ def _diffmap(adata, n_comps=15):
     adata.uns['diffmap_evals'] = dpt.eigen_values
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             '    \'X_diffmap\', diffmap coordinates (adata.obsm)\n'
@@ -119,7 +119,7 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
     dpt = DPT(adata, n_dcs=n_dcs, min_group_size=min_group_size,
               n_branchings=n_branchings,
               allow_kendall_tau_shift=allow_kendall_tau_shift)
-    logg.info(f'computing Diffusion Pseudotime using n_dcs={n_dcs}')
+    start = logg.info(f'computing Diffusion Pseudotime using n_dcs={n_dcs}')
     if n_branchings > 1: logg.info('    this uses a hierarchical implementation')
     if dpt.iroot is not None:
         dpt._set_pseudotime()  # pseudotimes are distances from root point
@@ -142,7 +142,7 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
         adata.obs['dpt_order_indices'] = dpt.indices
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             + ("    'dpt_pseudotime', the pseudotime (adata.obs)"

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -103,14 +103,14 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
         raise ValueError(
             'You need to run `pp.neighbors` and `tl.diffmap` first.')
     if 'iroot' not in adata.uns and 'xroot' not in adata.var:
-        logg.warn(
+        logg.warning(
             'No root cell found. To compute pseudotime, pass the index or '
             'expression vector of a root cell, one of:\n'
             '    adata.uns[\'iroot\'] = root_cell_index\n'
             '    adata.var[\'xroot\'] = adata[root_cell_name, :].X'
         )
     if 'X_diffmap' not in adata.obsm.keys():
-        logg.warn(
+        logg.warning(
             'Trying to run `tl.dpt` without prior call of `tl.diffmap`. '
             'Falling back to `tl.diffmap` with default parameters.'
         )
@@ -644,7 +644,7 @@ class DPT(Neighbors):
         ssegs_tips = []
         for inewseg, newseg in enumerate(ssegs):
             if len(np.flatnonzero(newseg)) <= 1:
-                logg.warn(f'detected group with only {np.flatnonzero(newseg)} cells')
+                logg.warning(f'detected group with only {np.flatnonzero(newseg)} cells')
             secondtip = newseg[np.argmax(Dseg[tips[inewseg]][newseg])]
             ssegs_tips.append([tips[inewseg], secondtip])
         undecided_cells = np.arange(Dseg.shape[0], dtype=int)[nonunique]
@@ -795,7 +795,7 @@ class DPT(Neighbors):
         if imax > 0.95 * len(idcs) and self.allow_kendall_tau_shift:
             # if "everything" is correlated (very large value of imax), a more
             # conservative choice amounts to reducing this
-            logg.warn(
+            logg.warning(
                 'shifting branching point away from maximal kendall-tau '
                 'correlation (suppress this with `allow_kendall_tau_shift=False`)'
             )

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -11,16 +11,21 @@ from ..neighbors import Neighbors, OnFlySymMatrix
 
 
 def _diffmap(adata, n_comps=15):
-    logg.info('computing Diffusion Maps using n_comps={}(=n_dcs)'.format(n_comps), r=True)
+    logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
     dpt = DPT(adata)
     dpt.compute_transitions()
     dpt.compute_eigen(n_comps=n_comps)
     adata.obsm['X_diffmap'] = dpt.eigen_basis
     adata.uns['diffmap_evals'] = dpt.eigen_values
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-              '    \'X_diffmap\', diffmap coordinates (adata.obsm)\n'
-              '    \'diffmap_evals\', eigenvalues of transition matrix (adata.uns)')
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            '    \'X_diffmap\', diffmap coordinates (adata.obsm)\n'
+            '    \'diffmap_evals\', eigenvalues of transition matrix (adata.uns)'
+        ),
+    )
 
 
 def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
@@ -102,16 +107,19 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
             'No root cell found. To compute pseudotime, pass the index or '
             'expression vector of a root cell, one of:\n'
             '    adata.uns[\'iroot\'] = root_cell_index\n'
-            '    adata.var[\'xroot\'] = adata[root_cell_name, :].X')
+            '    adata.var[\'xroot\'] = adata[root_cell_name, :].X'
+        )
     if 'X_diffmap' not in adata.obsm.keys():
-        logg.warn('Trying to run `tl.dpt` without prior call of `tl.diffmap`. '
-                  'Falling back to `tl.diffmap` with default parameters.')
+        logg.warn(
+            'Trying to run `tl.dpt` without prior call of `tl.diffmap`. '
+            'Falling back to `tl.diffmap` with default parameters.'
+        )
         _diffmap(adata)
     # start with the actual computation
     dpt = DPT(adata, n_dcs=n_dcs, min_group_size=min_group_size,
               n_branchings=n_branchings,
               allow_kendall_tau_shift=allow_kendall_tau_shift)
-    logg.info('computing Diffusion Pseudotime using n_dcs={}'.format(n_dcs), r=True)
+    logg.info(f'computing Diffusion Pseudotime using n_dcs={n_dcs}')
     if n_branchings > 1: logg.info('    this uses a hierarchical implementation')
     if dpt.iroot is not None:
         dpt._set_pseudotime()  # pseudotimes are distances from root point
@@ -132,13 +140,18 @@ def dpt(adata, n_dcs=10, n_branchings=0, min_group_size=0.01,
         for count, idx in enumerate(dpt.indices): ordering_id[idx] = count
         adata.obs['dpt_order'] = ordering_id
         adata.obs['dpt_order_indices'] = dpt.indices
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-           + ('    \'dpt_pseudotime\', the pseudotime (adata.obs)'
-              if dpt.iroot is not None else '')
-           + ('\n    \'dpt_groups\', the branching subgroups of dpt (adata.obs)\n'
-              + '    \'dpt_order\', cell order (adata.obs)'
-              if n_branchings > 0 else ''))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            + ("    'dpt_pseudotime', the pseudotime (adata.obs)"
+               if dpt.iroot is not None else '')
+            + ("\n    'dpt_groups', the branching subgroups of dpt (adata.obs)"
+               "\n    'dpt_order', cell order (adata.obs)"
+               if n_branchings > 0 else '')
+        ),
+    )
     return adata if copy else None
 
 
@@ -189,8 +202,8 @@ class DPT(Neighbors):
             List of indices of the tips of segments.
         """
         logg.debug(
-            '    detect', self.n_branchings,
-            'branching' + ('' if self.n_branchings == 1 else 's'),
+            f'    detect {self.n_branchings} '
+            f'branching{"" if self.n_branchings == 1 else "s"}',
         )
         # a segment is a subset of points of the data set (defined by the
         # indices of the points in the segment)
@@ -242,8 +255,7 @@ class DPT(Neighbors):
                 logg.debug('    partitioning converged')
                 break
             logg.debug(
-                '    branching {}:'.format(ibranch + 1),
-                'split group', iseg,
+                f'    branching {ibranch + 1}: split group {iseg}',
             )  # [third start end]
             # detect branching and update segs and segs_tips
             self.detect_branching(segs, segs_tips,
@@ -362,7 +374,7 @@ class DPT(Neighbors):
             score = dseg[tips3[2]] / Dseg[tips3[0], tips3[1]]
             score = len(seg) if self.choose_largest_segment else score  # simply the number of points
             logg.debug(
-                '    group', iseg, 'score', score, 'n_points', len(seg),
+                f'    group {iseg} score {score} n_points {len(seg)} ' +
                 '(too small)' if len(seg) < self.min_group_size else '',
             )
             if len(seg) <= self.min_group_size: score = 0
@@ -415,7 +427,7 @@ class DPT(Neighbors):
                     indices = np.argsort(self.pseudotime[tips])
                     self.segs_tips[itips] = self.segs_tips[itips][indices]
                 else:
-                    logg.debug('    group', itips, 'is very small')
+                    logg.debug(f'    group {itips} is very small')
         # sort indices according to segments
         indices = np.argsort(self.segs_names)
         segs_names = self.segs_names[indices]
@@ -566,12 +578,12 @@ class DPT(Neighbors):
                         segs_connects[jseg_min].append(closest_points_in_kseg[idx])
                         segs_adjacency[kseg].append(jseg_min)
                         segs_connects[kseg].append(closest_points_in_jseg[idx])
-                        logg.debug('    attaching new segment', kseg, 'at', jseg_min)
+                        logg.debug(f'    attaching new segment {kseg} at {jseg_min}')
                         # if we split the cluster, we should not attach kseg
                         do_not_attach_kseg = True
                     else:
                         logg.debug(
-                            '    cannot attach new segment', kseg, 'at', jseg_min,
+                            f'    cannot attach new segment {kseg} at {jseg_min} '
                             '(would produce cycle)'
                         )
                         if kseg != kseg_list[-1]:
@@ -632,7 +644,7 @@ class DPT(Neighbors):
         ssegs_tips = []
         for inewseg, newseg in enumerate(ssegs):
             if len(np.flatnonzero(newseg)) <= 1:
-                logg.warn('detected group with only {} cells'.format(np.flatnonzero(newseg)))
+                logg.warn(f'detected group with only {np.flatnonzero(newseg)} cells')
             secondtip = newseg[np.argmax(Dseg[tips[inewseg]][newseg])]
             ssegs_tips.append([tips[inewseg], secondtip])
         undecided_cells = np.arange(Dseg.shape[0], dtype=int)[nonunique]
@@ -783,7 +795,10 @@ class DPT(Neighbors):
         if imax > 0.95 * len(idcs) and self.allow_kendall_tau_shift:
             # if "everything" is correlated (very large value of imax), a more
             # conservative choice amounts to reducing this
-            logg.warn('shifting branching point away from maximal kendall-tau correlation (suppress this with `allow_kendall_tau_shift=False`)')
+            logg.warn(
+                'shifting branching point away from maximal kendall-tau '
+                'correlation (suppress this with `allow_kendall_tau_shift=False`)'
+            )
             ibranch = int(0.95 * imax)
         else:
             # otherwise, a more conservative choice is the following

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -94,7 +94,7 @@ def draw_graph(
         try:
             from fa2 import ForceAtlas2
         except ImportError:
-            logg.warn(
+            logg.warning(
                 'Package \'fa2\' is not installed, falling back to layout \'fr\'.'
                 'To use the faster and better ForceAtlas2 layout, '
                 'install package \'fa2\' (`pip install fa2`).'

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -70,7 +70,7 @@ def draw_graph(
     **X_draw_graph_layout** : `adata.obsm`
         Coordinates of graph layout. E.g. for layout='fa' (the default), the field is called 'X_draw_graph_fa'
     """
-    logg.info(f'drawing single-cell graph using layout {layout!r}')
+    start = logg.info(f'drawing single-cell graph using layout {layout!r}')
     avail_layouts = {'fr', 'drl', 'kk', 'grid_fr', 'lgl', 'rt', 'rt_circular', 'fa'}
     if layout not in avail_layouts:
         raise ValueError('Provide a valid layout, one of {}.'.format(avail_layouts))
@@ -144,7 +144,7 @@ def draw_graph(
     adata.obsm[key_added] = positions
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             f'    {key_added!r}, graph_drawing coordinates (adata.obsm)'

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -2,7 +2,6 @@ import numpy as np
 
 from .. import utils
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 from ._utils import get_init_pos_from_paga
 
 

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -70,8 +70,7 @@ def draw_graph(
     **X_draw_graph_layout** : `adata.obsm`
         Coordinates of graph layout. E.g. for layout='fa' (the default), the field is called 'X_draw_graph_fa'
     """
-    logg.info('drawing single-cell graph using layout "{}"'.format(layout),
-              r=True)
+    logg.info(f'drawing single-cell graph using layout {layout!r}')
     avail_layouts = {'fr', 'drl', 'kk', 'grid_fr', 'lgl', 'rt', 'rt_circular', 'fa'}
     if layout not in avail_layouts:
         raise ValueError('Provide a valid layout, one of {}.'.format(avail_layouts))
@@ -94,10 +93,12 @@ def draw_graph(
     if layout == 'fa':
         try:
             from fa2 import ForceAtlas2
-        except:
-            logg.warn('Package \'fa2\' is not installed, falling back to layout \'fr\'.'
-                      'To use the faster and better ForceAtlas2 layout, '
-                      'install package \'fa2\' (`pip install fa2`).')
+        except ImportError:
+            logg.warn(
+                'Package \'fa2\' is not installed, falling back to layout \'fr\'.'
+                'To use the faster and better ForceAtlas2 layout, '
+                'install package \'fa2\' (`pip install fa2`).'
+            )
             layout = 'fr'
     # actual drawing
     if layout == 'fa':
@@ -141,8 +142,12 @@ def draw_graph(
     adata.uns['draw_graph']['params'] = {'layout': layout, 'random_state': random_state}
     key_added = 'X_draw_graph_' + (layout if key_added_ext is None else key_added_ext)
     adata.obsm[key_added] = positions
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-              '    \'{}\', graph_drawing coordinates (adata.obsm)'
-              .format(key_added))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            f'    {key_added!r}, graph_drawing coordinates (adata.obsm)'
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_embedding_density.py
+++ b/scanpy/tools/_embedding_density.py
@@ -90,7 +90,7 @@ def embedding_density(
     """
     sanitize_anndata(adata) # to ensure that newly created covariates are categorical to test for categoy numbers
 
-    logg.info('computing density on \'{}\''.format(basis), r=True)
+    logg.info(f'computing density on {basis!r}')
 
     # Test user inputs
     basis = basis.lower()
@@ -157,11 +157,12 @@ def embedding_density(
     # Note: plot_scatter takes care of correcting diffmap components for plotting automatically
     if basis != 'diffmap': components += 1
 
-    adata.uns[density_covariate+'_params'] = {'covariate':groupby, 'components':components.tolist()}
-    
+    adata.uns[density_covariate+'_params'] = dict(covariate=groupby, components=components.tolist())
 
-    logg.hint('added\n'
-              '    \'{}\', densities (adata.obs)\n'
-              '    \'{}_params\', parameter (adata.uns)'.format(density_covariate, density_covariate))
+    logg.hint(
+        f'added\n'
+        f'    \'{density_covariate}\', densities (adata.obs)\n'
+        f'    \'{density_covariate}_params\', parameter (adata.uns)'
+    )
 
     return None

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -89,7 +89,7 @@ def leiden(
     except ImportError:
         raise ImportError('Please install the leiden algorithm: `pip3 install leidenalg`.')
 
-    logg.info('running Leiden clustering')
+    start = logg.info('running Leiden clustering')
     adata = adata.copy() if copy else adata
     # are we clustering a user-provided graph or the default AnnData one?
     if adjacency is None:
@@ -148,7 +148,7 @@ def leiden(
     )
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
             f'    {key_added!r}, the cluster labels (adata.obs, categorical)'

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -8,7 +8,6 @@ from scipy import sparse
 
 from .. import utils
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 
 from ._utils_clustering import rename_groups, restrict_adjacency
 

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -89,7 +89,7 @@ def leiden(
     except ImportError:
         raise ImportError('Please install the leiden algorithm: `pip3 install leidenalg`.')
 
-    logg.info('running Leiden clustering', r=True)
+    logg.info('running Leiden clustering')
     adata = adata.copy() if copy else adata
     # are we clustering a user-provided graph or the default AnnData one?
     if adjacency is None:
@@ -146,8 +146,12 @@ def leiden(
         random_state=random_state,
         n_iterations=n_iterations,
     )
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('found {} clusters and added\n'
-              '    \'{}\', the cluster labels (adata.obs, categorical)'
-              .format(len(np.unique(groups)), key_added))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            f'found {len(np.unique(groups))} clusters and added\n'
+            f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -107,7 +107,7 @@ def louvain(
         )
     if flavor in {'vtraag', 'igraph'}:
         if flavor == 'igraph' and resolution is not None:
-            logg.warn('`resolution` parameter has no effect for flavor "igraph"')
+            logg.warning('`resolution` parameter has no effect for flavor "igraph"')
         if directed and flavor == 'igraph':
             directed = False
         if not directed: logg.debug('    using the undirected graph')

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -87,7 +87,7 @@ def louvain(
     :class:`~anndata.AnnData`
         When ``copy=True`` is set, a copy of ``adata`` with those fields is returned.
     """
-    logg.info('running Louvain clustering', r=True)
+    logg.info('running Louvain clustering')
     if (flavor != 'vtraag') and (partition_type is not None):
         raise ValueError(
             '`partition_type` is only a valid argument when `flavour` is "vtraag"')
@@ -163,8 +163,12 @@ def louvain(
     )
     adata.uns['louvain'] = {}
     adata.uns['louvain']['params'] = {'resolution': resolution, 'random_state': random_state}
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('found {} clusters and added\n'
-              '    \'{}\', the cluster labels (adata.obs, categorical)'
-              .format(len(np.unique(groups)), key_added))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            f'found {len(np.unique(groups))} clusters and added\n'
+            f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -87,7 +87,7 @@ def louvain(
     :class:`~anndata.AnnData`
         When ``copy=True`` is set, a copy of ``adata`` with those fields is returned.
     """
-    logg.info('running Louvain clustering')
+    start = logg.info('running Louvain clustering')
     if (flavor != 'vtraag') and (partition_type is not None):
         raise ValueError(
             '`partition_type` is only a valid argument when `flavour` is "vtraag"')
@@ -165,7 +165,7 @@ def louvain(
     adata.uns['louvain']['params'] = {'resolution': resolution, 'random_state': random_state}
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
             f'    {key_added!r}, the cluster labels (adata.obs, categorical)'

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -8,7 +8,6 @@ from scipy.sparse import spmatrix
 
 from .. import utils
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 
 from ._utils_clustering import rename_groups, restrict_adjacency
 

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -79,10 +79,10 @@ def marker_gene_overlap(
     key_added: Optional[str] = 'marker_gene_overlap',
     inplace: Optional[bool] = False
 ):
-    """Calculate an overlap score between data-deriven marker genes and 
+    """Calculate an overlap score between data-deriven marker genes and
     provided markers
 
-    Marker gene overlap scores can be quoted as overlap counts, overlap 
+    Marker gene overlap scores can be quoted as overlap counts, overlap
     coefficients, or jaccard indices. The method returns a pandas dataframe
     which can be used to annotate clusters based on marker gene overlaps.
 
@@ -93,31 +93,31 @@ def marker_gene_overlap(
     adata
         The annotated data matrix.
     reference_markers
-        A marker gene dictionary object. Keys should be strings with the 
-        cell identity name and values are sets or lists of strings which match 
+        A marker gene dictionary object. Keys should be strings with the
+        cell identity name and values are sets or lists of strings which match
         format of `adata.var_name`.
     key
         The key in `adata.uns` where the rank_genes_groups output is stored.
         By default this is `'rank_genes_groups'`.
-    method : `{'overlap_count', 'overlap_coef', 'jaccard'}`, optional 
+    method : `{'overlap_count', 'overlap_coef', 'jaccard'}`, optional
         (default: `overlap_count`)
         Method to calculate marker gene overlap. `'overlap_count'` uses the
-        intersection of the gene set, `'overlap_coef'` uses the overlap 
+        intersection of the gene set, `'overlap_coef'` uses the overlap
         coefficient, and `'jaccard'` uses the Jaccard index.
     normalize : `{'reference', 'data', 'None'}`, optional (default: `None`)
         Normalization option for the marker gene overlap output. This parameter
         can only be set when `method` is set to `'overlap_count'`. `'reference'`
-        normalizes the data by the total number of marker genes given in the 
+        normalizes the data by the total number of marker genes given in the
         reference annotation per group. `'data'` normalizes the data by the
         total number of marker genes used for each cluster.
     top_n_markers
-        The number of top data-derived marker genes to use. By default all 
+        The number of top data-derived marker genes to use. By default all
         calculated marker genes are used. If `adj_pval_threshold` is set along
         with `top_n_markers`, then `adj_pval_threshold` is ignored.
     adj_pval_threshold
-        A significance threshold on the adjusted p-values to select marker 
-        genes. This can only be used when adjusted p-values are calculated by 
-        `sc.tl.rank_genes_groups()`. If `adj_pval_threshold` is set along with 
+        A significance threshold on the adjusted p-values to select marker
+        genes. This can only be used when adjusted p-values are calculated by
+        `sc.tl.rank_genes_groups()`. If `adj_pval_threshold` is set along with
         `top_n_markers`, then `adj_pval_threshold` is ignored.
     key_added
         Name of the `.uns` field that will contain the marker overlap scores.
@@ -128,8 +128,8 @@ def marker_gene_overlap(
     Returns
     -------
     A pandas dataframe with the marker gene overlap scores if `inplace=False`.
-    For `inplace=True` `adata.uns` is updated with an additional field 
-    specified by the `key_added` parameter (default = 'marker_gene_overlap'). 
+    For `inplace=True` `adata.uns` is updated with an additional field
+    specified by the `key_added` parameter (default = 'marker_gene_overlap').
 
 
     Examples
@@ -139,10 +139,10 @@ def marker_gene_overlap(
     >>> sc.pp.neighbors(adata)
     >>> sc.tl.louvain(adata)
     >>> sc.tl.rank_genes_groups(adata, groupby='louvain')
-    >>> marker_genes = {'CD4 T cells':{'IL7R'},'CD14+ Monocytes':{'CD14', 
-    ...                 'LYZ'}, 'B cells':{'MS4A1'}, 'CD8 T cells':{'CD8A'}, 
+    >>> marker_genes = {'CD4 T cells':{'IL7R'},'CD14+ Monocytes':{'CD14',
+    ...                 'LYZ'}, 'B cells':{'MS4A1'}, 'CD8 T cells':{'CD8A'},
     ...                 'NK cells':{'GNLY', 'NKG7'}, 'FCGR3A+ Monocytes':
-    ...                 {'FCGR3A', 'MS4A7'}, 'Dendritic Cells':{'FCER1A', 
+    ...                 {'FCGR3A', 'MS4A7'}, 'Dendritic Cells':{'FCER1A',
     ...                 'CST3'}, 'Megakaryocytes':{'PPBP'}}
     >>> marker_matches = sc.tl.marker_gene_overlap(adata, marker_genes)
     """
@@ -159,14 +159,14 @@ def marker_gene_overlap(
     avail_methods = {'overlap_count', 'overlap_coef', 'jaccard', 'enrich'}
     if method not in avail_methods:
         raise ValueError('Method must be one of {}.'.format(avail_methods))
-    
+
     if normalize == 'None':
         normalize = None
 
     avail_norm = {'reference', 'data', None}
     if normalize not in avail_norm:
         raise ValueError('Normalize must be one of {}.'.format(avail_norm))
-    
+
     if normalize is not None and method != 'overlap_count':
         raise ValueError('Can only normalize with method=`overlap_count`.')
 
@@ -185,25 +185,25 @@ def marker_gene_overlap(
                              'method that outputs adjusted p-values.')
 
         if adj_pval_threshold < 0:
-            logg.warn('`adj_pval_threshold` was set below 0. '
+            logg.warning('`adj_pval_threshold` was set below 0. '
                       'Threshold will be set to 0.')
             adj_pval_threshold = 0
 
         if adj_pval_threshold > 1:
-            logg.warn('`adj_pval_threshold` was set above 1. '
+            logg.warning('`adj_pval_threshold` was set above 1. '
                       'Threshold will be set to 1.')
             adj_pval_threshold = 1
 
         if top_n_markers is not None:
-            logg.warn('Both `adj_pval_threshold` and `top_n_markers` is set. '
+            logg.warning('Both `adj_pval_threshold` and `top_n_markers` is set. '
                       '`adj_pval_threshold` will be ignored.')
-            
+
     if top_n_markers is not None:
         if top_n_markers < 1:
-            logg.warn('`top_n_markers` was set below 1. '
+            logg.warning('`top_n_markers` was set below 1. '
                       '`top_n_markers` will be set to 1.')
             top_n_markers = 1
-            
+
     # Get data-derived marker genes in a dictionary of sets
     data_markers = dict()
     cluster_ids = adata.uns[key]['names'].dtype.names
@@ -219,8 +219,8 @@ def marker_gene_overlap(
             data_markers[group] = set(adata.uns[key]['names'][group][:n_genes])
 
             if n_genes == 0:
-                logg.warn('No marker genes passed the significance threshold of'
-                          ' {} for cluster {!r}.'.format(adj_pval_threshold, 
+                logg.warning('No marker genes passed the significance threshold of'
+                          ' {} for cluster {!r}.'.format(adj_pval_threshold,
                                                         group))
         else:
             data_markers[group] = set(adata.uns[key]['names'][group])
@@ -231,38 +231,38 @@ def marker_gene_overlap(
 
         if normalize == 'reference':
             # Ensure rows sum to 1
-            ref_lengths = np.array([len(reference_markers[m_group]) 
+            ref_lengths = np.array([len(reference_markers[m_group])
                                     for m_group in reference_markers])
             marker_match = marker_match/ref_lengths[:,np.newaxis]
             marker_match = np.nan_to_num(marker_match)
 
         elif normalize == 'data':
             #Ensure columns sum to 1
-            data_lengths = np.array([len(data_markers[dat_group]) 
+            data_lengths = np.array([len(data_markers[dat_group])
                                      for dat_group in data_markers])
             marker_match = marker_match/data_lengths
             marker_match = np.nan_to_num(marker_match)
-            
+
     elif method == 'overlap_coef':
         marker_match = _calc_overlap_coef(reference_markers, data_markers)
 
     elif method == 'jaccard':
         marker_match = _calc_jaccard(reference_markers, data_markers)
-        
+
     #Note:
-    # Could add an 'enrich' option here (fisher's exact test or hypergeometric 
+    # Could add an 'enrich' option here (fisher's exact test or hypergeometric
     # test), but that would require knowledge of the size of the space from which
-    # the reference marker gene set was taken. This is at best approximately 
-    # known. 
-    
+    # the reference marker gene set was taken. This is at best approximately
+    # known.
+
     # Create a pandas dataframe with the results
     marker_groups = list(reference_markers.keys())
     clusters = list(cluster_ids)
-    marker_matching_df = pd.DataFrame(marker_match, index=marker_groups, 
+    marker_matching_df = pd.DataFrame(marker_match, index=marker_groups,
                                       columns=clusters)
 
     # Store the results
-    if inplace: 
+    if inplace:
         adata.uns[key_added] = marker_matching_df
 
         logg.hint(

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -265,9 +265,10 @@ def marker_gene_overlap(
     if inplace: 
         adata.uns[key_added] = marker_matching_df
 
-        logg.hint('added\n'
-                  '    \'{}\', marker overlap scores (adata.uns)'
-                  .format(key_added))
+        logg.hint(
+            'added\n'
+            f'    {key_added!r}, marker overlap scores (adata.uns)'
+        )
 
     else:
         return marker_matching_df

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -7,7 +7,6 @@ from scipy.sparse.csgraph import minimum_spanning_tree
 
 from .. import utils
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 from ..neighbors import Neighbors
 
 _AVAIL_MODELS = {'v1.0', 'v1.2'}

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -85,7 +85,7 @@ def paga(
             'You need to run `pp.neighbors` first to compute a neighborhood graph.')
     adata = adata.copy() if copy else adata
     utils.sanitize_anndata(adata)
-    logg.info('running PAGA')
+    start = logg.info('running PAGA')
     paga = PAGA(adata, groups, model=model)
     # only add if not present
     if 'paga' not in adata.uns:
@@ -103,7 +103,7 @@ def paga(
     adata.uns['paga']['groups'] = groups
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep='added\n' + (
             "    'paga/transitions_confidence', connectivities adjacency (adata.uns)"
             # "    'paga/transitions_ttest', t-test on transitions (adata.uns)"

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -85,7 +85,7 @@ def paga(
             'You need to run `pp.neighbors` first to compute a neighborhood graph.')
     adata = adata.copy() if copy else adata
     utils.sanitize_anndata(adata)
-    logg.info('running PAGA', reset=True)
+    logg.info('running PAGA')
     paga = PAGA(adata, groups, model=model)
     # only add if not present
     if 'paga' not in adata.uns:
@@ -101,17 +101,17 @@ def paga(
         adata.uns['paga']['transitions_confidence'] = paga.transitions_confidence
         # adata.uns['paga']['transitions_ttest'] = paga.transitions_ttest
     adata.uns['paga']['groups'] = groups
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    if use_rna_velocity:
-        logg.hint(
-            'added\n'
-            '    \'paga/transitions_confidence\', connectivities adjacency (adata.uns)')
-        #    '    \'paga/transitions_ttest\', t-test on transitions (adata.uns)')
-    else:
-        logg.hint(
-            'added\n'
-            '    \'paga/connectivities\', connectivities adjacency (adata.uns)\n'
-            '    \'paga/connectivities_tree\', connectivities subtree (adata.uns)')
+    logg.info(
+        '    finished',
+        time=True,
+        deep='added\n' + (
+            "    'paga/transitions_confidence', connectivities adjacency (adata.uns)"
+            # "    'paga/transitions_ttest', t-test on transitions (adata.uns)"
+            if use_rna_velocity else
+            "    'paga/connectivities', connectivities adjacency (adata.uns)\n"
+            "    'paga/connectivities_tree', connectivities subtree (adata.uns)"
+        ),
+    )
     return adata if copy else None
 
 
@@ -227,7 +227,7 @@ class PAGA():
         if vkey not in self._adata.uns:
             if 'velocyto_transitions' in self._adata.uns:
                 self._adata.uns[vkey] = self._adata.uns['velocyto_transitions']
-                logg.debug("The key 'velocyto_transitions' has been changed to 'velocity_graph'.", no_indent=True)
+                logg.debug("The key 'velocyto_transitions' has been changed to 'velocity_graph'.")
             else:
                 raise ValueError(
                     'The passed AnnData needs to have an `uns` annotation '
@@ -404,7 +404,7 @@ def paga_compare_paths(adata1, adata2,
     g1 = nx.Graph(adata1.uns['paga'][adjacency_key])
     g2 = nx.Graph(adata2.uns['paga'][adjacency_key2 if adjacency_key2 is not None else adjacency_key])
     leaf_nodes1 = [str(x) for x in g1.nodes() if g1.degree(x) == 1]
-    logg.debug(f'leaf nodes in graph 1: {leaf_nodes1}', no_indent=True)
+    logg.debug(f'leaf nodes in graph 1: {leaf_nodes1}')
     paga_groups = adata1.uns['paga']['groups']
     asso_groups1 = utils.identify_groups(adata1.obs[paga_groups].values,
                                          adata2.obs[paga_groups].values)
@@ -421,12 +421,11 @@ def paga_compare_paths(adata1, adata2,
     # loop over all pairs of leaf nodes in the reference adata1
     for (r, s) in itertools.combinations(leaf_nodes1, r=2):
         r2, s2 = asso_groups1[r][0], asso_groups1[s][0]
-        orig_names = [orig_names1[int(i)] for i in [r, s]]
-        orig_names += [orig_names2[int(i)] for i in [r2, s2]]
+        on1_g1, on2_g1 = [orig_names1[int(i)] for i in [r, s]]
+        on1_g2, on2_g2 = [orig_names2[int(i)] for i in [r2, s2]]
         logg.debug(
-            'compare shortest paths between leafs ({}, {}) '
-            'in graph1 and ({}, {}) in graph2:'.format(*orig_names),
-            no_indent=True,
+            f'compare shortest paths between leafs ({on1_g1}, {on2_g1}) '
+            f'in graph1 and ({on1_g2}, {on2_g2}) in graph2:'
         )
         try:
             path1 = [str(x) for x in nx.shortest_path(g1, int(r), int(s))]
@@ -442,7 +441,7 @@ def paga_compare_paths(adata1, adata2,
             n_agreeing_paths += 1
             n_steps += 1
             n_agreeing_steps += 1
-            logg.debug('there are no connecting paths in both graphs', no_indent=True)
+            logg.debug('there are no connecting paths in both graphs')
             continue
         elif path1 is None or path2 is None:
             # non-consistent result
@@ -474,8 +473,8 @@ def paga_compare_paths(adata1, adata2,
                         # make sure that a step backward leads us to the same value of l
                         # in case we "jumped"
                         logg.debug(
-                            'found matching step ({} -> {}) at position {} in path{} and position {} in path_mapped'
-                            .format(l, path_compare_orig_names[il + 1], il, path_compare_id, ip)
+                            f'found matching step ({l} -> {path_compare_orig_names[il + 1]}) '
+                            f'at position {il} in path{path_compare_id} and position {ip} in path_mapped'
                         )
                         consistent_history = True
                         for iip in range(ip, ip_progress, -1):
@@ -484,9 +483,10 @@ def paga_compare_paths(adata1, adata2,
                         if consistent_history:
                             # here, we take one step further back (ip_progress - 1); it's implied that this
                             # was ok in the previous step
+                            poss = list(range(ip - 1, ip_progress - 2, -1))
                             logg.debug(
-                                '    step(s) backward to position(s) {} in path_mapped are fine, too: valid step'
-                                .format(list(range(ip - 1, ip_progress - 2, -1)))
+                                f'    step(s) backward to position(s) {poss} '
+                                'in path_mapped are fine, too: valid step'
                             )
                             n_agreeing_steps_path += 1
                             ip_progress = ip + 1
@@ -505,7 +505,6 @@ def paga_compare_paths(adata1, adata2,
             f'path_mapped = {[list(p) for p in path_mapped_orig_names]},\n'
             f'      path2 = {path2_orig_names},\n'
             f'-> n_agreeing_steps = {n_agreeing_steps_path} / n_steps = {n_steps_path}.',
-            no_indent=True,
         )
     Result = namedtuple('paga_compare_paths_result',
                         ['frac_steps', 'n_steps', 'frac_paths', 'n_paths'])

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -109,7 +109,7 @@ def phate(
     (2000, 2)
     >>> sc.pl.phate(adata)
     """
-    logg.info('computing PHATE', r=True)
+    logg.info('computing PHATE')
     adata = adata.copy() if copy else adata
     verbose = settings.verbosity if verbose is None else verbose
     if isinstance(settings.verbosity, (str, int)):
@@ -137,10 +137,14 @@ def phate(
         verbose=verbose,
         **kwargs
     ).fit_transform(adata)
-    logg.info('    finished', time=True,
-              end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
     # update AnnData instance
     adata.obsm['X_phate'] = X_phate  # annotate samples with PHATE coordinates
-    logg.hint('added\n'
-              '    \'X_phate\', PHATE coordinates (adata.obsm)')
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            "    'X_phate', PHATE coordinates (adata.obsm)"
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -109,7 +109,7 @@ def phate(
     (2000, 2)
     >>> sc.pl.phate(adata)
     """
-    logg.info('computing PHATE')
+    start = logg.info('computing PHATE')
     adata = adata.copy() if copy else adata
     verbose = settings.verbosity if verbose is None else verbose
     if isinstance(settings.verbosity, (str, int)):
@@ -141,7 +141,7 @@ def phate(
     adata.obsm['X_phate'] = X_phate  # annotate samples with PHATE coordinates
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             "    'X_phate', PHATE coordinates (adata.obsm)"

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -3,7 +3,6 @@
 
 from .._settings import settings
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 
 
 def phate(

--- a/scanpy/tools/_phenograph.py
+++ b/scanpy/tools/_phenograph.py
@@ -117,7 +117,7 @@ def phenograph( adata,
         
 
     """
-    logg.info('PhenoGraph clustering')
+    start = logg.info('PhenoGraph clustering')
 
     try:
         import phenograph
@@ -140,6 +140,6 @@ def phenograph( adata,
         nn_method=nn_method
     )
 
-    logg.info('    finished', time=True)
+    logg.info('    finished', time=start)
 
     return communities, graph, Q

--- a/scanpy/tools/_phenograph.py
+++ b/scanpy/tools/_phenograph.py
@@ -117,7 +117,7 @@ def phenograph( adata,
         
 
     """
-    logg.info('PhenoGraph clustering', r=True)
+    logg.info('PhenoGraph clustering')
 
     try:
         import phenograph
@@ -127,18 +127,18 @@ def phenograph( adata,
             'pip3 install git+https://github.com/jacoblevine/phenograph.git')
 
     communities, graph, Q = phenograph.cluster(
-                                        data=adata,
-                                        k=k,
-                                        directed=directed,
-                                        prune=prune,
-                                        min_cluster_size=min_cluster_size,
-                                        jaccard=jaccard,
-                                        primary_metric=primary_metric,
-                                        n_jobs=n_jobs,
-                                        q_tol=q_tol,
-                                        louvain_time_limit=louvain_time_limit,
-                                        nn_method=nn_method
-                                        )
+        data=adata,
+        k=k,
+        directed=directed,
+        prune=prune,
+        min_cluster_size=min_cluster_size,
+        jaccard=jaccard,
+        primary_metric=primary_metric,
+        n_jobs=n_jobs,
+        q_tol=q_tol,
+        louvain_time_limit=louvain_time_limit,
+        nn_method=nn_method
+    )
 
     logg.info('    finished', time=True)
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -100,7 +100,7 @@ def rank_genes_groups(
     if 'only_positive' in kwds:
         rankby_abs = not kwds.pop('only_positive')  # backwards compat
 
-    logg.info('ranking genes')
+    start = logg.info('ranking genes')
     avail_methods = {'t-test', 't-test_overestim_var', 'wilcoxon', 'logreg'}
     if method not in avail_methods:
         raise ValueError('Method must be one of {}.'.format(avail_methods))
@@ -409,7 +409,7 @@ def rank_genes_groups(
             dtype=[(rn, 'float64') for rn in groups_order_save])
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             f'added to `.uns[{key_added!r}]`\n'
             "    'names', sorted np.recarray to be indexed by group ids\n"

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -100,7 +100,7 @@ def rank_genes_groups(
     if 'only_positive' in kwds:
         rankby_abs = not kwds.pop('only_positive')  # backwards compat
 
-    logg.info('ranking genes', r=True)
+    logg.info('ranking genes')
     avail_methods = {'t-test', 't-test_overestim_var', 'wilcoxon', 'logreg'}
     if method not in avail_methods:
         raise ValueError('Method must be one of {}.'.format(avail_methods))
@@ -157,8 +157,8 @@ def rank_genes_groups(
     ns = np.zeros(n_groups, dtype=int)
     for imask, mask in enumerate(groups_masks):
         ns[imask] = np.where(mask)[0].size
-    logg.debug('consider \'{}\' groups:'.format(groupby), groups_order)
-    logg.debug('with sizes:', ns)
+    logg.debug(f'consider {groupby!r} groups:')
+    logg.debug(f'with sizes: {ns}')
     if reference != 'rest':
         ireference = np.where(groups_order == reference)[0][0]
     reference_indices = np.arange(adata_comp.n_vars, dtype=int)
@@ -407,16 +407,22 @@ def rank_genes_groups(
         adata.uns[key_added]['pvals_adj'] = np.rec.fromarrays(
             [n for n in rankings_gene_pvals_adj],
             dtype=[(rn, 'float64') for rn in groups_order_save])
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint(
-        'added to `.uns[\'{}\']`\n'
-        '    \'names\', sorted np.recarray to be indexed by group ids\n'
-        '    \'scores\', sorted np.recarray to be indexed by group ids\n'
-        .format(key_added)
-        + ('    \'logfoldchanges\', sorted np.recarray to be indexed by group ids\n'
-           '    \'pvals\', sorted np.recarray to be indexed by group ids\n'
-           '    \'pvals_adj\', sorted np.recarray to be indexed by group ids'
-           if method in {'t-test', 't-test_overestim_var', 'wilcoxon'} else ''))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            f'added to `.uns[{key_added!r}]`\n'
+            "    'names', sorted np.recarray to be indexed by group ids\n"
+            "    'scores', sorted np.recarray to be indexed by group ids\n"
+            + (
+                "    'logfoldchanges', sorted np.recarray to be indexed by group ids\n"
+                "    'pvals', sorted np.recarray to be indexed by group ids\n"
+                "    'pvals_adj', sorted np.recarray to be indexed by group ids"
+                if method in {'t-test', 't-test_overestim_var', 'wilcoxon'} else
+                ''
+            )
+        ),
+    )
     return adata if copy else None
 
 
@@ -474,9 +480,11 @@ def filter_rank_genes_groups(adata, key=None, groupby=None, use_raw=True, log=Tr
     fold_change_matrix = pd.DataFrame(np.zeros(gene_names.shape), columns=gene_names.columns, index=gene_names.index)
     fraction_out_cluster_matrix = pd.DataFrame(np.zeros(gene_names.shape), columns=gene_names.columns,
                                                index=gene_names.index)
-    logg.info("Filtering genes using: min_in_group_fraction: {} "
-              "min_fold_change: {}, max_out_group_fraction: {}".format(min_in_group_fraction, min_fold_change,
-                                                                       max_out_group_fraction))
+    logg.info(
+        f"Filtering genes using: "
+        f"min_in_group_fraction: {min_in_group_fraction} "
+        f"min_fold_change: {min_fold_change}, "
+        f"max_out_group_fraction: {max_out_group_fraction}")
     from ..plotting._anndata import _prepare_dataframe
     for cluster in gene_names.columns:
         # iterate per column

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -9,7 +9,6 @@ from scipy.sparse import issparse
 
 from .. import utils
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 from ..preprocessing._simple import _get_mean_var
 
 

--- a/scanpy/tools/_rna_velocity.py
+++ b/scanpy/tools/_rna_velocity.py
@@ -26,7 +26,7 @@ def compute_velocity_graph(adata, adata_u, X_du):
         vals = np.zeros((n_obs * n_neighbors), dtype=np.float32)
         for i in range(n_obs):
             if i % 1000 == 0:
-                logg.debug('{}/{},'.format(i, n_obs), end=' ')
+                logg.debug(f'{i}/{n_obs},')
             for nj in range(n_neighbors):
                 j = knn_indices[i, nj]
                 if j != i:

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -57,7 +57,7 @@ def score_genes(
     --------
     See this `notebook <https://github.com/theislab/scanpy_usage/tree/master/180209_cell_cycle>`__.
     """
-    logg.info(f'computing score {score_name!r}')
+    start = logg.info(f'computing score {score_name!r}')
     adata = adata.copy() if copy else adata
 
     if random_state:
@@ -130,7 +130,7 @@ def score_genes(
 
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             f'    {score_name!r}, score of gene set (adata.obs)'

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -69,7 +69,7 @@ def score_genes(
         if gene in var_names:
             gene_list_in_var.append(gene)
         else:
-            logg.warn(f'gene: {gene} is not in adata.var_names and will be ignored')
+            logg.warning(f'gene: {gene} is not in adata.var_names and will be ignored')
     gene_list = set(gene_list_in_var[:])
 
     if not gene_pool:

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -57,7 +57,7 @@ def score_genes(
     --------
     See this `notebook <https://github.com/theislab/scanpy_usage/tree/master/180209_cell_cycle>`__.
     """
-    logg.info('computing score \'{}\''.format(score_name), r=True)
+    logg.info(f'computing score {score_name!r}')
     adata = adata.copy() if copy else adata
 
     if random_state:
@@ -69,7 +69,7 @@ def score_genes(
         if gene in var_names:
             gene_list_in_var.append(gene)
         else:
-            logg.warn('gene: {} is not in adata.var_names and will be ignored'.format(gene))
+            logg.warn(f'gene: {gene} is not in adata.var_names and will be ignored')
     gene_list = set(gene_list_in_var[:])
 
     if not gene_pool:
@@ -117,8 +117,9 @@ def score_genes(
     if len(gene_list) == 0:
         # We shouldn't even get here, but just in case
         logg.hint(
-            'could not add \n'
-            '    \'{}\', score of gene set (adata.obs)'.format(score_name))
+            f'could not add \n'
+            f'    {score_name!r}, score of gene set (adata.obs)'
+        )
         return adata if copy else None
     elif len(gene_list) == 1:
         score = _adata[:, gene_list].X - X_control
@@ -127,9 +128,14 @@ def score_genes(
 
     adata.obs[score_name] = pd.Series(np.array(score).ravel(), index=adata.obs_names)
 
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-              '    \'{}\', score of gene set (adata.obs)'.format(score_name))
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            f'    {score_name!r}, score of gene set (adata.obs)'
+        ),
+    )
     return adata if copy else None
 
 

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -6,7 +6,6 @@ import pandas as pd
 from scipy.sparse import issparse
 
 from .. import logging as logg
-from ..logging import _settings_verbosity_greater_or_equal_than
 
 
 def score_genes(

--- a/scanpy/tools/_sim.py
+++ b/scanpy/tools/_sim.py
@@ -187,9 +187,10 @@ def sample_dynamic_data(**params):
                                       nrRealizations=nrRealizations)
                 if real >= nrRealizations:
                     break
-        if False:
-            logg.info('mean nr of offdiagonal edges',nrOffEdges_list.mean(),
-                      'compared to total nr',grnsim.dim*(grnsim.dim-1)/2.)
+        logg.debug(
+            f'mean nr of offdiagonal edges {nrOffEdges_list.mean()} '
+            f'compared to total nr {grnsim.dim*(grnsim.dim-1)/2.}'
+        )
 
     # more complex models
     else:
@@ -251,7 +252,7 @@ def sample_dynamic_data(**params):
     filename = None
     for filename in writedir.glob('sim*.txt'):
         pass
-    logg.info('reading simulation results', filename)
+    logg.info(f'reading simulation results {filename}')
     adata = readwrite._read(filename, first_column_names=True,
                             suppress_cache_warning=True)
     adata.uns['tmax_write'] = tmax/step
@@ -892,10 +893,7 @@ def _check_branching(X,Xsamples,restart,threshold=0.25):
                 check = False
         if check:
             Xsamples.append(X)
-    if not check:
-        logg.debug('realization {}:'.format(restart), 'no new branch')
-    else:
-        logg.debug('realization {}:'.format(restart), 'new branch')
+    logg.debug(f'realization {restart}: {"" if check else "no"} new branch')
     return check, Xsamples
 
 

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -70,15 +70,14 @@ def tsne(
     **X_tsne** : `np.ndarray` (`adata.obs`, dtype `float`)
         tSNE coordinates of data.
     """
-    logg.info('computing tSNE')
+    start = logg.info('computing tSNE')
     adata = adata.copy() if copy else adata
     X = choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs)
     # params for sklearn
-    verbosity = _VERBOSITY_LEVELS_FROM_STRINGS.get(settings.verbosity, settings.verbosity)
     params_sklearn = dict(
         perplexity=perplexity,
         random_state=random_state,
-        verbose=max(0, verbosity-3),
+        verbose=settings.verbosity > 3,
         early_exaggeration=early_exaggeration,
         learning_rate=learning_rate,
     )
@@ -109,7 +108,7 @@ def tsne(
     adata.obsm['X_tsne'] = X_tsne  # annotate samples with tSNE coordinates
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             "    'X_tsne', tSNE coordinates (adata.obsm)"

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -70,7 +70,7 @@ def tsne(
     **X_tsne** : `np.ndarray` (`adata.obs`, dtype `float`)
         tSNE coordinates of data.
     """
-    logg.info('computing tSNE', r=True)
+    logg.info('computing tSNE')
     adata = adata.copy() if copy else adata
     X = choose_representation(adata, use_rep=use_rep, n_pcs=n_pcs)
     # params for sklearn
@@ -107,7 +107,12 @@ def tsne(
         X_tsne = tsne.fit_transform(X)
     # update AnnData instance
     adata.obsm['X_tsne'] = X_tsne  # annotate samples with tSNE coordinates
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-              '    \'X_tsne\', tSNE coordinates (adata.obsm)')
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            "    'X_tsne', tSNE coordinates (adata.obsm)"
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -2,10 +2,6 @@ from .. utils import doc_params
 from ..tools._utils import choose_representation, doc_use_rep, doc_n_pcs
 from .._settings import settings
 from .. import logging as logg
-from ..logging import (
-    _VERBOSITY_LEVELS_FROM_STRINGS,
-    _settings_verbosity_greater_or_equal_than,
-)
 
 
 @doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -94,7 +94,7 @@ def tsne(
             X_tsne = tsne.fit_transform(X.astype('float64'))
             multicore_failed = False
         except ImportError:
-            logg.warn('Consider installing the package MulticoreTSNE '
+            logg.warning('Consider installing the package MulticoreTSNE '
                       '(https://github.com/DmitryUlyanov/Multicore-TSNE). '
                       'Even for n_jobs=1 this speeds up the computation considerably '
                       'and might yield better converged results.')

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -1,10 +1,6 @@
 from ._utils import get_init_pos_from_paga, choose_representation
 from .._settings import settings
 from .. import logging as logg
-from ..logging import (
-    _settings_verbosity_greater_or_equal_than,
-    _VERBOSITY_LEVELS_FROM_STRINGS,
-)
 
 def umap(
     adata,

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -99,7 +99,7 @@ def umap(
     logg.info('computing UMAP')
     if ('params' not in adata.uns['neighbors']
         or adata.uns['neighbors']['params']['method'] != 'umap'):
-        logg.warn('neighbors/connectivities have not been computed using umap')
+        logg.warning('neighbors/connectivities have not been computed using umap')
     from umap.umap_ import find_ab_params, simplicial_set_embedding
     if a is None or b is None:
         a, b = find_ab_params(spread, min_dist)

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -96,7 +96,7 @@ def umap(
     if 'neighbors' not in adata.uns:
         raise ValueError(
             'Did not find \'neighbors/connectivities\'. Run `sc.pp.neighbors` first.')
-    logg.info('computing UMAP')
+    start = logg.info('computing UMAP')
     if ('params' not in adata.uns['neighbors']
         or adata.uns['neighbors']['params']['method'] != 'umap'):
         logg.warning('neighbors/connectivities have not been computed using umap')
@@ -115,7 +115,6 @@ def umap(
     from sklearn.utils import check_random_state
     random_state = check_random_state(random_state)
     n_epochs = 0 if maxiter is None else maxiter
-    verbosity = _VERBOSITY_LEVELS_FROM_STRINGS.get(settings.verbosity, settings.verbosity)
     neigh_params = adata.uns['neighbors']['params']
     X = choose_representation(
         adata, neigh_params.get('use_rep', None), neigh_params.get('n_pcs', None), silent=True)
@@ -135,11 +134,12 @@ def umap(
         random_state,
         neigh_params.get('metric', 'euclidean'),
         neigh_params.get('metric_kwds', {}),
-        verbose=max(0, verbosity-3))
+        verbose=settings.verbosity > 3,
+    )
     adata.obsm['X_umap'] = X_umap  # annotate samples with UMAP coordinates
     logg.info(
         '    finished',
-        time=True,
+        time=start,
         deep=(
             'added\n'
             "    'X_umap', UMAP coordinates (adata.obsm)"

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -96,7 +96,7 @@ def umap(
     if 'neighbors' not in adata.uns:
         raise ValueError(
             'Did not find \'neighbors/connectivities\'. Run `sc.pp.neighbors` first.')
-    logg.info('computing UMAP', r=True)
+    logg.info('computing UMAP')
     if ('params' not in adata.uns['neighbors']
         or adata.uns['neighbors']['params']['method'] != 'umap'):
         logg.warn('neighbors/connectivities have not been computed using umap')
@@ -137,7 +137,12 @@ def umap(
         neigh_params.get('metric_kwds', {}),
         verbose=max(0, verbosity-3))
     adata.obsm['X_umap'] = X_umap  # annotate samples with UMAP coordinates
-    logg.info('    finished', time=True, end=' ' if _settings_verbosity_greater_or_equal_than(3) else '\n')
-    logg.hint('added\n'
-              '    \'X_umap\', UMAP coordinates (adata.obsm)')
+    logg.info(
+        '    finished',
+        time=True,
+        deep=(
+            'added\n'
+            "    'X_umap', UMAP coordinates (adata.obsm)"
+        ),
+    )
     return adata if copy else None

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -32,7 +32,7 @@ def choose_representation(adata, use_rep=None, n_pcs=None, silent=False):
                 X = adata.obsm['X_pca'][:, :n_pcs]
                 logg.info(f'    using \'X_pca\' with n_pcs = {X.shape[1]}')
             else:
-                logg.warn(
+                logg.warning(
                     f'You’re trying to run this on {adata.n_vars} dimensions of `.X`, '
                     'if you really want this, set `use_rep=\'X\'`.\n         '
                     'Falling back to preprocessing with `sc.pp.pca` and default params.'

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -30,13 +30,13 @@ def choose_representation(adata, use_rep=None, n_pcs=None, silent=False):
                     raise ValueError(
                         '`X_pca` does not have enough PCs. Rerun `sc.pp.pca` with adjusted `n_comps`.')
                 X = adata.obsm['X_pca'][:, :n_pcs]
-                logg.info('    using \'X_pca\' with n_pcs = {}'.format(X.shape[1]))
+                logg.info(f'    using \'X_pca\' with n_pcs = {X.shape[1]}')
             else:
                 logg.warn(
-                    'You\'re trying to run this on {} dimensions of `.X`, '
+                    f'You’re trying to run this on {adata.n_vars} dimensions of `.X`, '
                     'if you really want this, set `use_rep=\'X\'`.\n         '
                     'Falling back to preprocessing with `sc.pp.pca` and default params.'
-                    .format(adata.n_vars))
+                )
                 X = pca(adata.X)
                 adata.obsm['X_pca'] = X[:, :n_pcs]
         else:
@@ -68,18 +68,16 @@ def preprocess_with_pca(adata, n_pcs=None, random_state=0):
         logg.info('    using data matrix X directly (no PCA)')
         return adata.X
     elif n_pcs is None and 'X_pca' in adata.obsm_keys():
-        logg.info('    using \'X_pca\' with n_pcs = {}'
-                  .format(adata.obsm['X_pca'].shape[1]))
+        logg.info(f'    using \'X_pca\' with n_pcs = {adata.obsm["X_pca"].shape[1]}')
         return adata.obsm['X_pca']
     elif ('X_pca' in adata.obsm_keys()
           and adata.obsm['X_pca'].shape[1] >= n_pcs):
-        logg.info('    using \'X_pca\' with n_pcs = {}'
-                  .format(n_pcs))
+        logg.info(f'    using \'X_pca\' with n_pcs = {n_pcs}')
         return adata.obsm['X_pca'][:, :n_pcs]
     else:
         n_pcs = N_PCS if n_pcs is None else n_pcs
         if adata.X.shape[1] > n_pcs:
-            logg.info('    computing \'X_pca\' with n_pcs = {}'.format(n_pcs))
+            logg.info(f'    computing \'X_pca\' with n_pcs = {n_pcs}')
             logg.hint('avoid this by setting n_pcs = 0')
             X = pca(adata.X, n_comps=n_pcs, random_state=random_state)
             adata.obsm['X_pca'] = X

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -45,7 +45,7 @@ def check_versions():
         from . import __version__
         # make this a warning, not an error
         # it might be useful for people to still be able to run it
-        logg.warn(
+        logg.warning(
             f'Scanpy {__version__} needs umap '
             f'version >=0.3.0, not {umap.__version__}.'
         )
@@ -387,7 +387,7 @@ def get_igraph_from_adjacency(adjacency, directed=None):
     except:
         pass
     if g.vcount() != adjacency.shape[0]:
-        logg.warn(
+        logg.warning(
             f'The constructed graph has only {g.vcount()} nodes. '
             'Your adjacency matrix contained redundant nodes.'
         )

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -45,8 +45,10 @@ def check_versions():
         from . import __version__
         # make this a warning, not an error
         # it might be useful for people to still be able to run it
-        logg.warn('Scanpy {} needs umap version >=0.3.0, not {}.'
-                  .format(__version__, umap.__version__))
+        logg.warn(
+            f'Scanpy {__version__} needs umap '
+            f'version >=0.3.0, not {umap.__version__}.'
+        )
 
 
 def getdoc(c_or_f: Union[Callable, type]) -> Optional[str]:
@@ -226,9 +228,9 @@ def cross_entropy_neighbors_in_rep(adata, use_rep, n_points=3):
     n_edges_cmp = len(graph_cmp.nonzero()[0])
     n_edges_union = len(edgeset_union)
     logg.debug(
-        '... n_edges_ref', n_edges_ref,
-        'n_edges_cmp', n_edges_cmp,
-        'n_edges_union', n_edges_union,
+        f'... n_edges_ref {n_edges_ref} '
+        f'n_edges_cmp {n_edges_cmp} '
+        f'n_edges_union {n_edges_union} '
     )
 
     graph_ref = graph_ref.tocsr()  # need a copy of the csr graph anyways
@@ -253,9 +255,9 @@ def cross_entropy_neighbors_in_rep(adata, use_rep, n_points=3):
     fraction_edges = n_edges_ref / n_edges_fully_connected
     naive_entropy = (fraction_edges * np.log(1./fraction_edges)
                      + (1-fraction_edges) * np.log(1./(1-fraction_edges)))
-    logg.debug('cross entropy of naive sparse prediction {:.3e}'.format(naive_entropy))
-    logg.debug('cross entropy of random prediction {:.3e}'.format(-np.log(0.5)))
-    logg.info('cross entropy {:.3e}'.format(entropy))
+    logg.debug(f'cross entropy of naive sparse prediction {naive_entropy:.3e}')
+    logg.debug(f'cross entropy of random prediction {-np.log(0.5):.3e}')
+    logg.info(f'cross entropy {entropy:.3e}')
 
     # for manifold analysis, restrict to largest connected component in
     # reference
@@ -265,7 +267,7 @@ def cross_entropy_neighbors_in_rep(adata, use_rep, n_points=3):
     largest_component = np.arange(graph_ref.shape[0], dtype=int)
     if n_components > 1:
         component_sizes = np.bincount(labels)
-        logg.debug('largest component has size', component_sizes.max())
+        logg.debug(f'largest component has size {component_sizes.max()}')
         largest_component = np.where(
             component_sizes == component_sizes.max())[0][0]
         graph_ref_red = graph_ref.tocsr()[labels == largest_component, :]
@@ -326,18 +328,18 @@ def cross_entropy_neighbors_in_rep(adata, use_rep, n_points=3):
             adata_ref.uns['highlights'][points2[ip]] = 'D' + str(ip)
             found_disconnected_points = True
     if found_disconnected_points:
-        logg.debug('most disconnected points', points)
-        logg.debug('    with weights', weights[max_weights].round(1))
+        logg.debug(f'most disconnected points {points}')
+        logg.debug(f'    with weights {weights[max_weights].round(1)}')
 
     max_weights = np.argpartition(
         weights_overlap, kth=-n_points)[-n_points:]
     points = list(edgeset_union_indices[0][max_weights])
     for p in points:
         adata_ref.uns['highlights'][p] = 'O'
-    logg.debug('most overlapping points', points)
-    logg.debug('    with weights', weights_overlap[max_weights].round(1))
-    logg.debug('    with d_rep', d_cmp[max_weights].round(1))
-    logg.debug('    with d_ref', d_ref[max_weights].round(1))
+    logg.debug(f'most overlapping points {points}')
+    logg.debug(f'    with weights {weights_overlap[max_weights].round(1)}')
+    logg.debug(f'    with d_rep {d_cmp[max_weights].round(1)}')
+    logg.debug(f'    with d_ref {d_ref[max_weights].round(1)}')
 
     geo_entropy_d = np.sum(weights * p_ref * np.log(ratio))
     geo_entropy_o = np.sum(weights_overlap * (1-p_ref) * np.log(ratio_1m))
@@ -345,7 +347,7 @@ def cross_entropy_neighbors_in_rep(adata, use_rep, n_points=3):
     geo_entropy_d /= n_edges_fully_connected
     geo_entropy_o /= n_edges_fully_connected
 
-    logg.info('geodesic cross entropy {:.3e}'.format(geo_entropy_d + geo_entropy_o))
+    logg.info(f'geodesic cross entropy {geo_entropy_d + geo_entropy_o:.3e}')
     return entropy, geo_entropy_d, geo_entropy_o
 
 
@@ -383,9 +385,10 @@ def get_igraph_from_adjacency(adjacency, directed=None):
     except:
         pass
     if g.vcount() != adjacency.shape[0]:
-        logg.warn('The constructed graph has only {} nodes. '
-                  'Your adjacency matrix contained redundant nodes.'
-                  .format(g.vcount()))
+        logg.warn(
+            f'The constructed graph has only {g.vcount()} nodes. '
+            'Your adjacency matrix contained redundant nodes.'
+        )
     return g
 
 
@@ -445,9 +448,10 @@ def compute_association_matrix_of_groups(adata, prediction, reference,
     cats = adata.obs[reference].cat.categories
     for cat in cats:
         if cat in settings.categories_to_ignore:
-            logg.info('Ignoring category \'{}\' '
-                      'as it\'s in `settings.categories_to_ignore`.'
-                      .format(cat))
+            logg.info(
+                f'Ignoring category {cat!r} '
+                'as it’s in `settings.categories_to_ignore`.'
+            )
     asso_names = []
     asso_matrix = []
     for ipred_group, pred_group in enumerate(
@@ -721,9 +725,8 @@ def select_groups(adata, groups_order_subset='all', key='groups'):
                                           np.array(groups_order_subset)))[0]
         if len(groups_ids) == 0:
             logg.debug(
-                np.array(groups_order_subset),
-                'invalid! specify valid groups_order (or indices) one of',
-                adata.obs[key].cat.categories,
+                f'{np.array(groups_order_subset)} invalid! specify valid '
+                f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
             exit(0)
@@ -861,7 +864,7 @@ def subsample(X, subsample=1, seed=0):
         n = int(X.shape[0]/subsample)
         np.random.seed(seed)
         Xsampled, rows = subsample_n(X, n=n)
-    logg.debug('... subsampled to', n, 'of', X.shape[0], 'data points')
+    logg.debug(f'... subsampled to {n} of {X.shape[0]} data points')
     return Xsampled, rows
 
 

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -117,7 +117,9 @@ def descend_classes_and_funcs(mod: ModuleType, root: str, encountered=None):
         if isinstance(obj, Callable) and not isinstance(obj, MethodType):
             yield obj
             if isinstance(obj, type):
-                yield from (m for m in vars(obj).values() if isinstance(m, Callable))
+                for m in vars(obj).values():
+                    if isinstance(m, Callable) and getattr(m, '__module__', None) != 'builtins':
+                        yield m
         elif isinstance(obj, ModuleType) and obj not in encountered:
             encountered.add(obj)
             yield from descend_classes_and_funcs(obj, root, encountered)

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
         doc=['sphinx', 'sphinx_rtd_theme', 'sphinx_autodoc_typehints', 'scanpydoc'],
-        test=['pytest>=3.9', 'dask[array]', 'zappy', 'zarr'],
+        test=['pytest>=4.4', 'dask[array]', 'zappy', 'zarr'],
     ),
     packages=find_packages(),
     # `package_data` does NOT work for source distributions!!!


### PR DESCRIPTION
Here we go. ~~It’s not done yet~~:

- [x] The timing stuff isn’t yet implemented. I think we just do timing stuff when doing “info” level logging, correct?

    If yes, we probably just need to override `RootLogger.info` so it sets `self.handlers[0].formatter.passed_time = kwargs.get('t', False)`.

- [x] All the places hackily using `_settings_verbosity_greater_or_equal_than(2|3)` have to work differently. I propose that we just add a kwarg `deepinfo: str` or so which only adds the passed string to the message if the active verbosity is higher than the function’s (i.e. calling `logging.warn('foo', deepinfo='bar')` and the loglevel/verbosity is 'INFO' or noisier adds 'bar')

- [x] We now use vanilla log function syntax, so no more using it like `print`. We switched to Python 3.6+ though, so I propose f-strings everywhere! That looks better and works.

Fixes #256