### PR TITLE
Use cacheing and parallelism for qc metrics

### DIFF
--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -1,4 +1,5 @@
 from typing import Optional, Tuple, Collection
+from warnings import warn
 
 import numba
 import numpy as np
@@ -69,8 +70,6 @@ def describe_obs(
         Whether to place calculated metrics in `adata.obs`.
     X
         Matrix to calculate values on. Meant for internal usage.
-    parallel
-        Deprecated argument, doesn't do anything.
 
     Returns
     -------
@@ -79,6 +78,11 @@ def describe_obs(
 
     {doc_obs_qc_returns}
     """
+    if parallel is not None:
+        warn(
+            "Argument `parallel` is deprecated, and currently has no effect.",
+            FutureWarning
+        )
     # Handle whether X is passed
     if X is None:
         X = _choose_mtx_rep(adata, use_raw, layer)
@@ -227,8 +231,6 @@ def calculate_qc_metrics(
     {doc_expr_reps}
     inplace
         Whether to place calculated metrics in `adata`'s `.obs` and `.var`.
-    parallel
-        Deprecated argument, doesn't do anything.
 
     Returns
     -------
@@ -252,6 +254,11 @@ def calculate_qc_metrics(
             data=adata.obs, kind="hex"
         )
     """
+    if parallel is not None:
+        warn(
+            "Argument `parallel` is deprecated, and currently has no effect.",
+            FutureWarning
+        )
     # Pass X so I only have to do it once
     X = _choose_mtx_rep(adata, use_raw, layer)
     if isspmatrix_coo(X):

--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -60,6 +60,9 @@ def describe_obs(
     Calculates a number of qc metrics for observations in AnnData object. See
     section `Returns` for a description of those metrics.
 
+    Note that this method can take a while to compile on the first call. That
+    result is then cached to disk to be used later.
+
     Params
     ------
     {doc_adata_basic}
@@ -222,6 +225,9 @@ def calculate_qc_metrics(
     Calculates a number of qc metrics for an AnnData object, see section
     `Returns` for specifics. Largely based on `calculateQCMetrics` from scater
     [McCarthy17]_. Currently is most efficient on a sparse CSR or dense matrix.
+
+    Note that this method can take a while to compile on the first call. That
+    result is then cached to disk to be used later.
 
     Parameters
     ----------


### PR DESCRIPTION
This simplifies `top_segment_proportions_sparse_csr` by using improvements in numba which allow cacheing parallel code.

A downside of this is it takes a really long time to compile on first run, which might be off-putting.

Side note: I accidentally ran formatting before committing, so some other lines got changed too.