### PR TITLE
Rotate only xticks in sc.pl.violin

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -621,7 +621,7 @@ def violin(
         g.set_titles(col_template='{col_name}').set_xlabels('')
         if rotation is not None:
             for ax in g.axes[0]:
-                ax.tick_params(labelrotation=rotation)
+                ax.tick_params(axis='x', labelrotation=rotation)
     else:
         if ax is None:
             axs, _, _, _ = setup_axes(
@@ -644,7 +644,7 @@ def violin(
             if log:
                 ax.set_yscale('log')
             if rotation is not None:
-                ax.tick_params(labelrotation=rotation)
+                ax.tick_params(axis='x', labelrotation=rotation)
     _utils.savefig_or_show('violin', show=show, save=save)
     if show is False:
         if multi_panel and groupby is None and len(ys) == 1:


### PR DESCRIPTION
`rotation` argument is supposed to rotate only xticks, not both x and y according to the documentation:

![image](https://user-images.githubusercontent.com/1140359/64564216-043c0500-d31f-11e9-8248-c24a93d037f3.png)
