### PR TITLE
Exit with an error if sc.pl.pca_loadings is called with indices < 1

### DIFF
--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -84,6 +84,9 @@ def pca_loadings(
     if components is None: components = [1, 2, 3]
     elif isinstance(components, str): components = components.split(',')
     components = np.array(components) - 1
+    if np.any(components < 0):
+        logg.error("Component indices must be greater than zero.")
+        return
     ranking(adata, 'varm', 'PCs', indices=components)
     utils.savefig_or_show('pca_loadings', show=show, save=save)
 


### PR DESCRIPTION
Right now, when we do `sc.pl.pca_loadings(adata, components=range(5))` to plot first 5 components or even weirder things like `sc.pl.pca_loadings(adata, components=[-10, 0, 5])` the plotting function silently subtracts 1 and uses these as indices for `adata.varm['PCs']`. We can see in the plot title things like `PC-11`. It's confusing and error prone.

This change throws an error if a PC index is invalid.