### PR TITLE
Make External more visible in docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Docs
 /docs/_build/
 /docs/api/scanpy.*.rst
+/docs/external/scanpy.*.rst
 !/docs/api/scanpy.api.rst
 !/docs/api/scanpy.api.AnnData.rst
 !/docs/api/scanpy.plotting.rstk

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -307,7 +307,6 @@ Further modules
 .. autosummary::
    :toctree: .
 
-   external
    api
    plotting
 

--- a/docs/external/index.rst
+++ b/docs/external/index.rst
@@ -1,0 +1,1 @@
+.. automodule:: scanpy.external

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,4 +16,5 @@ If Scanpy is useful for your research, consider citing `Genome Biology (2018) <h
    basic_usage
    installation
    api/index
+   external/index
    references

--- a/scanpy/external/__init__.py
+++ b/scanpy/external/__init__.py
@@ -19,6 +19,8 @@ Import Scanpy's wrappers to external tools as::
 
    import scanpy.external as sce
 
+If you'd like to see your tool included here, please open a `pull request <https://github.com/theislab/scanpy>`_!
+
 Preprocessing: PP
 ------------------
 


### PR DESCRIPTION
Fixes #588

I'm not sure how to deal with references to external under api, so there are two copies of external at the moment. Sphinx gives warnings about this, and it'll probably mess with search. Any ideas @flying-sheep?