### PR TITLE
Move adding `--internet-tests` option back to `conftest.py`

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+# Command line options for pytest must be added from conftest.py from where
+# `pytest` is called.
 def pytest_addoption(parser):
     parser.addoption(
         "--internet-tests",

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,19 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--internet-tests",
+        action="store_true",
+        default=False,
+        help="Run tests that retrieve stuff from the internet. This increases test time.",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    run_internet = config.getoption("--internet-tests")
+    skip_internet = pytest.mark.skip(reason="need --internet-tests option to run")
+    for item in items:
+        # All tests marked with `pytest.mark.internet` get skipped unless
+        # `--run-internet` passed
+        if not run_internet and ("internet" in item.keywords):
+            item.add_marker(skip_internet)

--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -1,34 +1,14 @@
 from pathlib import Path
 
-import pytest
-
 import matplotlib as mpl
 mpl.use('agg')
 from matplotlib import pyplot
 from matplotlib.testing.compare import compare_images
+import pytest
 
 import scanpy
 
 scanpy.settings.verbosity = "hint"
-
-
-def pytest_addoption(parser):
-    parser.addoption(
-        "--internet-tests",
-        action="store_true",
-        default=False,
-        help="Run tests that retrieve stuff from the internet. This increases test time.",
-    )
-
-
-def pytest_collection_modifyitems(config, items):
-    run_internet = config.getoption("--internet-tests")
-    skip_internet = pytest.mark.skip(reason="need --internet-tests option to run")
-    for item in items:
-        # All tests marked with `pytest.mark.internet` get skipped unless
-        # `--run-internet` passed
-        if not run_internet and ("internet" in item.keywords):
-            item.add_marker(skip_internet)
 
 
 def make_comparer(path_expected: Path, path_actual: Path, *, tol: int):


### PR DESCRIPTION
`pytest_addoption` and `pytest_collection_modifyitems` have to be defined where `pytest` gets called from, otherwise they don't work.

@flying-sheep, I saw you had changed this in d979267f48607fd609954c96cd5c586b6135dc30. Was there a functional reason you moved these things, or was it aesthetic?