### PR TITLE
Inherit main requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,27 +1,6 @@
-# use highlighting until the merge of https://github.com/rtfd/readthedocs.org/pull/4096
+-r ../requirements.txt
 sphinx_rtd_theme>=0.3.1
-# sphinx-autodoc-typehints needs at least sphinx 1.8
-# Sphinx 2 has nicer looking sections
 sphinx>=2.0.1
 sphinx-autodoc-typehints
 scanpydoc>=0.4.3
-# same as ../requires.txt, but omitting the c++ packages
-anndata>=0.6.18
-matplotlib>=2.2
-pandas>=0.21
-scipy
-seaborn
-h5py
-tables
-scikit-learn>=0.19.1
-# statsmodels  # not needed for docs
-networkx
-natsort
-joblib
-numba
-tqdm
-importlib_metadata; python_version < '3.8'
 typing_extensions; python_version < '3.8'
-setuptools_scm
-umap-learn
-legacy-api-wrap

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,3 +17,4 @@ joblib
 numba>=0.41.0
 umap-learn>=0.3.0
 legacy-api-wrap
+setuptools_scm


### PR DESCRIPTION
To not repeat ourselves @ivirshup (I think) suggested this. Let’s see if readthedocs supports this. If so, this should soon be visible: https://icb-scanpy.readthedocs-hosted.com/en/inherit-requirements/