### PR TITLE
dtype fixes for downsample and normalization

### DIFF
--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -11,6 +11,8 @@ from .._compat import Literal
 
 def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
+    if issubclass(X.dtype.type, (int, np.integer)):
+        X = X.astype(np.float32)  # TODO: Check if float64 should be used
     after = np.median(counts[counts>0]) if after is None else after
     counts += (counts == 0)
     counts = counts / after
@@ -182,10 +184,7 @@ def normalize_total(
         layer = adata.layers[layer_name]
         counts = np.ravel(layer.sum(1))
         if inplace:
-            if hasattr(layer, '__itruediv__'):
-                _normalize_data(layer, counts, after)
-            else:
-                adata.layers[layer_name] = _normalize_data(layer, counts, after, copy=True)
+            adata.layers[layer_name] = _normalize_data(layer, counts, after)
         else:
             dat[layer_name] = _normalize_data(layer, counts, after, copy=True)
 

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -13,7 +13,8 @@ def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
     if issubclass(X.dtype.type, (int, np.integer)):
         X = X.astype(np.float32)  # TODO: Check if float64 should be used
-    after = np.median(counts[counts>0]) if after is None else after
+    counts = np.asarray(counts)  # dask doesn't do medians
+    after = np.median(counts[counts>0], axis=0) if after is None else after
     counts += (counts == 0)
     counts = counts / after
     if issparse(X):

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -13,12 +13,12 @@ def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
     after = np.median(counts[counts>0]) if after is None else after
     counts += (counts == 0)
-    counts /= after
+    counts = counts / after
     if issparse(X):
         sparsefuncs.inplace_row_scale(X, 1/counts)
     else:
-        X /= counts[:, None]
-    return X if copy else None
+        np.divide(X, counts[:, None], out=X)
+    return X
 
 
 def normalize_total(
@@ -170,10 +170,7 @@ def normalize_total(
     if inplace:
         if key_added is not None:
             adata.obs[key_added] = counts_per_cell
-        if hasattr(adata.X, '__itruediv__'):
-            _normalize_data(adata.X, counts_per_cell, target_sum)
-        else:
-            adata.X = _normalize_data(adata.X, counts_per_cell, target_sum, copy=True)
+        adata.X = _normalize_data(adata.X, counts_per_cell, target_sum)
     else:
         # not recarray because need to support sparse
         dat = dict(

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -983,8 +983,10 @@ def downsample_counts(
     adata: AnnData,
     counts_per_cell: Optional[Union[int, Collection[int]]] = None,
     total_counts: Optional[int] = None,
+    *,
     random_state: Optional[Union[int, RandomState]] = 0,
     replace: bool = False,
+    dtype: Optional[np.dtype] = None,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -1010,6 +1012,9 @@ def downsample_counts(
         Random seed for subsampling.
     replace
         Whether to sample the counts with replacement.
+    dtype
+        What dtype X should be returned as, since data is converted to integers
+        during downsampling. Defaults to input dtype.
     copy
         Determines whether a copy of `adata` is returned.
 
@@ -1024,11 +1029,16 @@ def downsample_counts(
         raise ValueError("Must specify exactly one of `total_counts` or `counts_per_cell`.")
     if copy:
         adata = adata.copy()
+    if dtype is None:
+        dtype = adata.X.dtype
+
     adata.X = adata.X.astype(np.integer)  # Numba doesn't want floats
     if total_counts_call:
         adata.X = _downsample_total_counts(adata.X, total_counts, random_state, replace)
     elif counts_per_cell_call:
         adata.X = _downsample_per_cell(adata.X, counts_per_cell, random_state, replace)
+
+    adata.X = adata.X.astype(dtype)
     if copy:
         return adata
 

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -986,7 +986,6 @@ def downsample_counts(
     *,
     random_state: Optional[Union[int, RandomState]] = 0,
     replace: bool = False,
-    dtype: Optional[np.dtype] = None,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -1012,9 +1011,6 @@ def downsample_counts(
         Random seed for subsampling.
     replace
         Whether to sample the counts with replacement.
-    dtype
-        What dtype X should be returned as, since data is converted to integers
-        during downsampling. Defaults to input dtype.
     copy
         Determines whether a copy of `adata` is returned.
 
@@ -1029,16 +1025,10 @@ def downsample_counts(
         raise ValueError("Must specify exactly one of `total_counts` or `counts_per_cell`.")
     if copy:
         adata = adata.copy()
-    if dtype is None:
-        dtype = adata.X.dtype
-
-    adata.X = adata.X.astype(np.integer)  # Numba doesn't want floats
     if total_counts_call:
         adata.X = _downsample_total_counts(adata.X, total_counts, random_state, replace)
     elif counts_per_cell_call:
         adata.X = _downsample_per_cell(adata.X, counts_per_cell, random_state, replace)
-
-    adata.X = adata.X.astype(dtype)
     if copy:
         return adata
 
@@ -1049,6 +1039,8 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         counts_per_cell = np.full(n_obs, counts_per_cell)
     else:
         counts_per_cell = np.asarray(counts_per_cell)
+    # np.random.choice needs int arguments in numba code:
+    counts_per_cell = counts_per_cell.astype(np.int_, copy=False)
     if not isinstance(counts_per_cell, np.ndarray) or len(counts_per_cell) != n_obs:
         raise ValueError(
             "If provided, 'counts_per_cell' must be either an integer, or "
@@ -1061,7 +1053,7 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
             X = csr_matrix(X)
         totals = np.ravel(X.sum(axis=1))  # Faster for csr matrix
         under_target = np.nonzero(totals > counts_per_cell)[0]
-        rows = np.split(X.data.view(), X.indptr[1:-1])
+        rows = np.split(X.data, X.indptr[1:-1])
         for rowidx in under_target:
             row = rows[rowidx]
             _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
@@ -1073,13 +1065,14 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         totals = np.ravel(X.sum(axis=1))
         under_target = np.nonzero(totals > counts_per_cell)[0]
         for rowidx in under_target:
-            row = X[rowidx, :].view()
+            row = X[rowidx, :]
             _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
                               replace=replace, inplace=True)
     return X
 
 
 def _downsample_total_counts(X, total_counts, random_state, replace):
+    total_counts = int(total_counts)
     total = X.sum()
     if total < total_counts:
         return X
@@ -1093,7 +1086,7 @@ def _downsample_total_counts(X, total_counts, random_state, replace):
         if original_type is not csr_matrix:
             X = original_type(X)
     else:
-        v = X.view().reshape(np.multiply(*X.shape))
+        v = X.reshape(np.multiply(*X.shape))
         _downsample_array(v, total_counts, random_state, replace=replace,
                           inplace=True)
     return X
@@ -1101,7 +1094,7 @@ def _downsample_total_counts(X, total_counts, random_state, replace):
 
 @numba.njit(cache=True)
 def _downsample_array(
-    col: np.array,
+    col: np.ndarray,
     target: int,
     random_state: Optional[Union[int, RandomState]] = 0,
     replace: bool = True,
@@ -1112,7 +1105,6 @@ def _downsample_array(
 
     This is an internal function and has some restrictions:
 
-    * `dtype` of col must be an integer (i.e. satisfy issubclass(col.dtype.type, np.integer))
     * total counts in cell must be less than target
     """
     np.random.seed(random_state)
@@ -1121,7 +1113,7 @@ def _downsample_array(
         col[:] = 0
     else:
         col = np.zeros_like(col)
-    total = cumcounts[-1]
+    total = np.int_(cumcounts[-1])
     sample = np.random.choice(total, target, replace=replace)
     sample.sort()
     geneptr = 0

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -1022,13 +1022,19 @@ def downsample_counts(
     total_counts_call = total_counts is not None
     counts_per_cell_call = counts_per_cell is not None
     if total_counts_call is counts_per_cell_call:
-        raise ValueError("Must specify exactly one of `total_counts` or `counts_per_cell`.")
+        raise ValueError(
+            "Must specify exactly one of `total_counts` or `counts_per_cell`."
+        )
     if copy:
         adata = adata.copy()
     if total_counts_call:
-        adata.X = _downsample_total_counts(adata.X, total_counts, random_state, replace)
+        adata.X = _downsample_total_counts(
+            adata.X, total_counts, random_state, replace
+        )
     elif counts_per_cell_call:
-        adata.X = _downsample_per_cell(adata.X, counts_per_cell, random_state, replace)
+        adata.X = _downsample_per_cell(
+            adata.X, counts_per_cell, random_state, replace
+        )
     if copy:
         return adata
 
@@ -1041,7 +1047,10 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         counts_per_cell = np.asarray(counts_per_cell)
     # np.random.choice needs int arguments in numba code:
     counts_per_cell = counts_per_cell.astype(np.int_, copy=False)
-    if not isinstance(counts_per_cell, np.ndarray) or len(counts_per_cell) != n_obs:
+    if (
+        not isinstance(counts_per_cell, np.ndarray)
+        or len(counts_per_cell) != n_obs
+    ):
         raise ValueError(
             "If provided, 'counts_per_cell' must be either an integer, or "
             "coercible to an `np.ndarray` of length as number of observations"
@@ -1056,8 +1065,13 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         rows = np.split(X.data, X.indptr[1:-1])
         for rowidx in under_target:
             row = rows[rowidx]
-            _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
-                              replace=replace, inplace=True)
+            _downsample_array(
+                row,
+                counts_per_cell[rowidx],
+                random_state=random_state,
+                replace=replace,
+                inplace=True,
+            )
         X.eliminate_zeros()
         if original_type is not csr_matrix:  # Put it back
             X = original_type(X)
@@ -1066,8 +1080,13 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         under_target = np.nonzero(totals > counts_per_cell)[0]
         for rowidx in under_target:
             row = X[rowidx, :]
-            _downsample_array(row, counts_per_cell[rowidx], random_state=random_state,
-                              replace=replace, inplace=True)
+            _downsample_array(
+                row,
+                counts_per_cell[rowidx],
+                random_state=random_state,
+                replace=replace,
+                inplace=True,
+            )
     return X
 
 
@@ -1080,15 +1099,21 @@ def _downsample_total_counts(X, total_counts, random_state, replace):
         original_type = type(X)
         if not isspmatrix_csr(X):
             X = csr_matrix(X)
-        _downsample_array(X.data, total_counts, random_state=random_state,
-                          replace=replace, inplace=True)
+        _downsample_array(
+            X.data,
+            total_counts,
+            random_state=random_state,
+            replace=replace,
+            inplace=True,
+        )
         X.eliminate_zeros()
         if original_type is not csr_matrix:
             X = original_type(X)
     else:
         v = X.reshape(np.multiply(*X.shape))
-        _downsample_array(v, total_counts, random_state, replace=replace,
-                          inplace=True)
+        _downsample_array(
+            v, total_counts, random_state, replace=replace, inplace=True
+        )
     return X
 
 
@@ -1122,6 +1147,7 @@ def _downsample_array(
             geneptr += 1
         col[geneptr] += 1
     return col
+
 
 
 def zscore_deprecated(X: np.ndarray) -> np.ndarray:

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -9,7 +9,9 @@ X_total = [[1, 0], [3, 0], [5, 6]]
 X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
 
 
-@pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)
+@pytest.mark.parametrize(
+    'typ', [np.array, csr_matrix], ids=lambda x: x.__name__
+)
 @pytest.mark.parametrize('dtype', ['float32', 'int64'])
 def test_normalize_total(typ, dtype):
     adata = AnnData(typ(X_total, dtype=dtype))
@@ -23,3 +25,14 @@ def test_normalize_total(typ, dtype):
         adata, exclude_highly_expressed=True, max_fraction=0.7
     )
     assert np.allclose(np.ravel(adata.X[:, 1:3].sum(axis=1)), [1.0, 1.0, 1.0])
+
+
+@pytest.mark.parametrize(
+    'typ', [np.array, csr_matrix], ids=lambda x: x.__name__
+)
+@pytest.mark.parametrize('dtype', ['float32', 'int64'])
+def test_normalize_total_layers(typ, dtype):
+    adata = AnnData(typ(X_total), dtype=dtype)
+    adata.layers["layer"] = adata.X.copy()
+    sc.pp.normalize_total(adata, layers=["layer"])
+    assert np.allclose(adata.layers["layer"].sum(axis=1), [3.0, 3.0, 3.0])

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -9,15 +9,16 @@ X_total = [[1, 0], [3, 0], [5, 6]]
 X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
 
 
-@pytest.mark.parametrize('typ', [np.array, csr_matrix])
-def test_normalize_total(typ):
-    adata = AnnData(typ(X_total, dtype='float32'))
+@pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)
+@pytest.mark.parametrize('dtype', ['float32', 'int64'])
+def test_normalize_total(typ, dtype):
+    adata = AnnData(typ(X_total, dtype=dtype))
     sc.pp.normalize_total(adata, key_added='n_counts')
     assert np.allclose(np.ravel(adata.X.sum(axis=1)), [3.0, 3.0, 3.0])
     sc.pp.normalize_total(adata, target_sum=1, key_added='n_counts2')
     assert np.allclose(np.ravel(adata.X.sum(axis=1)), [1.0, 1.0, 1.0])
 
-    adata = AnnData(typ(X_frac, dtype='float32'))
+    adata = AnnData(typ(X_frac, dtype=dtype))
     sc.pp.normalize_total(
         adata, exclude_highly_expressed=True, max_fraction=0.7
     )

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -14,7 +14,7 @@ X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
 )
 @pytest.mark.parametrize('dtype', ['float32', 'int64'])
 def test_normalize_total(typ, dtype):
-    adata = AnnData(typ(X_total, dtype=dtype))
+    adata = AnnData(typ(X_total), dtype=dtype)
     sc.pp.normalize_total(adata, key_added='n_counts')
     assert np.allclose(np.ravel(adata.X.sum(axis=1)), [3.0, 3.0, 3.0])
     sc.pp.normalize_total(adata, target_sum=1, key_added='n_counts2')

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -161,17 +161,22 @@ def dtype(request):
 
 def test_downsample_counts_per_cell(count_matrix_format, replace, dtype):
     TARGET = 1000
-    X = np.random.randint(0, 100, (1000, 100)) * \
-        np.random.binomial(1, .3, (1000, 100))
+    X = (
+        np.random.randint(0, 100, (1000, 100))
+        * np.random.binomial(1, 0.3, (1000, 100))
+    )
     X = X.astype(dtype)
     adata = AnnData(X=count_matrix_format(X), dtype=dtype)
     with pytest.raises(ValueError):
-        sc.pp.downsample_counts(adata, counts_per_cell=TARGET, total_counts=TARGET, replace=replace)
+        sc.pp.downsample_counts(
+            adata, counts_per_cell=TARGET, total_counts=TARGET, replace=replace
+        )
     with pytest.raises(ValueError):
         sc.pp.downsample_counts(adata, replace=replace)
     initial_totals = np.ravel(adata.X.sum(axis=1))
-    adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGET,
-                                    replace=replace, copy=True)
+    adata = sc.pp.downsample_counts(
+        adata, counts_per_cell=TARGET, replace=replace, copy=True
+    )
     new_totals = np.ravel(adata.X.sum(axis=1))
     if sp.issparse(adata.X):
         assert all(adata.X.toarray()[X == 0] == 0)
@@ -179,23 +184,33 @@ def test_downsample_counts_per_cell(count_matrix_format, replace, dtype):
         assert all(adata.X[X == 0] == 0)
     assert all(new_totals <= TARGET)
     assert all(initial_totals >= new_totals)
-    assert all(initial_totals[initial_totals <= TARGET]
-                == new_totals[initial_totals <= TARGET])
+    assert all(
+        initial_totals[initial_totals <= TARGET]
+        == new_totals[initial_totals <= TARGET]
+    )
     if not replace:
         assert np.all(X >= adata.X)
     assert X.dtype == adata.X.dtype
 
 
-def test_downsample_counts_per_cell_multiple_targets(count_matrix_format, replace, dtype):
+def test_downsample_counts_per_cell_multiple_targets(
+    count_matrix_format, replace, dtype
+):
     TARGETS = np.random.randint(500, 1500, 1000)
-    X = np.random.randint(0, 100, (1000, 100)) * \
-        np.random.binomial(1, .3, (1000, 100))
+    X = (
+        np.random.randint(0, 100, (1000, 100))
+        * np.random.binomial(1, 0.3, (1000, 100))
+    )
     X = X.astype(dtype)
     adata = AnnData(X=count_matrix_format(X), dtype=dtype)
     initial_totals = np.ravel(adata.X.sum(axis=1))
     with pytest.raises(ValueError):
-        sc.pp.downsample_counts(adata, counts_per_cell=[40, 10], replace=replace)
-    adata = sc.pp.downsample_counts(adata, counts_per_cell=TARGETS, replace=replace, copy=True)
+        sc.pp.downsample_counts(
+            adata, counts_per_cell=[40, 10], replace=replace
+        )
+    adata = sc.pp.downsample_counts(
+        adata, counts_per_cell=TARGETS, replace=replace, copy=True
+    )
     new_totals = np.ravel(adata.X.sum(axis=1))
     if sp.issparse(adata.X):
         assert all(adata.X.toarray()[X == 0] == 0)
@@ -203,23 +218,28 @@ def test_downsample_counts_per_cell_multiple_targets(count_matrix_format, replac
         assert all(adata.X[X == 0] == 0)
     assert all(new_totals <= TARGETS)
     assert all(initial_totals >= new_totals)
-    assert all(initial_totals[initial_totals <= TARGETS]
-                == new_totals[initial_totals <= TARGETS])
+    assert all(
+        initial_totals[initial_totals <= TARGETS]
+        == new_totals[initial_totals <= TARGETS]
+    )
     if not replace:
         assert np.all(X >= adata.X)
     assert X.dtype == adata.X.dtype
 
 
 def test_downsample_total_counts(count_matrix_format, replace, dtype):
-    X = np.random.randint(0, 100, (1000, 100)) * \
-        np.random.binomial(1, .3, (1000, 100))
+    X = (
+        np.random.randint(0, 100, (1000, 100))
+        * np.random.binomial(1, 0.3, (1000, 100))
+    )
     X = X.astype(dtype)
     adata_orig = AnnData(X=count_matrix_format(X), dtype=dtype)
     total = X.sum()
     target = np.floor_divide(total, 10)
     initial_totals = np.ravel(adata_orig.X.sum(axis=1))
-    adata = sc.pp.downsample_counts(adata_orig, total_counts=target,
-                                    replace=replace, copy=True)
+    adata = sc.pp.downsample_counts(
+        adata_orig, total_counts=target, replace=replace, copy=True
+    )
     new_totals = np.ravel(adata.X.sum(axis=1))
     if sp.issparse(adata.X):
         assert all(adata.X.toarray()[X == 0] == 0)
@@ -229,7 +249,8 @@ def test_downsample_total_counts(count_matrix_format, replace, dtype):
     assert all(initial_totals >= new_totals)
     if not replace:
         assert np.all(X >= adata.X)
-        adata = sc.pp.downsample_counts(adata_orig, total_counts=total + 10,
-                                        replace=False, copy=True)
+        adata = sc.pp.downsample_counts(
+            adata_orig, total_counts=total + 10, replace=False, copy=True
+        )
         assert (adata.X == X).all()
     assert X.dtype == adata.X.dtype


### PR DESCRIPTION
Addressing https://github.com/theislab/scanpy/issues/435#issuecomment-538776417

This PR does two things:

1. `downsample_counts` will convert the resulting downsampled matrix back to the initial dtype by default.
2. `normalize_total` will now work with integer matrices.

I think 2 should definitely be the case. 1 does have a performance cost, but it's close to @falexwolf's [suggestion](https://github.com/theislab/scanpy/issues/435#issuecomment-475999342) and removes a minor foot-gun.