### PR TITLE
Fix obs_df, var_df for sparse obsm, varm

### DIFF
--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -3,7 +3,7 @@ from typing import Optional, Iterable, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy import sparse
+from scipy.sparse import spmatrix
 
 from anndata import AnnData
 # --------------------------------------------------------------------------------
@@ -146,10 +146,13 @@ def obs_df(
         df[k] = adata.obs_vector(l, layer=layer)
     for k, idx in obsm_keys:
         added_k = f"{k}-{idx}"
-        if isinstance(adata.obsm[k], (np.ndarray, sparse.csr_matrix)):
-            df[added_k] = np.ravel(adata.obsm[k][:, idx])
-        elif isinstance(adata.obsm[k], pd.DataFrame):
-            df[added_k] = adata.obsm[k].loc[:, idx]
+        val = adata.obsm[k]
+        if isinstance(val, np.ndarray):
+            df[added_k] = np.ravel(val[:, idx])
+        elif isinstance(val, spmatrix):
+            df[added_k] = np.ravel(val[:, idx].toarray())
+        elif isinstance(val, pd.DataFrame):
+            df[added_k] = val.loc[:, idx]
     return df
 
 
@@ -201,8 +204,11 @@ def var_df(
         df[k] = adata.var_vector(l, layer=layer)
     for k, idx in varm_keys:
         added_k = f"{k}-{idx}"
-        if isinstance(adata.varm[k], (np.ndarray, sparse.csr_matrix)):
-            df[added_k] = np.ravel(adata.varm[k][:, idx])
-        elif isinstance(adata.varm[k], pd.DataFrame):
-            df[added_k] = adata.varm[k].loc[:, idx]
+        val = adata.varm[k]
+        if isinstance(val, np.ndarray):
+            df[added_k] = np.ravel(val[:, idx])
+        elif isinstance(val, spmatrix):
+            df[added_k] = np.ravel(val[:, idx].toarray())
+        elif isinstance(val, pd.DataFrame):
+            df[added_k] = val.loc[:, idx]
     return df

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -3,6 +3,7 @@ from itertools import repeat, chain
 import numpy as np
 import pandas as pd
 import pytest
+from scipy import sparse
 
 import scanpy as sc
 
@@ -12,16 +13,16 @@ def test_obs_df():
         X=np.ones((2, 2)),
         obs=pd.DataFrame({"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]),
         var=pd.DataFrame({"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]),
-        obsm={"eye": np.eye(2)},
+        obsm={"eye": np.eye(2), "sparse": sparse.csr_matrix(np.eye(2))},
         layers={"double": np.ones((2, 2)) * 2}
     )
     assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0)]),
-        pd.DataFrame({"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0]}, index=adata.obs_names)
+        sc.get.obs_df(adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)]),
+        pd.DataFrame({"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names)
     ))
     assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["genesymbol2", "obs1"], obsm_keys=[("eye", 0)], gene_symbols="gene_symbols"),
-        pd.DataFrame({"genesymbol2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0]}, index=adata.obs_names)
+        sc.get.obs_df(adata, keys=["genesymbol2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)], gene_symbols="gene_symbols"),
+        pd.DataFrame({"genesymbol2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names)
     ))
     assert np.all(np.equal(
         sc.get.obs_df(adata, keys=["gene2", "obs1"], layer="double"),
@@ -38,12 +39,12 @@ def test_var_df():
         X=np.ones((2, 2)),
         obs=pd.DataFrame({"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]),
         var=pd.DataFrame({"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]),
-        varm={"eye": np.eye(2)},
+        varm={"eye": np.eye(2), "sparse": sparse.csr_matrix(np.eye(2))},
         layers={"double": np.ones((2, 2)) * 2}
     )
     assert np.all(np.equal(
-        sc.get.var_df(adata, keys=["cell2", "gene_symbols"], varm_keys=[("eye", 0)]),
-        pd.DataFrame({"cell2": [1, 1], "gene_symbols": ["genesymbol1", "genesymbol2"], "eye-0": [1, 0]}, index=adata.obs_names)
+        sc.get.var_df(adata, keys=["cell2", "gene_symbols"], varm_keys=[("eye", 0), ("sparse", 1)]),
+        pd.DataFrame({"cell2": [1, 1], "gene_symbols": ["genesymbol1", "genesymbol2"], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names)
     ))
     assert np.all(np.equal(
         sc.get.var_df(adata, keys=["cell1", "gene_symbols"], layer="double"),


### PR DESCRIPTION
Previously, retrieving values from sparse matrices stored in obsm, varm via obs_df and var_df would silently fail.