### PR TITLE
Add fsspec as a test dependency due to dask

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
         doc=['sphinx', 'sphinx_rtd_theme', 'sphinx_autodoc_typehints', 'scanpydoc'],
-        test=['pytest>=4.4', 'dask[array]', 'zappy', 'zarr'],
+        test=['pytest>=4.4', 'dask[array]', 'fsspec', 'zappy', 'zarr'],
     ),
     packages=find_packages(),
     # `package_data` does NOT work for source distributions!!!


### PR DESCRIPTION
Dask no longer having fsspec as a required dependency means the dask tests fail. This should fix that.