### PR TITLE
Enable caching of datasets on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
   - '3.6'
   - '3.7'
   #- '3.8-dev' # https://github.com/numpy/numpy/issues/13790
-cache: pip
+cache: 
+  - pip
+  - directories: data
 install:
   - pip install docutils sphinx
   - pip install -e .[test,louvain,leiden]

--- a/scanpy/tests/notebooks/test_pbmc3k.py
+++ b/scanpy/tests/notebooks/test_pbmc3k.py
@@ -27,7 +27,6 @@ ROOT = HERE / 'pbmc3k_images'
 FIGS = HERE / 'figures'
 
 
-@pytest.mark.internet
 def test_pbmc3k(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=20)
 


### PR DESCRIPTION
Cache datasets so notebook tests can run without requiring an external server, since they cover realistic use cases and a good amount of the API.