### PR TITLE
highly_variable_gene batch_key variant fix

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -10,6 +10,7 @@ from ._distributed import materialize_as_ndarray
 from ._utils import _get_mean_var
 from .._utils import sanitize_anndata
 from ._simple import filter_genes
+from .._settings import settings, Verbosity
 
 def _highly_variable_genes_single_batch(
     adata: AnnData,
@@ -262,14 +263,15 @@ def highly_variable_genes(
         sanitize_anndata(adata)
         batches = adata.obs[batch_key].cat.categories
         df = []
+        gene_list = adata.var_names
         for batch in batches:
             adata_subset = adata[adata.obs[batch_key] == batch]
 
             # Filter to genes that are in the dataset
-            genes_before = adata_subset.var_names
-            filter_genes(adata_subset, min_cells=1)
-            genes_after = adata_subset.var_names
-            genes_missing = genes_before.difference(genes_after)
+            with settings.verbosity.override(Verbosity.error):
+                filt = filter_genes(adata_subset, min_cells=1, inplace=False)[0]
+
+            adata_subset = adata_subset[:,filt]
 
             hvg = _highly_variable_genes_single_batch(
                 adata_subset,
@@ -282,21 +284,19 @@ def highly_variable_genes(
 
             # Add 0 values for genes that were filtered out
             missing_hvg = pd.DataFrame(
-                np.zeros((len(genes_missing), len(hvg.columns))),
+                np.zeros((np.sum(~filt), len(hvg.columns))),
                 columns=hvg.columns,
             )
             missing_hvg['highly_variable'] = missing_hvg['highly_variable'].astype(bool)
-            missing_hvg['gene'] = genes_missing
+            missing_hvg['gene'] = gene_list[~filt]
             hvg['gene'] = adata_subset.var_names.values
             hvg = hvg.append(missing_hvg, ignore_index=True)
 
             # Order as before filtering
-            tmp = hvg.set_index('gene')
-            tmp = tmp.loc[genes_before]
-            tmp['gene'] = tmp.index
-            tmp.index = hvg.index
+            idxs = np.concatenate((np.where(filt)[0], np.where(~filt)[0]))
+            hvg = hvg.loc[np.argsort(idxs)]
 
-            df.append(tmp)
+            df.append(hvg)
 
         df = pd.concat(df, axis=0)
         df['highly_variable'] = df['highly_variable'].astype(int)

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -9,7 +9,7 @@ from .. import logging as logg
 from ._distributed import materialize_as_ndarray
 from ._utils import _get_mean_var
 from .._utils import sanitize_anndata
-
+from ._simple import filter_genes
 
 def _highly_variable_genes_single_batch(
     adata: AnnData,
@@ -262,13 +262,35 @@ def highly_variable_genes(
         df = []
         for batch in batches:
             adata_subset = adata[adata.obs[batch_key] == batch]
+
+            # Filter to genes that are in the dataset
+            genes_before = adata_subset.var_names
+            filter_genes(adata_subset, min_cells=1)
+            genes_after = adata_subset.var_names
+            
+            genes_missing = genes_before.difference(genes_after)
             hvg = _highly_variable_genes_single_batch(adata_subset,
                                                       min_disp=min_disp, max_disp=max_disp,
                                                       min_mean=min_mean, max_mean=max_mean,
                                                       n_top_genes=n_top_genes,
                                                       n_bins=n_bins,
                                                       flavor=flavor)
-            hvg['gene'] = adata.var_names.values
+
+            # Add 0 values for genes that were filtered out
+            missing_hvg = pd.DataFrame(np.zeros((len(genes_missing),len(hvg.columns))),
+                                       columns=hvg.columns
+            )
+            missing_hvg['highly_variable'] = missing_hvg['highly_variable'].astype(bool)
+            missing_hvg['gene'] = genes_missing
+            hvg['gene'] = adata_subset.var_names.values
+            hvg = hvg.append(missing_hvg, ignore_index=True)
+
+            # Order as before filtering
+            tmp = hvg.set_index('gene')
+            tmp = tmp.loc[genes_before]
+            tmp['gene'] = tmp.index
+            tmp.index = hvg.index
+
             df.append(hvg)
 
         df = pd.concat(df, axis=0)

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -267,8 +267,8 @@ def highly_variable_genes(
             genes_before = adata_subset.var_names
             filter_genes(adata_subset, min_cells=1)
             genes_after = adata_subset.var_names
-            
             genes_missing = genes_before.difference(genes_after)
+
             hvg = _highly_variable_genes_single_batch(adata_subset,
                                                       min_disp=min_disp, max_disp=max_disp,
                                                       min_mean=min_mean, max_mean=max_mean,

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -250,12 +250,14 @@ def highly_variable_genes(
             'pass `inplace=False` if you want to return a `np.recarray`.')
 
     if batch_key is None:
-        df = _highly_variable_genes_single_batch(adata,
-                                                 min_disp=min_disp, max_disp=max_disp,
-                                                 min_mean=min_mean, max_mean=max_mean,
-                                                 n_top_genes=n_top_genes,
-                                                 n_bins=n_bins,
-                                                 flavor=flavor)
+        df = _highly_variable_genes_single_batch(
+            adata,
+            min_disp=min_disp, max_disp=max_disp,
+            min_mean=min_mean, max_mean=max_mean,
+            n_top_genes=n_top_genes,
+            n_bins=n_bins,
+            flavor=flavor,
+        )
     else:
         sanitize_anndata(adata)
         batches = adata.obs[batch_key].cat.categories
@@ -269,16 +271,19 @@ def highly_variable_genes(
             genes_after = adata_subset.var_names
             genes_missing = genes_before.difference(genes_after)
 
-            hvg = _highly_variable_genes_single_batch(adata_subset,
-                                                      min_disp=min_disp, max_disp=max_disp,
-                                                      min_mean=min_mean, max_mean=max_mean,
-                                                      n_top_genes=n_top_genes,
-                                                      n_bins=n_bins,
-                                                      flavor=flavor)
+            hvg = _highly_variable_genes_single_batch(
+                adata_subset,
+                min_disp=min_disp, max_disp=max_disp,
+                min_mean=min_mean, max_mean=max_mean,
+                n_top_genes=n_top_genes,
+                n_bins=n_bins,
+                flavor=flavor,
+            )
 
             # Add 0 values for genes that were filtered out
-            missing_hvg = pd.DataFrame(np.zeros((len(genes_missing),len(hvg.columns))),
-                                       columns=hvg.columns
+            missing_hvg = pd.DataFrame(
+                np.zeros((len(genes_missing), len(hvg.columns))),
+                columns=hvg.columns,
             )
             missing_hvg['highly_variable'] = missing_hvg['highly_variable'].astype(bool)
             missing_hvg['gene'] = genes_missing

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -296,7 +296,7 @@ def highly_variable_genes(
             tmp['gene'] = tmp.index
             tmp.index = hvg.index
 
-            df.append(hvg)
+            df.append(tmp)
 
         df = pd.concat(df, axis=0)
         df['highly_variable'] = df['highly_variable'].astype(int)

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -107,12 +107,11 @@ def test_highly_variable_genes_batches():
     adata_1 = adata[adata.obs.batch.isin(['0']),:]
     adata_2 = adata[adata.obs.batch.isin(['1']),:]
 
-    hvg = sc.pp.highly_variable_genes(
+    adata = sc.pp.highly_variable_genes(
         adata,
         batch_key='batch',
         flavor='cell_ranger',
         n_top_genes=200,
-        inplace=False
     )
 
     sc.pp.filter_genes(adata_1, min_cells=1)

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -99,11 +99,10 @@ def test_filter_genes_dispersion_compare_to_seurat():
 
 
 def test_highly_variable_genes_batches():
-    adata = sc.datasets.pbmc3k()
-    sc.pp.filter_genes(adata, min_cells=1)
-    sc.pp.normalize_per_cell(adata, counts_per_cell_after=10000)
+    adata = sc.datasets.pbmc68k_reduced()
+    adata[:100,:100].X = np.zeros((100,100))
 
-    adata.obs['batch'] = ['0' if i<200 else '1' for i in range(adata.n_obs)]
+    adata.obs['batch'] = ['0' if i<100 else '1' for i in range(adata.n_obs)]
     adata_1 = adata[adata.obs.batch.isin(['0']),:]
     adata_2 = adata[adata.obs.batch.isin(['1']),:]
 
@@ -130,12 +129,12 @@ def test_highly_variable_genes_batches():
     )
 
     assert np.isclose(
-        adata.var['dispersions_norm'][3],
-        0.5*hvg1['dispersions_norm'][0] + 0.5*hvg2['dispersions_norm'][3]
+        adata.var['dispersions_norm'][100],
+        0.5*hvg1['dispersions_norm'][0] + 0.5*hvg2['dispersions_norm'][100]
     )
     assert np.isclose(
-        adata.var['dispersions_norm'][4],
-        0.5*hvg1['dispersions_norm'][1] + 0.5*hvg2['dispersions_norm'][4]
+        adata.var['dispersions_norm'][101],
+        0.5*hvg1['dispersions_norm'][1] + 0.5*hvg2['dispersions_norm'][101]
     )
     assert np.isclose(
         adata.var['dispersions_norm'][0],

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -123,7 +123,7 @@ def test_highly_variable_genes_batches():
         inplace=False
     )
     hvg2 = sc.pp.highly_variable_genes(
-        adata_1,
+        adata_2,
         flavor='cell_ranger',
         n_top_genes=200,
         inplace=False

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -107,7 +107,7 @@ def test_highly_variable_genes_batches():
     adata_1 = adata[adata.obs.batch.isin(['0']),:]
     adata_2 = adata[adata.obs.batch.isin(['1']),:]
 
-    adata = sc.pp.highly_variable_genes(
+    sc.pp.highly_variable_genes(
         adata,
         batch_key='batch',
         flavor='cell_ranger',


### PR DESCRIPTION
This PR addresses part of #758. I just added a gene filtering addition to the `batch_key` variant of `sc.pp.highly_variable_genes()`. This ensures that the function does not fail because a gene is not expressed in a batch.

I would welcome some feedback on setting dispersions to 0 for filtered out genes. I think this is the standard set by Seurat, and also what is implemented by @gokceneraslan in the original function. 

I have tested on my own data for correct implementation. Testing for result is more difficult in this I guess...
