### PR TITLE
Defer loading of umap to speed up import

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python:
   - '3.6'
   - '3.7'
-  - '3.8-dev'
+  #- '3.8-dev' # https://github.com/numpy/numpy/issues/13790
 cache: pip
 install:
   - pip install docutils sphinx

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: python
 python:
   - '3.6'
   - '3.7'
+  - '3.8-dev'
 cache: pip
 install:
   - pip install docutils sphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ seaborn
 h5py
 tables
 tqdm
-importlib_metadata; python_version in '3.6;3.7'
+importlib_metadata; python_version < '3.8'
 # exclude buggy versions
 scikit-learn >= 0.19.1, != 0.21.0, != 0.21.1
 statsmodels>=0.10.0rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ seaborn
 h5py
 tables
 tqdm
-importlib_metadata ; python_version<'3.8'
+importlib_metadata; python_version in '3.6;3.7'
 # exclude buggy versions
 scikit-learn >= 0.19.1, != 0.21.0, != 0.21.1
 statsmodels>=0.10.0rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ seaborn
 h5py
 tables
 tqdm
-importlib_metadata
+importlib_metadata ; python_version<'3.8'
 # exclude buggy versions
 scikit-learn >= 0.19.1, != 0.21.0, != 0.21.1
 statsmodels>=0.10.0rc2

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ seaborn
 h5py
 tables
 tqdm
+importlib_metadata
 # exclude buggy versions
 scikit-learn >= 0.19.1, != 0.21.0, != 0.21.1
 statsmodels>=0.10.0rc2

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -25,29 +25,29 @@ EPS = 1e-15
 
 def check_versions():
     from distutils.version import LooseVersion
+    from importlib_metadata import version
 
     if sys.version_info < (3, 6):
         warnings.warn('Scanpy prefers Python 3.6 or higher. '
                       'Currently, Python 3.5 leads to a bug in `tl.marker_gene_overlap` '
                       'and we might stop supporting it in the future.')
 
-    import anndata, umap
-    # NOTE: pytest does not correctly retrieve anndata's version? why?
-    #       use the following hack...
-    if anndata.__version__ != '0+unknown':
-        if anndata.__version__ < LooseVersion('0.6.10'):
-            from . import __version__
-            raise ImportError('Scanpy {} needs anndata version >=0.6.10, not {}.\n'
-                              'Run `pip install anndata -U --no-deps`.'
-                              .format(__version__, anndata.__version__))
+    anndata_version = version("anndata")
+    umap_version = version("umap-learn")
 
-    if umap.__version__ < LooseVersion('0.3.0'):
+    if anndata_version < LooseVersion('0.6.10'):
+        from . import __version__
+        raise ImportError('Scanpy {} needs anndata version >=0.6.10, not {}.\n'
+                            'Run `pip install anndata -U --no-deps`.'
+                            .format(__version__, anndata_version))
+
+    if umap_version < LooseVersion('0.3.0'):
         from . import __version__
         # make this a warning, not an error
         # it might be useful for people to still be able to run it
         logg.warning(
             f'Scanpy {__version__} needs umap '
-            f'version >=0.3.0, not {umap.__version__}.'
+            f'version >=0.3.0, not {umap_version}.'
         )
 
 

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -25,11 +25,10 @@ EPS = 1e-15
 
 def check_versions():
     from distutils.version import LooseVersion
-    import importlib
 
-    if importlib.util.find_spec("importlib.metadata") is not None:
+    try:
         from importlib.metadata import version
-    else:
+    except ImportError:  # < Python 3.8: Use backport module
         from importlib_metadata import version
 
     if sys.version_info < (3, 6):

--- a/scanpy/utils.py
+++ b/scanpy/utils.py
@@ -25,7 +25,12 @@ EPS = 1e-15
 
 def check_versions():
     from distutils.version import LooseVersion
-    from importlib_metadata import version
+    import importlib
+
+    if importlib.util.find_spec("importlib.metadata") is not None:
+        from importlib.metadata import version
+    else:
+        from importlib_metadata import version
 
     if sys.version_info < (3, 6):
         warnings.warn('Scanpy prefers Python 3.6 or higher. '


### PR DESCRIPTION
Follow up to #703, this should take import times down another second. It does add a dependency, but that dependency will be in the stdlib from 3.8+.

After this it looks like the next biggest contributors to import times are caused by `numba` (which would be hard to factor out) and `sklearn.metrics`, but these are on a smaller scale. Evidence of speedup:

```sh
isaac@Mimir ~/github/scanpy$ time python3 -c "import scanpy as sc"                      ✹ ✭master 
python3 -c "import scanpy as sc"  3.10s user 0.41s system 116% cpu 3.010 total
isaac@Mimir ~/github/scanpy$ git checkout defer-umap                                    ✹ ✭master 
Switched to branch 'defer-umap'
Your branch is up to date with 'origin/defer-umap'.
isaac@Mimir ~/github/scanpy$ time python3 -c "import scanpy as sc"                  ✹ ✭defer-umap 
python3 -c "import scanpy as sc"  2.18s user 0.42s system 131% cpu 1.981 total
```