### PR TITLE
Add ability to run nearest neighbors, umap and louvain on a GPU using RAPIDS

### DIFF
--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -641,7 +641,7 @@ class Neighbors:
         if method == 'rapids' and metric != 'euclidean':
             raise ValueError("`method` 'rapids' only supports the 'euclidean' `metric`.")
         if method not in {'umap', 'gauss', 'rapids'}:
-            raise ValueError('`method` needs to be \'umap\', \'gauss\', or \'rapids\'.')
+            raise ValueError("`method` needs to be 'umap', 'gauss', or 'rapids'.")
         if self._adata.shape[0] >= 10000 and not knn:
             logg.warning('Using high n_obs without `knn=True` takes a lot of memory...')
         self.n_neighbors = n_neighbors

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -638,6 +638,8 @@ class Neighbors:
             logg.warning(f'n_obs too small: adjusting to `n_neighbors = {n_neighbors}`')
         if method == 'umap' and not knn:
             raise ValueError('`method = \'umap\' only with `knn = True`.')
+        if method == 'rapids' and metric != 'euclidean':
+            raise ValueError("`method` 'rapids' only supports the 'euclidean' `metric`.")
         if method not in {'umap', 'gauss', 'rapids'}:
             raise ValueError('`method` needs to be \'umap\', \'gauss\', or \'rapids\'.')
         if self._adata.shape[0] >= 10000 and not knn:

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -673,7 +673,7 @@ class Neighbors:
             self.knn_indices = knn_indices
             self.knn_distances = knn_distances
         start_connect = logg.debug('computed neighbors', time=start_neighbors)
-        if not use_dense_distances or method == 'umap' or method == 'rapids':
+        if not use_dense_distances or method in {'umap', 'rapids'}:
             # we need self._distances also for method == 'gauss' if we didn't
             # use dense distances
             self._distances, self._connectivities = _compute_connectivities_umap(

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -241,6 +241,19 @@ def compute_neighbors_rapids(
     X: np.ndarray,
     n_neighbors: int
 ):
+    """Compute nearest neighbors using RAPIDS cuml.
+
+    Parameters
+    ----------
+    X: array of shape (n_samples, n_features)
+        The data to compute nearest neighbors for.
+    n_neighbors
+        The number of neighbors to use.
+
+        Returns
+    -------
+    **knn_indices**, **knn_dists** : np.arrays of shape (n_observations, n_neighbors)
+    """
     from cuml.neighbors import NearestNeighbors
     nn = NearestNeighbors(n_neighbors=n_neighbors)
     X_contiguous = np.ascontiguousarray(X, dtype=np.float32)

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -154,7 +154,7 @@ def louvain(
         g = cugraph.Graph()
         g.add_adj_list(offsets, indices, weights)
         logg.info('    using the "louvain" package of rapids')
-        louvain_parts, modularity_score = cugraph.nvLouvain(g)
+        louvain_parts, _ = cugraph.nvLouvain(g)
         groups = louvain_parts.to_pandas().sort_values('vertex')[['partition']].to_numpy().ravel()
     elif flavor == 'taynaud':
         # this is deprecated

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -60,7 +60,7 @@ def louvain(
     adjacency
         Sparse adjacency matrix of the graph, defaults to
         ``adata.uns['neighbors']['connectivities']``.
-    flavor : {``'vtraag'``, ``'igraph'``}
+    flavor : {``'vtraag'``, ``'igraph'``, ``'rapids'``}
         Choose between to packages for computing the clustering.
         ``'vtraag'`` is much more powerful, and the default.
     directed
@@ -137,6 +137,25 @@ def louvain(
         else:
             part = g.community_multilevel(weights=weights)
         groups = np.array(part.membership)
+    elif flavor == 'rapids':
+        # nvLouvain only works with undirected graphs, and `adjacency` must have a directed edge in both directions
+        import cudf
+        import cugraph
+        offsets = cudf.Series(adjacency.indptr)
+        indices = cudf.Series(adjacency.indices)
+        if use_weights:
+            sources, targets = adjacency.nonzero()
+            weights = adjacency[sources, targets]
+            if isinstance(weights, np.matrix):
+                weights = weights.A1
+            weights = cudf.Series(weights)
+        else:
+            weights = None
+        g = cugraph.Graph()
+        g.add_adj_list(offsets, indices, weights)
+        logg.info('    using the "louvain" package of rapids')
+        louvain_parts, modularity_score = cugraph.nvLouvain(g)
+        groups = louvain_parts.to_pandas().sort_values('vertex')[['partition']].to_numpy().ravel()
     elif flavor == 'taynaud':
         # this is deprecated
         import networkx as nx

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -21,6 +21,7 @@ def umap(
     a=None,
     b=None,
     copy=False,
+    method='umap'
 ):
     """Embed the neighborhood graph using UMAP [McInnes18]_.
 
@@ -89,6 +90,8 @@ def umap(
         `spread`.
     copy : `bool` (default: `False`)
         Return a copy instead of writing to adata.
+    method : {{'umap', 'rapids'}}  (default: `'umap'`)
+        Use the original 'umap' implementation, or 'rapids' (experimental, GPU only)
 
     Returns
     -------
@@ -122,28 +125,48 @@ def umap(
         init_coords = check_array(init_coords, dtype=np.float32, accept_sparse=False)
 
     random_state = check_random_state(random_state)
-    n_epochs = 0 if maxiter is None else maxiter
     neigh_params = adata.uns['neighbors']['params']
     X = _choose_representation(
         adata, neigh_params.get('use_rep', None), neigh_params.get('n_pcs', None), silent=True)
-    # the data matrix X is really only used for determining the number of connected components
-    # for the init condition in the UMAP embedding
-    X_umap = simplicial_set_embedding(
-        X,
-        adata.uns['neighbors']['connectivities'].tocoo(),
-        n_components,
-        alpha,
-        a,
-        b,
-        gamma,
-        negative_sample_rate,
-        n_epochs,
-        init_coords,
-        random_state,
-        neigh_params.get('metric', 'euclidean'),
-        neigh_params.get('metric_kwds', {}),
-        verbose=settings.verbosity > 3,
-    )
+    if method == 'umap':
+        # the data matrix X is really only used for determining the number of connected components
+        # for the init condition in the UMAP embedding
+        n_epochs = 0 if maxiter is None else maxiter
+        X_umap = simplicial_set_embedding(
+            X,
+            adata.uns['neighbors']['connectivities'].tocoo(),
+            n_components,
+            alpha,
+            a,
+            b,
+            gamma,
+            negative_sample_rate,
+            n_epochs,
+            init_coords,
+            random_state,
+            neigh_params.get('metric', 'euclidean'),
+            neigh_params.get('metric_kwds', {}),
+            verbose=settings.verbosity > 3,
+        )
+    elif method == 'rapids':
+        from cuml import UMAP
+        n_neighbors = adata.uns['neighbors']['params']['n_neighbors']
+        n_epochs = 500 if maxiter is None else maxiter # 0 is not a valid value for rapids, unlike original umap
+        X_contiguous = np.ascontiguousarray(X, dtype=np.float32)
+        umap = UMAP(
+            n_neighbors=n_neighbors,
+            n_components=n_components,
+            n_epochs=n_epochs,
+            learning_rate=alpha,
+            init=init_pos,
+            min_dist=min_dist,
+            spread=spread,
+            negative_sample_rate=negative_sample_rate,
+            a=a,
+            b=b,
+            verbose=settings.verbosity > 3,
+        )
+        X_umap = umap.fit_transform(X_contiguous)
     adata.obsm['X_umap'] = X_umap  # annotate samples with UMAP coordinates
     logg.info(
         '    finished',

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -90,7 +90,7 @@ def umap(
         `spread`.
     copy : `bool` (default: `False`)
         Return a copy instead of writing to adata.
-    method : {{'umap', 'rapids'}}  (default: `'umap'`)
+    method : {`'umap'`, `'rapids'`}  (default: `'umap'`)
         Use the original 'umap' implementation, or 'rapids' (experimental, GPU only)
 
     Returns

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -149,6 +149,12 @@ def umap(
             verbose=settings.verbosity > 3,
         )
     elif method == 'rapids':
+        metric = neigh_params.get('metric', 'euclidean')
+        if metric != 'euclidean':
+            raise ValueError(
+                f'`sc.pp.neighbors` was called with `metric` {metric!r}, '
+                "but umap `method` 'rapids' only supports the 'euclidean' metric."
+            ) 
         from cuml import UMAP
         n_neighbors = adata.uns['neighbors']['params']['n_neighbors']
         n_epochs = 500 if maxiter is None else maxiter # 0 is not a valid value for rapids, unlike original umap

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         louvain=['python-igraph', 'louvain>=0.6'],
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
+        rapids=['cudf', 'cuml', 'cugraph'],
         doc=[
             'sphinx',
             'sphinx_rtd_theme',


### PR DESCRIPTION
This adds RAPIDS as an (experimental) option for running some of the graph algorithms on a GPU.

Example usage is demonstrated here: https://github.com/tomwhite/scanpy_usage/tree/rapids-gpu/1909_rapids_gpu

In summary:

```python
    sc.pp.neighbors(adata, method='rapids')
    sc.tl.louvain(adata, flavor='rapids')
    sc.tl.umap(adata, method='rapids')
```

Timings (on 130K samples):

| Step      | CPU time (s) | GPU time (s) | Speedup |
| --------- | ------------ | ------------ | ------- |
| Neighbors | 47           | 15           | 3x      |
| Louvain   | 70           | 1            | 70x     |
| UMAP      | 186          | 15           | 12x     |

Comments:
* In general the output figures are quite different for each of the algorithms compared to regular Scanpy. (See the figures in the link above.)
* RAPIDS uses exact nearest neighbors (using https://github.com/facebookresearch/faiss I think), whereas the default NNDescent algorithm in Scanpy is approximate.
* Louvain community detection results in a different number of communities (28 vs 45). I'm not sure if it is possible to change the termination criteria or other parameters that would make the two outputs the same, or at least more similar.
* UMAP is different too, and in particular it is bunched in one corner. There are a few very small clusters in the opposite corner, which looks like it might be a bug.
* UMAP computes the nearest neighbors again from scratch - it can’t reuse the ones computed earlier since RAPIDS only exposes the fit/transform methods, and not `simplicial_set_embedding` that regular UMAP exposes.
* In general it would be useful to understand what random number generators each of the alternatives use, how they can be controlled, and what prospects there are for achieving identical output (if any).
* This is using RAPIDS version 0.7 since it is the version available on the Google Cloud image I used (https://cloud.google.com/deep-learning-vm/docs/images).
