### PR TITLE
making Cell ranger's normalized dispersion (for highly variable gene selection) not absolute

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -128,12 +128,9 @@ def _highly_variable_genes_single_batch(
         with warnings.catch_warnings():
             warnings.simplefilter('ignore')
             disp_mad_bin = disp_grouped.apply(robust.mad)
-        df['dispersions_norm'] = (
-            np.abs(
-                df['dispersions'].values
+            df['dispersions_norm'] = (df['dispersions'].values
                 - disp_median_bin[df['mean_bin'].values].values
-            ) / disp_mad_bin[df['mean_bin'].values].values
-        )
+                ) / disp_mad_bin[df['mean_bin'].values].values
     else:
         raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
     dispersion_norm = df['dispersions_norm'].values.astype('float32')


### PR DESCRIPTION
Deleted abs(...) from normalized dispersion definition. Taking the absolute dispersion will also result in selection of genes with dispersion lower than the bin's median, whereas we only want to select genes with dispersion higher than the bin's median.