### PR TITLE
Update verbosity call in sc.external.tl.phate

### DIFF
--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -1,7 +1,7 @@
 """Embed high-dimensional data using PHATE
 """
 
-from .._settings import settings, Verbosity
+from .._settings import settings
 from .. import logging as logg
 
 
@@ -147,4 +147,3 @@ def phate(
         ),
     )
     return adata if copy else None
-https://graphtools.readthedocs.io/en/latest/reference.html#graphtools.api.Graph

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -113,7 +113,7 @@ def phate(
     adata = adata.copy() if copy else adata
     verbose = settings.verbosity if verbose is None else verbose
     if isinstance(settings.verbosity, (str, int)):
-        verbose = _settings_verbosity_greater_or_equal_than(2)
+        verbose = verbose if int(verbose) <= 2 else 2
     n_jobs = settings.n_jobs if n_jobs is None else n_jobs
     try:
         import phate

--- a/scanpy/tools/_phate.py
+++ b/scanpy/tools/_phate.py
@@ -1,7 +1,7 @@
 """Embed high-dimensional data using PHATE
 """
 
-from .._settings import settings
+from .._settings import settings, Verbosity
 from .. import logging as logg
 
 
@@ -81,7 +81,7 @@ def phate(
     random_state : `int`, `numpy.RandomState` or `None`, optional (default: `None`)
         Random seed. Defaults to the global `numpy` random number generator
     verbose : `bool`, `int` or `None`, optional (default: `sc.settings.verbosity`)
-        If `True` or an integer `>= 2`, print status messages.
+        If `True` or an `int`/`Verbosity` ≥ 2/`hint`, print status messages.
         If `None`, `sc.settings.verbosity` is used.
     copy : `bool` (default: `False`)
         Return a copy instead of writing to `adata`.
@@ -111,9 +111,8 @@ def phate(
     """
     start = logg.info('computing PHATE')
     adata = adata.copy() if copy else adata
-    verbose = settings.verbosity if verbose is None else verbose
-    if isinstance(settings.verbosity, (str, int)):
-        verbose = verbose if int(verbose) <= 2 else 2
+    verbosity = settings.verbosity if verbose is None else verbose
+    verbose = verbosity if isinstance(verbosity, bool) else verbosity >= 2
     n_jobs = settings.n_jobs if n_jobs is None else n_jobs
     try:
         import phate
@@ -148,3 +147,4 @@ def phate(
         ),
     )
     return adata if copy else None
+https://graphtools.readthedocs.io/en/latest/reference.html#graphtools.api.Graph


### PR DESCRIPTION
The phate too makes a call to a function named `_settings_verbosity_greater_or_equal_than()`, which appears to no longer exist, preventing phate from running at all.  I exchanged that call for a simple comparison that yields what I believe the old function returned.  In any case, the change results in phate being able to run.