### PR TITLE
Make write_knn_indices option of Neighbors.compute_neighbors() public

### DIFF
--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -30,6 +30,7 @@ def neighbors(
     method: str = 'umap',
     metric: Union[str, Metric] = 'euclidean',
     metric_kwds: Mapping[str, Any] = {},
+    write_knn_indices: bool = False,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -69,6 +70,8 @@ def neighbors(
         A known metric’s name or a callable that returns a distance.
     metric_kwds
         Options for the metric.
+    write_knn_indices
+        Saves kNN indices into adata.uns['neighbors'].
     copy
         Return a copy instead of writing to adata.
 
@@ -91,7 +94,7 @@ def neighbors(
     neighbors.compute_neighbors(
         n_neighbors=n_neighbors, knn=knn, n_pcs=n_pcs, use_rep=use_rep,
         method=method, metric=metric, metric_kwds=metric_kwds,
-        random_state=random_state,
+        write_knn_indices=write_knn_indices, random_state=random_state,
     )
     adata.uns['neighbors'] = {}
     adata.uns['neighbors']['params'] = {'n_neighbors': n_neighbors, 'method': method}
@@ -106,6 +109,8 @@ def neighbors(
     adata.uns['neighbors']['connectivities'] = neighbors.connectivities
     if neighbors.rp_forest is not None:
         adata.uns['neighbors']['rp_forest'] = neighbors.rp_forest
+    if write_knn_indices and knn:
+        adata.uns['neighbors']['knn_indices'] = neighbors.knn_indices
     logg.info(
         '    finished',
         time=start,


### PR DESCRIPTION
`compute_neighbors` method of the Neighbors class has a nice option called `write_knn_indices` which saves kNN indices into the Neighbors object. But this object and its members are not accessible from sc.pp.neighbors since we don't save the reference to it. 

Making the write_knn_indices option available from `sc.pp.neighbors` gives access to knn indices which provide additional information on top of connectivities and distances since these matrices are symmetrized. 

With knn_indices one can do cool things like building a mutual kNN graph, e.g.:

```python
import scipy.sparse as sp

lm = sp.lil_matrix((adata.n_obs, adata.n_obs))
lm.rows = adata.uns['neighbors']['knn_indices']
lm.data = np.ones_like(adata.uns['neighbors']['knn_indices'])
lm = lm.tocsr()
lm.setdiag(0)
lm.eliminate_zeros()
lm = lm.multiply(lm.T) # build mnn mask

adata.uns['neighbors']['distances'] = adata.uns['neighbors']['distances'].multiply(lm)
adata.uns['neighbors']['connectivities'] = adata.uns['neighbors']['connectivities'].multiply(lm)
```