### PR TITLE
Allow specification of mitochondrial chromosome when retrieving mitochondrial genes

### DIFF
--- a/scanpy/queries/_queries.py
+++ b/scanpy/queries/_queries.py
@@ -162,6 +162,7 @@ def mitochondrial_genes(
     attrname: str = "external_gene_name",
     host: str = "www.ensembl.org",
     use_cache: bool = False,
+    chromosome: str = "MT",
 ) -> pd.DataFrame:
     """\
     Mitochondrial gene symbols for specific organism through BioMart.
@@ -175,6 +176,8 @@ def mitochondrial_genes(
         and "zfin_id_symbol".
     {doc_host}
     {doc_use_cache}
+    chromosome
+        Mitochrondrial chromosome name used in BioMart for organism.
 
     Returns
     -------
@@ -185,11 +188,12 @@ def mitochondrial_genes(
     >>> import scanpy as sc
     >>> mito_gene_names = sc.queries.mitochondrial_genes("hsapiens")
     >>> mito_ensembl_ids = sc.queries.mitochondrial_genes("hsapiens", attrname="ensembl_gene_id")
+    >>> mito_gene_names_fly = sc.queries.mitochondrial_genes("dmelanogaster", chromosome="mitochondrion_genome")
     """
     return simple_query(
         org,
         attrs=[attrname],
-        filters={"chromosome_name": ["MT"]},
+        filters={"chromosome_name": [chromosome]},
         host=host,
         use_cache=use_cache,
     )


### PR DESCRIPTION
Allow specification of mitochondrial chromosome when retrieving mitochondrial
genes as some organisms use a different chromosome name than "MT".