### PR TITLE
Run static analysis concurrently

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,13 @@
 dist: xenial
 language: python
-stages:
-    - name: static analysis
-    - name: test
+matrix:
+  include:
+    - name: "static analysis"
+      python: "3.7"
+      script:
+        - black . --check --diff
+        - python -m scanpy.tests.blackdiff 10
+      after_success: skip
 python:
   - '3.6'
   - '3.7'
@@ -19,11 +24,3 @@ script:
   - pytest --ignore=scanpy/tests/_images
   - python setup.py check --restructuredtext --strict
   - rst2html.py --halt=2 README.rst >/dev/null
-jobs:
-  include:
-    - stage: static analysis
-      python: "3.7"
-      script:
-        - black . --check --diff
-        - python -m scanpy.tests.blackdiff 10
-      after_success: skip


### PR DESCRIPTION
Runs static analysis concurrently with tests, while currently static analysis is run first. This cuts down on total test time, and will always test both correctness and style.