### PR TITLE
use default_20 palette for scatter plots with less than 20 colors

### DIFF
--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -658,7 +658,9 @@ def _set_default_colors_for_categorical_obs(adata, value_to_plot):
         palette = [next(cc)['color'] for _ in range(length)]
 
     else:
-        if length <= 28:
+        if length <= 20:
+            palette = palettes.default_20
+        elif length <= 26:
             palette = palettes.default_26
         elif length <= len(palettes.default_64):  # 103 colors
             palette = palettes.default_64


### PR DESCRIPTION
Related to #740 

This PR changes changes the default color palette for scatter plots to use the palette at `scanpy.pl.palettes.default_20` when there are 20 or less categories present.

Here's an example of what this would change. Using the following code:

```python
import scanpy as sc
pbmc = sc.datasets.pbmc68k_reduced()
del pbmc.uns["louvain_colors"]
sc.pl.umap(pbmc, color="louvain")
```

Without this PR:

![image](https://user-images.githubusercontent.com/8238804/61576675-30f24e00-ab20-11e9-856e-db0717b8f8dd.png)

With this PR:

![image](https://user-images.githubusercontent.com/8238804/61576668-18823380-ab20-11e9-99ec-3597c59c01af.png)

I think the colors used in default 20 are much easier to differentiate with this number of groups.