### PR TITLE
Pass on copy and return_info to dca

### DIFF
--- a/scanpy/preprocessing/_dca.py
+++ b/scanpy/preprocessing/_dca.py
@@ -151,4 +151,6 @@ def dca(adata,
         threads=threads,
         verbose=verbose,
         training_kwds=training_kwds,
-        return_model=return_model)
+        return_model=return_model,
+        return_info=return_info,
+        copy=copy)


### PR DESCRIPTION
The arguments were not passed in preprocessing/_dca.py, which
makes debugging much more complicated  than needed.