### PR TITLE
WIP Links to tutorials

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,3 +18,6 @@ If Scanpy is useful for your research, consider citing `Genome Biology (2018) <h
    api/index
    external/index
    references
+
+.. intersphinx-tocs::
+   scanpy_tutorials: Tutorials


### PR DESCRIPTION
This defines a directive to include other TOCs into your own using intersphinx:

https://github.com/theislab/scanpy/blob/23ac33691acfc188d17c2e84bbf8a7750ce5e063/docs/conf.py#L90-L93
https://github.com/theislab/scanpy/blob/23ac33691acfc188d17c2e84bbf8a7750ce5e063/docs/index.rst#L22-L23

![grafik](https://user-images.githubusercontent.com/291575/68944214-a0660a80-07ad-11ea-8e13-6f7c92732633.png)

Fixes #922. There’s three problems however:

- [ ] The names of our tutorials don’t work as well as the headers in our [Tutorials section](https://scanpy.readthedocs.io/en/stable/tutorials.html)
- [ ] The order isn’t preserved. PAGA should definitely come last as it’s most specific.
- [ ] neither the best practices repo nor scanpy_usage is published with nbsphinx. Also it contains a lot of notebooks, no idea what we want in