### PR TITLE
Fix pl paga when adata.uns color list was not set

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1982,7 +1982,7 @@ def tracksplot(
 
     # get categories colors:
     if groupby + "_colors" not in adata.uns:
-        from ._tools.scatterplots import _set_default_colors_for_categorical_obs
+        from ._utils import _set_default_colors_for_categorical_obs
         _set_default_colors_for_categorical_obs(adata, groupby)
 
     groupby_colors = adata.uns[groupby + "_colors"]

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -10,7 +10,7 @@ from pandas.api.types import is_categorical_dtype
 from matplotlib import pyplot as pl
 from matplotlib import rcParams
 from matplotlib import patheffects
-from matplotlib.colors import is_color_like, Colormap
+from matplotlib.colors import Colormap
 
 from .. import _utils
 from .._docs import doc_adata_color_etc, doc_edges_arrows, doc_scatter_embedding, doc_show_save_ax

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -313,7 +313,6 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
     None
     """
     from matplotlib.colors import to_hex
-    from cycler import Cycler, cycler
 
     categories = adata.obs[value_to_plot].cat.categories
     # check is palette is a valid matplotlib colormap
@@ -339,8 +338,8 @@ def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
                 if not is_color_like(color):
                     # check if the color is a valid R color and translate it
                     # to a valid hex color value
-                    if color in _utils.additional_colors:
-                        color = _utils.additional_colors[color]
+                    if color in additional_colors:
+                        color = additional_colors[color]
                     else:
                         raise ValueError("The following color value of the given palette is not valid: {}".format(color))
                 _color_list.append(color)
@@ -406,7 +405,7 @@ def add_colors_for_categorical_sample_annotation(adata, key, palette=None,
     if palette and force_update_colors:
         _set_colors_for_categorical_obs(adata, key, palette)
     elif color_key in adata.uns and len(adata.uns[color_key]) <= colors_needed:
-        _validate_palette()
+        _validate_palette(adata, key)
     else:
         _set_default_colors_for_categorical_obs(adata, key)
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -262,60 +262,153 @@ def default_palette(palette=None):
     else: return palette
 
 
-def adjust_palette(palette: Union[Cycler, ListedColormap, Sequence[ColorLike]], length: int):
-    if isinstance(palette, cabc.Sequence):
-        length_pal = len(palette)
-    elif isinstance(palette, Cycler):
-        length_pal = len(palette.by_key()['color'])
-    elif isinstance(palette, ListedColormap):
-        length_pal = len(palette.colors)
-    else:
-        raise ValueError(f'Unknown palette type {type(palette)}')
-    if length_pal < length:
-        if length <= 28:
-            palette = palettes.default_26
-        elif length <= len(palettes.default_64):  # 103 colors
-            palette = palettes.default_64
-        else:
-            palette = ['grey' for i in range(length)]
-            logg.info("more than 103 colors would be required, initializing as 'grey'")
-    if isinstance(palette, (Cycler, ListedColormap, cabc.Sequence)):
-        return palette
-    else:
-        return cycler(color=palette)
+def _validate_palette(adata, key):
+    """
+    checks if the list of colors in adata.uns[f'{key}_colors'] is valid
+    and updates the color list in adata.uns[f'{key}_colors'] if needed.
+
+    Not only valid matplotlib colors are checked but also if the color name
+    is a valid R color name, in which case it will be translated to a valid name
+    """
+
+    _palette = []
+    color_key = f"{key}_colors"
+
+    for color in adata.uns[color_key]:
+        if not is_color_like(color):
+            # check if the color is a valid R color and translate it
+            # to a valid hex color value
+            if color in additional_colors:
+                color = additional_colors[color]
+            else:
+                logg.warning(
+                    f"The following color value found in adata.uns['{key}_colors'] "
+                    f"is not valid: '{color}'. Default colors will be used instead."
+                )
+                _set_default_colors_for_categorical_obs(adata, key)
+                _palette = None
+                break
+        _palette.append(color)
+    if _palette is not None:
+        adata.uns[color_key] = _palette
 
 
-def add_colors_for_categorical_sample_annotation(adata, key, palette=None, force_update_colors=False):
-    if key + '_colors' in adata.uns and not force_update_colors:
-        if len(adata.obs[key].cat.categories) > len(adata.uns[key + '_colors']):
-            logg.info(
-                f"    number of colors in `.uns[{key}'_colors']` smaller "
-                'than number of categories, falling back to palette'
-            )
-        else:
-            # make sure that these are valid colors
-            adata.uns[key + '_colors'] = [
-                additional_colors[c] if c in additional_colors else c
-                for c in adata.uns[key + '_colors']]
-            return
+def _set_colors_for_categorical_obs(adata, value_to_plot, palette):
+    """
+    Sets the adata.uns[value_to_plot + '_colors'] according to the given palette
+
+    Parameters
+    ----------
+    adata
+        annData object
+    value_to_plot
+        name of a valid categorical observation
+    palette
+        Palette should be either a valid :func:`~matplotlib.pyplot.colormaps` string,
+        a list of colors (in a format that can be understood by matplotlib,
+        eg. RGB, RGBS, hex, or a cycler object with key='color'
+
+    Returns
+    -------
+    None
+    """
+    from matplotlib.colors import to_hex
+    from cycler import Cycler, cycler
+
+    categories = adata.obs[value_to_plot].cat.categories
+    # check is palette is a valid matplotlib colormap
+    if isinstance(palette, str) and palette in pl.colormaps():
+        # this creates a palette from a colormap. E.g. 'Accent, Dark2, tab20'
+        cmap = pl.get_cmap(palette)
+        colors_list = [to_hex(x) for x in cmap(np.linspace(0, 1, len(categories)))]
+
     else:
-        logg.debug(f'generating colors for {key} using palette')
-    palette = default_palette(palette)
-    palette_adjusted = adjust_palette(palette,
-                                      length=len(adata.obs[key].cat.categories))
-    adata.uns[key + '_colors'] = palette_adjusted[
-        :len(adata.obs[key].cat.categories)].by_key()['color']
-    if len(adata.obs[key].cat.categories) > len(adata.uns[key + '_colors']):
-        raise ValueError(
-            'Cannot plot more than {} categories, which is not enough for {}.'
-            .format(len(adata.uns[key + '_colors']), key))
-    for iname, name in enumerate(adata.obs[key].cat.categories):
-        if name in settings.categories_to_ignore:
+        # check if palette is a list and convert it to a cycler, thus
+        # it doesnt matter if the list is shorter than the categories length:
+        if isinstance(palette, cabc.Sequence):
+            if len(palette) < len(categories):
+                logg.warning(
+                    "Length of palette colors is smaller than the number of "
+                    f"categories (palette length: {len(palette)}, "
+                    f"categories length: {len(categories)}. "
+                    "Some categories will have the same color."
+                )
+            # check that colors are valid
+            _color_list = []
+            for color in palette:
+                if not is_color_like(color):
+                    # check if the color is a valid R color and translate it
+                    # to a valid hex color value
+                    if color in _utils.additional_colors:
+                        color = _utils.additional_colors[color]
+                    else:
+                        raise ValueError("The following color value of the given palette is not valid: {}".format(color))
+                _color_list.append(color)
+
+            palette = cycler(color=_color_list)
+        if not isinstance(palette, Cycler):
+            raise ValueError("Please check that the value of 'palette' is a "
+                             "valid matplotlib colormap string (eg. Set2), a "
+                             "list of color names or a cycler with a 'color' key.")
+        if 'color' not in palette.keys:
+            raise ValueError("Please set the palette key 'color'.")
+
+        cc = palette()
+        colors_list = [to_hex(next(cc)['color']) for x in range(len(categories))]
+
+    adata.uns[value_to_plot + '_colors'] = colors_list
+
+
+def _set_default_colors_for_categorical_obs(adata, value_to_plot):
+    """
+    Sets the adata.uns[value_to_plot + '_colors'] using default color palettes
+
+    Parameters
+    ----------
+    adata : annData object
+    value_to_plot : name of a valid categorical observation
+
+    Returns
+    -------
+    None
+    """
+
+    categories = adata.obs[value_to_plot].cat.categories
+    length = len(categories)
+
+    # check if default matplotlib palette has enough colors
+    if len(rcParams['axes.prop_cycle'].by_key()['color']) >= length:
+        cc = rcParams['axes.prop_cycle']()
+        palette = [next(cc)['color'] for _ in range(length)]
+
+    else:
+        if length <= 20:
+            palette = palettes.default_20
+        elif length <= 28:
+            palette = palettes.default_28
+        elif length <= len(palettes.default_102):  # 103 colors
+            palette = palettes.default_102
+        else:
+            palette = ['grey' for _ in range(length)]
             logg.info(
-                f"    setting color of group {name!r} in {key!r} to 'grey' "
-                '(`sc.settings.categories_to_ignore`)'
+                f'the obs value {value_to_plot!r} has more than 103 categories. Uniform '
+                "'grey' color will be used for all categories."
             )
-            adata.uns[key + '_colors'][iname] = 'grey'
+
+    adata.uns[value_to_plot + '_colors'] = palette[:length]
+
+
+def add_colors_for_categorical_sample_annotation(adata, key, palette=None,
+                                                 force_update_colors=False):
+
+    color_key = f"{key}_colors"
+    colors_needed = len(adata.obs[key].cat.categories)
+    if palette and force_update_colors:
+        _set_colors_for_categorical_obs(adata, key, palette)
+    elif color_key in adata.uns and len(adata.uns[color_key]) <= colors_needed:
+        _validate_palette()
+    else:
+        _set_default_colors_for_categorical_obs(adata, key)
 
 
 def plot_edges(axs, adata, basis, edges_width, edges_color):

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -6,7 +6,7 @@ import numpy as np
 from matplotlib import pyplot as pl
 from matplotlib import rcParams, ticker
 from matplotlib.axes import Axes
-from matplotlib.colors import is_color_like, ListedColormap
+from matplotlib.colors import is_color_like
 from matplotlib.figure import SubplotParams as sppars
 from cycler import Cycler, cycler
 

--- a/scanpy/plotting/palettes.py
+++ b/scanpy/plotting/palettes.py
@@ -30,7 +30,7 @@ default_20 = vega_20_scanpy
 # https://graphicdesign.stackexchange.com/questions/3682/where-can-i-find-a-large-palette-set-of-contrasting-colors-for-coloring-many-d
 # update 1
 # orig reference http://epub.wu.ac.at/1692/1/document.pdf
-zeileis_26 = [
+zeileis_28 = [
     "#023fa5", "#7d87b9", "#bec1d4", "#d6bcc0", "#bb7784", "#8e063b", "#4a6fe3",
     "#8595e1", "#b5bbe3", "#e6afb9", "#e07b91", "#d33f6a", "#11c638", "#8dd593",
     "#c6dec7", "#ead3c6", "#f0b98d", "#ef9708", "#0fcfc0", "#9cded6", "#d5eae7",
@@ -38,10 +38,10 @@ zeileis_26 = [
     '#7f7f7f', "#c7c7c7", "#1CE6FF", "#336600",  # these last ones were added,
 ]
 
-default_26 = zeileis_26
+default_28 = zeileis_28
 
 # from http://godsnotwheregodsnot.blogspot.de/2012/09/color-distribution-methodology.html
-godsnot_64 = [
+godsnot_102 = [
     # "#000000",  # remove the black, as often, we have black colored annotation
     "#FFFF00", "#1CE6FF", "#FF34FF", "#FF4A46", "#008941", "#006FA6", "#A30059",
     "#FFDBE5", "#7A4900", "#0000A6", "#63FFAC", "#B79762", "#004D43", "#8FB0FF", "#997D87",
@@ -58,7 +58,7 @@ godsnot_64 = [
     "#5B4534", "#FDE8DC", "#404E55", "#0089A3", "#CB7E98", "#A4E804", "#324E72",
 ]
 
-default_64 = godsnot_64
+default_102 = godsnot_102
 
 
 from typing import Mapping, Sequence

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -56,6 +56,7 @@ def test_heatmap(image_comparer):
                   standard_scale='obs')
     save_and_compare_images('master_heatmap_std_scale_obs')
 
+
 def test_clustermap(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
 
@@ -65,6 +66,7 @@ def test_clustermap(image_comparer):
 
     sc.pl.clustermap(adata, 'cell_type')
     save_and_compare_images('master_clustermap_withcolor')
+
 
 def test_dotplot(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
@@ -321,7 +323,6 @@ def test_scatterplots(image_comparer):
     save_and_compare_images('master_umap')
 
     # test umap with gene expression
-    import numpy as np
     sc.pl.umap(pbmc, color=np.array(['LYZ', 'CD79A']), s=20, alpha=0.5, frameon=False,
                title=['gene1', 'gene2'], show=False)
     save_and_compare_images('master_umap_gene_expr')
@@ -451,6 +452,7 @@ def test_scatter_rep(tmpdir):
             assert comp is None, comp
         else:
             assert "Error" in comp, f"{s1.outpth}, {s2.outpth} aren't supposed to match"
+
 
 def test_paga(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=20)

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -458,6 +458,8 @@ def test_paga(image_comparer):
     pbmc = sc.datasets.pbmc68k_reduced()
     sc.tl.paga(pbmc, groups='bulk_labels')
 
+    # delete bulk_labels_colors to test the creation of color list by paga
+    del pbmc.uns['bulk_labels_colors']
     sc.pl.paga(pbmc, threshold=0.5, max_edge_width=1.0, show=False)
     save_and_compare_images('master_paga')
 


### PR DESCRIPTION
`sc.pl.paga` was throwing and error when the color list in `.uns` was not previously set. While fixing the error I realized that some functionality was duplicated between legacy scatter plots and the embedding plots and removed the code duplication.