### PR TITLE
Make partition modularity available in adata.uns

### DIFF
--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -23,6 +23,7 @@
 On master
 ---------
 
+- :func:`~scanpy.tl.louvain` and :func:`~scanpy.tl.leiden` now store all partitioning parameters as well as a modularity score under adata.uns[key_added]. The key for the adata.uns field was incorrectly set to 'louvain' in leiden function before, this is also fixed. :pr:`819` :noteversion:`1.4.5` :smaller:`thanks to G Eraslan`
 - :mod:`scanpy.queries` recieved many updates. This includes enrichment through `gprofiler <https://biit.cs.ut.ee/gprofiler/>`_ and more advanced biomart queries :noteversion:`1.4.5` :pr:`467` :smaller:`thanks to I Virshup`
 
 Post v1.4 :small:`July 20, 2019`

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -56,9 +56,11 @@ def test_louvain_basic(adata_neighbors):
 
 def test_partition_type(adata_neighbors):
     import louvain
+    sc.tl.louvain(adata_neighbors, partition_type=louvain.ModularityVertexPartition)
     sc.tl.louvain(adata_neighbors, partition_type=louvain.RBERVertexPartition)
     sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)
 
     import leidenalg
+    sc.tl.leiden(adata_neighbors, partition_type=leidenalg.ModularityVertexPartition, resolution=None)
     sc.tl.leiden(adata_neighbors, partition_type=leidenalg.RBERVertexPartition)
     sc.tl.leiden(adata_neighbors, partition_type=leidenalg.SurpriseVertexPartition, resolution=None)

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -8,7 +8,10 @@ def adata_neighbors():
 
 
 def test_leiden_basic(adata_neighbors):
-    sc.tl.leiden(adata_neighbors)
+    sc.tl.leiden(adata_neighbors, use_weights=True, directed=True)
+    sc.tl.leiden(adata_neighbors, use_weights=True, directed=False)
+    sc.tl.leiden(adata_neighbors, use_weights=False, directed=True)
+    sc.tl.leiden(adata_neighbors, use_weights=False, directed=False)
 
 @pytest.mark.parametrize('clustering,key', [
     (sc.tl.louvain, 'louvain'),
@@ -43,7 +46,10 @@ def test_clustering_subset(adata_neighbors, clustering, key):
 
 def test_louvain_basic(adata_neighbors):
     sc.tl.louvain(adata_neighbors)
-    sc.tl.louvain(adata_neighbors, use_weights=True)
+    sc.tl.louvain(adata_neighbors, use_weights=True, directed=True)
+    sc.tl.louvain(adata_neighbors, use_weights=True, directed=False)
+    sc.tl.louvain(adata_neighbors, use_weights=False, directed=True)
+    sc.tl.louvain(adata_neighbors, use_weights=False, directed=False)
     sc.tl.louvain(adata_neighbors, use_weights=True, flavor="igraph")
     sc.tl.louvain(adata_neighbors, flavor="igraph")
 
@@ -52,3 +58,7 @@ def test_partition_type(adata_neighbors):
     import louvain
     sc.tl.louvain(adata_neighbors, partition_type=louvain.RBERVertexPartition)
     sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)
+
+    import leidenalg
+    sc.tl.leiden(adata_neighbors, partition_type=leidenalg.RBERVertexPartition)
+    sc.tl.leiden(adata_neighbors, partition_type=leidenalg.SurpriseVertexPartition, resolution=None)

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -170,8 +170,8 @@ def leiden(
             q /= m if directed else m*2
         if isinstance(part, (
             leidenalg.RBConfigurationVertexPartition,
-            leidenalg.ModularityVertexPartition),
-        ):
+            leidenalg.ModularityVertexPartition,
+        )):
             qual_type = ' (scaled modularity)'
         else:
             qual_type = ''

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -161,10 +161,13 @@ def leiden(
         n_iterations=n_iterations,
     )
     if 'quality' in dir(part):
-        adata.uns[uns_key]['quality'] = part.quality()
+        q = part.quality()
+        if q > 1.0: # scale by 2*num_edges
+            q /= g.ecount()
+        adata.uns[uns_key]['quality'] = q
         quality_msg = (
             f'\n'
-            f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
+            f'    quality of the partitioning (scaled modularity) is {q:.3f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
     else:

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -162,8 +162,9 @@ def leiden(
     )
     if 'quality' in dir(part):
         q = part.quality()
-        if q > 1.0: # scale by 2*num_edges
-            q /= g.ecount()
+        if isinstance(part, leidenalg.RBConfigurationVertexPartition) and q > 1.0: #scale quality
+            m = partition_kwargs['weights'].sum() if use_weights else g.ecount()
+            q /= m if directed else m*2
         adata.uns[uns_key]['quality'] = q
         quality_msg = (
             f'\n'

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -153,7 +153,7 @@ def leiden(
         categories=natsorted(np.unique(groups).astype('U')),
     )
     # store information on the clustering parameters
-    uns_key = 'leiden' if key_added == 'leiden' else f'leiden_{key_added}'
+    uns_key = key_added if key_added.startswith('leiden') else f'leiden_{key_added}'
     adata.uns[uns_key] = {}
     adata.uns[uns_key]['params'] = dict(
         resolution=resolution,
@@ -165,10 +165,15 @@ def leiden(
         if isinstance(part, leidenalg.RBConfigurationVertexPartition) and q > 1.0: #scale quality
             m = partition_kwargs['weights'].sum() if use_weights else g.ecount()
             q /= m if directed else m*2
+        if isinstance(part, (leidenalg.RBConfigurationVertexPartition,
+                             leidenalg.ModularityVertexPartition)):
+            qual_type = ' (scaled modularity)'
+        else:
+            qual_type = ''
         adata.uns[uns_key]['quality'] = q
         quality_msg = (
             f'\n'
-            f'    quality of the partitioning (scaled modularity) is {q:.3f}\n'
+            f'    quality of the partitioning{qual_type} is {q:.3f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
     else:

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -153,9 +153,8 @@ def leiden(
         categories=natsorted(np.unique(groups).astype('U')),
     )
     # store information on the clustering parameters
-    uns_key = key_added if key_added.startswith('leiden') else f'leiden_{key_added}'
-    adata.uns[uns_key] = {}
-    adata.uns[uns_key]['params'] = dict(
+    adata.uns[key_added] = {}
+    adata.uns[key_added]['params'] = dict(
         resolution=resolution,
         random_state=random_state,
         n_iterations=n_iterations,
@@ -169,7 +168,7 @@ def leiden(
         initial_membership=part.membership,
     )
     q = modularity_part.quality()
-    adata.uns[uns_key]['modularity'] = q
+    adata.uns[key_added]['modularity'] = q
     logg.info(
         '    finished',
         time=start,
@@ -177,7 +176,7 @@ def leiden(
             f'found {len(np.unique(groups))} clusters and added\n'
             f'    {key_added!r}, the cluster labels (adata.obs, categorical)\n'
             f'    modularity: {q:.3f}, resolution: {resolution}\n'
-            f'    added "modularity" key to adata.uns["{uns_key}"]'
+            f'    added "modularity" key to adata.uns["{key_added}"]'
         ),
     )
     return adata if copy else None

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -163,6 +163,7 @@ def leiden(
     if 'quality' in dir(part):
         adata.uns[uns_key]['quality'] = part.quality()
         quality_msg = (
+            f'\n'
             f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
@@ -173,7 +174,7 @@ def leiden(
         time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
-            f'    {key_added!r}, the cluster labels (adata.obs, categorical)\n'
+            f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
             f'{quality_msg}'
         ),
     )

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -173,7 +173,7 @@ def leiden(
         time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
-            f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
+            f'    {key_added!r}, the cluster labels (adata.obs, categorical)\n'
             f'{quality_msg}'
         ),
     )

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -159,14 +159,19 @@ def leiden(
         resolution=resolution,
         random_state=random_state,
         n_iterations=n_iterations,
+        use_weights=use_weights,
+        directed=directed,
+        partition_type=None if partition_type is None else partition_type.__name__,
     )
     if 'quality' in dir(part):
         q = part.quality()
         if isinstance(part, leidenalg.RBConfigurationVertexPartition) and q > 1.0: #scale quality
             m = partition_kwargs['weights'].sum() if use_weights else g.ecount()
             q /= m if directed else m*2
-        if isinstance(part, (leidenalg.RBConfigurationVertexPartition,
-                             leidenalg.ModularityVertexPartition)):
+        if isinstance(part, (
+            leidenalg.RBConfigurationVertexPartition,
+            leidenalg.ModularityVertexPartition),
+        ):
             qual_type = ' (scaled modularity)'
         else:
             qual_type = ''

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -138,7 +138,7 @@ def leiden(
     # store output into adata.obs
     groups = np.array(part.membership)
     if restrict_to is not None:
-        if key_added == 'louvain':
+        if key_added == 'leiden':
             key_added += '_R'
         groups = rename_groups(
             adata,
@@ -153,18 +153,28 @@ def leiden(
         categories=natsorted(np.unique(groups).astype('U')),
     )
     # store information on the clustering parameters
-    adata.uns['leiden'] = {}
-    adata.uns['leiden']['params'] = dict(
+    uns_key = 'leiden' if key_added == 'leiden' else f'leiden_{key_added}'
+    adata.uns[uns_key] = {}
+    adata.uns[uns_key]['params'] = dict(
         resolution=resolution,
         random_state=random_state,
         n_iterations=n_iterations,
     )
+    if 'quality' in dir(part):
+        adata.uns[uns_key]['quality'] = part.quality()
+        quality_msg = (
+            f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
+            f'    added "quality" key to adata.uns["{uns_key}"]'
+        )
+    else:
+        quality_msg = ''
     logg.info(
         '    finished',
         time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
             f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
+            f'{quality_msg}'
         ),
     )
     return adata if copy else None

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -117,6 +117,7 @@ def louvain(
     uns_key = 'louvain' if key_added == 'louvain' else f'louvain_{key_added}'
     adata.uns[uns_key] = {}
     adata.uns[uns_key]['params'] = {'resolution': resolution, 'random_state': random_state}
+    quality_msg = ''
     if flavor in {'vtraag', 'igraph'}:
         if flavor == 'igraph' and resolution is not None:
             logg.warning(
@@ -150,6 +151,11 @@ def louvain(
                     m = weights.sum() if use_weights else g.ecount()
                     q /= m if directed else m*2
                 adata.uns[uns_key]['quality'] = q
+                quality_msg = (
+                    f'\n'
+                    f'    quality of the partitioning (scaled modularity) is {q:.3f}\n'
+                    f'    added "quality" key to adata.uns["{uns_key}"]'
+                )
         else:
             part = g.community_multilevel(weights=weights)
         groups = np.array(part.membership)
@@ -200,14 +206,6 @@ def louvain(
         values=groups.astype('U'),
         categories=natsorted(np.unique(groups).astype('U')),
     )
-    if 'quality' in adata.uns[uns_key]:
-        quality_msg = (
-            f'\n'
-            f'    quality of the partitioning (scaled modularity) is {adata.uns[uns_key]["quality"]:.3f}\n'
-            f'    added "quality" key to adata.uns["{uns_key}"]'
-        )
-    else:
-        quality_msg = ''
     logg.info(
         '    finished',
         time=start,

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -145,7 +145,10 @@ def louvain(
                 **partition_kwargs,
             )
             if 'quality' in dir(part):
-                adata.uns[uns_key]['quality'] = part.quality()
+                q = part.quality()
+                if q > 1.0:
+                    q /= g.ecount()
+                adata.uns[uns_key]['quality'] = q
         else:
             part = g.community_multilevel(weights=weights)
         groups = np.array(part.membership)
@@ -199,7 +202,7 @@ def louvain(
     if 'quality' in adata.uns[uns_key]:
         quality_msg = (
             f'\n'
-            f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
+            f'    quality of the partitioning (scaled modularity) is {adata.uns[uns_key]["quality"]:.2f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
     else:

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -114,8 +114,7 @@ def louvain(
             restrict_categories,
             adjacency,
         )
-    uns_key = key_added if key_added.startswith('louvain') else f'louvain_{key_added}'
-    adata.uns[uns_key] = {}
+    adata.uns[key_added] = {}
     quality_msg = ''
     if flavor in {'vtraag', 'igraph'}:
         if flavor == 'igraph' and resolution is not None:
@@ -150,11 +149,11 @@ def louvain(
                 initial_membership=part.membership,
             )
             q = modularity_part.quality()
-            adata.uns[uns_key]['modularity'] = q
+            adata.uns[key_added]['modularity'] = q
             quality_msg = (
                 f'\n'
                 f'    modularity: {q:.3f}, resolution: {resolution}\n'
-                f'    added "modularity" key to adata.uns["{uns_key}"]'
+                f'    added "modularity" key to adata.uns["{key_added}"]'
             )
         else:
             part = g.community_multilevel(weights=weights)
@@ -202,7 +201,7 @@ def louvain(
             restrict_indices,
             groups,
         )
-    adata.uns[uns_key]['params'] = {
+    adata.uns[key_added]['params'] = {
         'resolution': resolution,
         'random_state': random_state,
         'partition_type': None if partition_type is None else partition_type.__name__,

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -201,6 +201,10 @@ def louvain(
             restrict_indices,
             groups,
         )
+    adata.obs[key_added] = pd.Categorical(
+        values=groups.astype('U'),
+        categories=natsorted(np.unique(groups).astype('U')),
+    )
     adata.uns[key_added]['params'] = {
         'resolution': resolution,
         'random_state': random_state,
@@ -208,10 +212,6 @@ def louvain(
         'use_weights': use_weights,
         'directed': directed,
     }
-    adata.obs[key_added] = pd.Categorical(
-        values=groups.astype('U'),
-        categories=natsorted(np.unique(groups).astype('U')),
-    )
     logg.info(
         '    finished',
         time=start,

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -198,6 +198,7 @@ def louvain(
     )
     if 'quality' in adata.uns[uns_key]:
         quality_msg = (
+            f'\n'
             f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
@@ -208,7 +209,7 @@ def louvain(
         time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
-            f'    {key_added!r}, the cluster labels (adata.obs, categorical).\n'
+            f'    {key_added!r}, the cluster labels (adata.obs, categorical)'
             f'{quality_msg}'
         ),
     )

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -196,14 +196,20 @@ def louvain(
         values=groups.astype('U'),
         categories=natsorted(np.unique(groups).astype('U')),
     )
+    if 'quality' in adata.uns[uns_key]:
+        quality_msg = (
+            f'    quality of the partitioning is {adata.uns[uns_key]["quality"]:.2f}\n'
+            f'    added "quality" key to adata.uns["{uns_key}"]'
+        )
+    else:
+        quality_msg = ''
     logg.info(
         '    finished',
         time=start,
         deep=(
             f'found {len(np.unique(groups))} clusters and added\n'
             f'    {key_added!r}, the cluster labels (adata.obs, categorical).\n'
-            f'    quality of the partitioning is {adata.uns[uns_key].get("quality", "unknown")}\n'
-            f'    added "quality" key to adata.uns["{uns_key}"]'
+            f'{quality_msg}'
         ),
     )
     return adata if copy else None

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -114,7 +114,7 @@ def louvain(
             restrict_categories,
             adjacency,
         )
-    uns_key = 'louvain' if key_added == 'louvain' else f'louvain_{key_added}'
+    uns_key = key_added if key_added.startswith('louvain') else f'louvain_{key_added}'
     adata.uns[uns_key] = {}
     adata.uns[uns_key]['params'] = {'resolution': resolution, 'random_state': random_state}
     quality_msg = ''
@@ -150,10 +150,15 @@ def louvain(
                 if isinstance(part, louvain.RBConfigurationVertexPartition) and q > 1.0: #scale
                     m = weights.sum() if use_weights else g.ecount()
                     q /= m if directed else m*2
+                if isinstance(part, (louvain.RBConfigurationVertexPartition,
+                                     louvain.ModularityVertexPartition)):
+                    qual_type = ' (scaled modularity)'
+                else:
+                    qual_type = ''
                 adata.uns[uns_key]['quality'] = q
                 quality_msg = (
                     f'\n'
-                    f'    quality of the partitioning (scaled modularity) is {q:.3f}\n'
+                    f'    quality of the partitioning{qual_type} is {q:.3f}\n'
                     f'    added "quality" key to adata.uns["{uns_key}"]'
                 )
         else:

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -116,7 +116,6 @@ def louvain(
         )
     uns_key = key_added if key_added.startswith('louvain') else f'louvain_{key_added}'
     adata.uns[uns_key] = {}
-    adata.uns[uns_key]['params'] = {'resolution': resolution, 'random_state': random_state}
     quality_msg = ''
     if flavor in {'vtraag', 'igraph'}:
         if flavor == 'igraph' and resolution is not None:
@@ -150,8 +149,10 @@ def louvain(
                 if isinstance(part, louvain.RBConfigurationVertexPartition) and q > 1.0: #scale
                     m = weights.sum() if use_weights else g.ecount()
                     q /= m if directed else m*2
-                if isinstance(part, (louvain.RBConfigurationVertexPartition,
-                                     louvain.ModularityVertexPartition)):
+                if isinstance(part, (
+                    louvain.RBConfigurationVertexPartition,
+                    louvain.ModularityVertexPartition),
+                ):
                     qual_type = ' (scaled modularity)'
                 else:
                     qual_type = ''
@@ -207,6 +208,13 @@ def louvain(
             restrict_indices,
             groups,
         )
+    adata.uns[uns_key]['params'] = {
+        'resolution': resolution,
+        'random_state': random_state,
+        'partition_type': None if partition_type is None else partition_type.__name__,
+        'use_weights': use_weights,
+        'directed': directed,
+    }
     adata.obs[key_added] = pd.Categorical(
         values=groups.astype('U'),
         categories=natsorted(np.unique(groups).astype('U')),

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -144,24 +144,18 @@ def louvain(
                 g, partition_type,
                 **partition_kwargs,
             )
-            if 'quality' in dir(part):
-                q = part.quality()
-                if isinstance(part, louvain.RBConfigurationVertexPartition) and q > 1.0: #scale
-                    m = weights.sum() if use_weights else g.ecount()
-                    q /= m if directed else m*2
-                if isinstance(part, (
-                    louvain.RBConfigurationVertexPartition,
-                    louvain.ModularityVertexPartition,
-                )):
-                    qual_type = ' (scaled modularity)'
-                else:
-                    qual_type = ''
-                adata.uns[uns_key]['quality'] = q
-                quality_msg = (
-                    f'\n'
-                    f'    quality of the partitioning{qual_type} is {q:.3f}\n'
-                    f'    added "quality" key to adata.uns["{uns_key}"]'
-                )
+            # modularity calculation
+            modularity_part = louvain.ModularityVertexPartition(
+                g,
+                initial_membership=part.membership,
+            )
+            q = modularity_part.quality()
+            adata.uns[uns_key]['modularity'] = q
+            quality_msg = (
+                f'\n'
+                f'    modularity: {q:.3f}, resolution: {resolution}\n'
+                f'    added "modularity" key to adata.uns["{uns_key}"]'
+            )
         else:
             part = g.community_multilevel(weights=weights)
         groups = np.array(part.membership)

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -151,8 +151,8 @@ def louvain(
                     q /= m if directed else m*2
                 if isinstance(part, (
                     louvain.RBConfigurationVertexPartition,
-                    louvain.ModularityVertexPartition),
-                ):
+                    louvain.ModularityVertexPartition,
+                )):
                     qual_type = ' (scaled modularity)'
                 else:
                     qual_type = ''

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -146,8 +146,9 @@ def louvain(
             )
             if 'quality' in dir(part):
                 q = part.quality()
-                if q > 1.0:
-                    q /= g.ecount()
+                if isinstance(part, louvain.RBConfigurationVertexPartition) and q > 1.0: #scale
+                    m = weights.sum() if use_weights else g.ecount()
+                    q /= m if directed else m*2
                 adata.uns[uns_key]['quality'] = q
         else:
             part = g.community_multilevel(weights=weights)
@@ -202,7 +203,7 @@ def louvain(
     if 'quality' in adata.uns[uns_key]:
         quality_msg = (
             f'\n'
-            f'    quality of the partitioning (scaled modularity) is {adata.uns[uns_key]["quality"]:.2f}\n'
+            f'    quality of the partitioning (scaled modularity) is {adata.uns[uns_key]["quality"]:.3f}\n'
             f'    added "quality" key to adata.uns["{uns_key}"]'
         )
     else:


### PR DESCRIPTION
This PR stores modularity metric into adata.uns. I also added `key_added` as a suffix to uns key "louvain", so that we can run louvain with different parameters and store their quality metrics separately.

```python
import scanpy as sc

sc.settings.verbosity = 3
adata = sc.datasets.pbmc3k()
sc.pp.pca(adata, svd_solver='arpack')
sc.pp.neighbors(adata)
sc.tl.louvain(adata, resolution=2.0, key_added='newkey')
adata.uns
```

![image](https://user-images.githubusercontent.com/1140359/64479798-2a7c6c00-d18a-11e9-9c83-179ddfc54a8a.png)

I'm really bad at writing warning messages and naming things, so feel free to edit these :)
