### PR TITLE
Fix init_pos argument of sc.tl.umap

### DIFF
--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -1,0 +1,13 @@
+import numpy as np
+from sklearn.utils.testing import assert_array_almost_equal
+
+import scanpy as sc
+
+def test_umap_init_dtype():
+    pbmc = sc.datasets.pbmc68k_reduced()
+    sc.tl.umap(pbmc, init_pos=pbmc.obsm["X_pca"][:, :2].astype(np.float32))
+    embed1 = pbmc.obsm["X_umap"].copy()
+    sc.tl.umap(pbmc, init_pos=pbmc.obsm["X_pca"][:, :2].astype(np.float64))
+    embed2 = pbmc.obsm["X_umap"].copy()
+    assert_array_almost_equal(embed1, embed2)
+    assert_array_almost_equal(embed1, embed2)

--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -5,6 +5,7 @@ import scanpy as sc
 
 def test_umap_init_dtype():
     pbmc = sc.datasets.pbmc68k_reduced()
+    pbmc = pbmc[:100, :].copy()
     sc.tl.umap(pbmc, init_pos=pbmc.obsm["X_pca"][:, :2].astype(np.float32))
     embed1 = pbmc.obsm["X_umap"].copy()
     sc.tl.umap(pbmc, init_pos=pbmc.obsm["X_pca"][:, :2].astype(np.float64))

--- a/scanpy/tests/test_embedding_density.py
+++ b/scanpy/tests/test_embedding_density.py
@@ -20,4 +20,4 @@ def test_embedding_density_plot():
     # Test that sc.pl.embedding_density() runs without error
     adata = sc.datasets.pbmc68k_reduced()
     sc.tl.embedding_density(adata, 'umap')
-    sc.pl.embedding_density(adata, 'umap', 'umap_density')
+    sc.pl.embedding_density(adata, 'umap', 'umap_density', show=False)

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -1,6 +1,11 @@
+import numpy as np
+from pandas.api.types import is_numeric_dtype
+from sklearn.utils import check_random_state, check_array
+
 from ._utils import get_init_pos_from_paga, choose_representation
 from .._settings import settings
 from .. import logging as logg
+
 
 def umap(
     adata,
@@ -106,13 +111,16 @@ def umap(
     else:
         a = a
         b = b
-    if init_pos in adata.obsm.keys():
+
+    if isinstance(init_pos, str) and init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]
-    elif init_pos == 'paga':
-        init_coords = get_init_pos_from_paga(adata, random_state=random_state).astype(adata.X.dtype)
+    elif isinstance(init_pos, str) and init_pos == 'paga':
+        init_coords = get_init_pos_from_paga(adata, random_state=random_state)
     else:
-        init_coords = init_pos
-    from sklearn.utils import check_random_state
+        init_coords = init_pos  # Let umap handle it
+    if hasattr(init_coords, "dtype") and is_numeric_dtype(init_pos):
+        init_coords = check_array(init_coords, dtype=np.float32, accept_sparse=False)
+
     random_state = check_random_state(random_state)
     n_epochs = 0 if maxiter is None else maxiter
     neigh_params = adata.uns['neighbors']['params']


### PR DESCRIPTION
* Now actually allows passing an array (previously threw error from `if init_pos in adata.obsm.keys()`)
* Additionally allows providing an array (even through key of obsm or via paga) of dtype other than float32
* Code converting arrays to float32 can be removed if https://github.com/lmcinnes/umap/pull/262 gets merged and released
* Should solve #666 related issues 