### PR TITLE
Doc builds

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,4 +21,5 @@ joblib
 numba
 tqdm
 importlib_metadata; python_version < '3.8'
+setuptools_scm
 umap-learn

--- a/scanpy/api/__init__.py
+++ b/scanpy/api/__init__.py
@@ -138,7 +138,6 @@ Embeddings
    tl.draw_graph
    tl.diffmap
    tl.phate
-   tl.embedding
 
 Clustering and trajectory inference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -89,7 +89,7 @@ vmin
     the values to plot, `def my_vmin(values): return np.mean(values)` and then 
     set `vmin=my_vmin`. If vmin is None (default) an automatic minimum value is used
     as defined by matplotlib `scatter` function. When making multiple plots, vmin can 
-    be a list of values, one for each plot. For example `vmin=[0.1, 'p1', None, my_vmin]
+    be a list of values, one for each plot. For example `vmin=[0.1, 'p1', None, my_vmin]`
 vmax
     Maximum value to plot. The format is the same as for `vmin`
 add_outline

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -482,9 +482,9 @@ def phate(adata, **kwargs) -> Union[List[Axes], None]:
     >>> import scanpy.external as sce
     >>> import phate
     >>> data, branches = phate.tree.gen_dla(
-    ... n_dim=100,
-    ... n_branch=20,
-    ... branch_length=100,
+    ...     n_dim=100,
+    ...     n_branch=20,
+    ...     branch_length=100,
     ... )
     >>> data.shape
     (2000, 100)


### PR DESCRIPTION
This PR is meant to get doc builds working again. I've added `setuptools_scm` and fixed a typo in the shared plotting docs. Read the docs seems to be working again, but I'm still getting this error locally:

```
Warning, treated as error:
/Users/isaac/github/scanpy/docs/external/scanpy.external.exporting.cellbrowser.rst:2:duplicate object description of scanpy.external.exporting.cellbrowser, other instance in api/scanpy.external.exporting.cellbrowser, use :noindex: for one of them
```