### PR TITLE
Defer import of seaborn

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -10,7 +10,7 @@ from matplotlib import rcParams
 from matplotlib import gridspec
 from matplotlib import patheffects
 from matplotlib.colors import is_color_like
-import seaborn as sns
+
 
 from .._settings import settings
 from .. import logging as logg
@@ -622,6 +622,7 @@ def violin(adata, keys, groupby=None, log=False, use_raw=None, stripplot=True, j
     -------
     A :class:`~matplotlib.axes.Axes` object if `ax` is `None` else `None`.
     """
+    import seaborn as sns  # Slow import, only import if called
     sanitize_anndata(adata)
     if use_raw is None and adata.raw is not None: use_raw = True
     if isinstance(keys, str): keys = [keys]
@@ -746,6 +747,7 @@ def clustermap(
     >>> adata = sc.datasets.krumsiek11()
     >>> sc.pl.clustermap(adata, obs_keys='cell_type')
     """
+    import seaborn as sns  # Slow import, only import if called
     if not isinstance(obs_keys, (str, type(None))):
         raise ValueError('Currently, only a single key is supported.')
     sanitize_anndata(adata)
@@ -836,6 +838,7 @@ def stacked_violin(adata, var_names, groupby=None, log=False, use_raw=None, num_
     >>> markers = {{'T-cell': 'CD3D', 'B-cell': 'CD79A', 'myeloid': 'CST3'}}
     >>> sc.pl.stacked_violin(adata, markers, groupby='bulk_labels', dendrogram=True)
     """
+    import seaborn as sns  # Slow import, only import if called
     if use_raw is None and adata.raw is not None: use_raw = True
     var_names, var_group_labels, var_group_positions = _check_var_names_type(var_names,
                                                                              var_group_labels, var_group_positions)

--- a/scanpy/plotting/_qc.py
+++ b/scanpy/plotting/_qc.py
@@ -1,4 +1,3 @@
-import seaborn as sns
 from matplotlib import pyplot as plt
 import pandas as pd
 from . import _utils as utils
@@ -47,6 +46,7 @@ def highest_expr_genes(
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes`.
     """
+    import seaborn as sns  # Slow import, only import if called
     from scipy.sparse import issparse
 
     # compute the percentage of each gene per cell

--- a/scanpy/plotting/_top_genes_visual.py
+++ b/scanpy/plotting/_top_genes_visual.py
@@ -4,7 +4,6 @@
 are captured here and accessed through the standard function call sc.pl.
 """
 
-import seaborn as sns
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.sparse import issparse
@@ -34,7 +33,7 @@ def correlation_matrix(adata,groupby=None ,group=None, corr_matrix=None, annotat
                 If specified, looks in data annotation for this key.
 
         """
-
+    import seaborn as sns  # Slow import, only import if called
     # TODO: At the moment, noly works for int identifiers
 
     if corr_matrix is None:


### PR DESCRIPTION
Cuts around 1 second off import of scanpy.

```sh
isaac@Mimir ~/github/scanpy$ time python3 -c "import scanpy"                        ✭defer-seaborn 
python3 -c "import scanpy"  3.36s user 0.61s system 104% cpu 3.801 total
isaac@Mimir ~/github/scanpy$ git checkout master                                    ✭defer-seaborn 
Switched to branch 'master'
Your branch is up to date with 'upstream/master'.
isaac@Mimir ~/github/scanpy$ time python3 -c "import scanpy"                               ✭master 
python3 -c "import scanpy"  4.23s user 0.48s system 108% cpu 4.324 total
```

I'd like to cut down import time even more, but I figure this is a good place to start.