### PR TITLE
Improve accuracy and speed of _get_mean_var

### DIFF
--- a/scanpy/preprocessing/_utils.py
+++ b/scanpy/preprocessing/_utils.py
@@ -2,23 +2,16 @@ import numpy as np
 from scipy import sparse
 import numba
 
-STANDARD_SCALER_FIXED = False
-
 
 def _get_mean_var(X):
     if sparse.issparse(X):
         mean, var = sparse_mean_variance_axis(X, axis=0)
     else:
-        if STANDARD_SCALER_FIXED:
-            from sklearn.preprocessing import StandardScaler
-
-            scaler = StandardScaler(with_mean=False).partial_fit(X)
-            mean, var = scaler.mean_, scaler.var_
-        else:
-            mean = X.mean(axis=0, dtype=np.float64)
-            var = X.var(axis=0, dtype=np.float64)
+        mean = np.mean(X, axis=0, dtype=np.float64)
+        mean_sq = np.multiply(X, X).mean(axis=0, dtype=np.float64)
+        var = mean_sq - mean ** 2
     # enforce R convention (unbiased estimator) for variance
-    var = var * (X.shape[0] / (X.shape[0] - 1))
+    var *= X.shape[0] / (X.shape[0] - 1)
     return mean, var
 
 

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -1,3 +1,4 @@
+from itertools import product
 from pathlib import Path
 
 import numpy as np
@@ -31,10 +32,10 @@ def test_mean_var_sparse():
     csc64 = csr64.tocsc()
 
     # Test that we're equivalent for 64 bit
-    for mtx in (csr64, csc64):
-        scm, scv = sc.pp._utils._get_mean_var(mtx)
-        skm, skv = mean_variance_axis(mtx, 0)
-        skv *= (mtx.shape[0] / (mtx.shape[0] - 1))
+    for mtx, ax in product((csr64, csc64), (0, 1)):
+        scm, scv = sc.pp._utils._get_mean_var(mtx, axis=ax)
+        skm, skv = mean_variance_axis(mtx, ax)
+        skv *= (mtx.shape[ax] / (mtx.shape[ax] - 1))
 
         assert np.allclose(scm, skm)
         assert np.allclose(scv, skv)


### PR DESCRIPTION
This is a PR I've been meaning to get around to for a while. Previously discussed with @fidelram and @falexwolf. This calculates mean and variance for sparse matrices much faster than the current implementation. In addition, this accumulates to 64bit floats, which can greatly increase accuracy for large datasets and values.

Some numbers using 50k cells from tabula muris using the call `sc.pp._utils._get_mean_var`.

|   | speed | memory (`%memit`) |
|--|-------|---------|
|current master| ~6.2 seconds | ~4.7 GB |
|this PR | 1.2 seconds | 0.5 MB |

Pretty good improvements.

For accuracy, I'll compare against `sklearn.utils.sparsefuncs.mean_variance_axis`:

```python
import numba
import numpy as np
from scipy import sparse
from sklearn.utils.sparsefuncs import mean_variance_axis

import matplotlib.pyplot as plt
import seaborn as sns

csr64 = sparse.random(10000, 1000, format="csr", dtype=np.float64)

csr32 = csr64.astype(np.float32)

m_my64, v_my64 = sparse_mean_variance_axis(csr64, 0)
m_sk64, v_sk64 = mean_variance_axis(csr64, 0)
m_my32, v_my32 = sparse_mean_variance_axis(csr32, 0)
m_sk32, v_sk32 = mean_variance_axis(csr32, 0)

sns.distplot(m_sk64 - m_sk32, color="blue")
sns.distplot(m_my64 - m_my32, color="red")
plt.show()
```

<details>
<summary> plot </summary>

![residual_mean](https://user-images.githubusercontent.com/8238804/65942102-ed955380-e46f-11e9-8293-334f1e7d6488.png)

</details>

```python
sns.distplot(m_sk64 - m_sk32, color="blue")
sns.distplot(m_my64 - m_my32, color="red")
plt.show()
```

<details>
<summary> plot </summary>

![residual_var](https://user-images.githubusercontent.com/8238804/65942056-d0608500-e46f-11e9-86da-58f89371c10f.png)

</details>