### PR TITLE
Update release_notes and remove inline links

### DIFF
--- a/docs/basic_usage.rst
+++ b/docs/basic_usage.rst
@@ -7,39 +7,47 @@ Import Scanpy as::
 
 Workflow
 ^^^^^^^^
-
 The typical workflow consists of subsequent calls of data analysis tools
 in `sc.tl`, e.g.::
 
     sc.tl.umap(adata, **tool_params)  # embed a neighborhood graph of the data using UMAP
 
-where `adata` is an :class:`~anndata.AnnData` object. Each of these calls adds annotation to an expression matrix *X*, which stores *n_obs* observations (cells) of *n_vars* variables (genes). For each tool, there typically is an associated plotting function in ``sc.pl``::
+where `adata` is an :class:`~anndata.AnnData` object.
+Each of these calls adds annotation to an expression matrix *X*,
+which stores *n_obs* observations (cells) of *n_vars* variables (genes).
+For each tool, there typically is an associated plotting function in `sc.pl`::
 
     sc.pl.umap(adata, **plotting_params)
 
-If you pass `show=False`, a :class:`matplotlib.axes.Axes` instance is returned and you have all of matplotlib's detailed configuration possibilities.
+If you pass `show=False`, a :class:`matplotlib.axes.Axes` instance is returned
+and you have all of matplotlib's detailed configuration possibilities.
 
-To facilitate writing memory-efficient pipelines, by default, Scanpy tools operate *inplace* on `adata` and return `None` - this also allows to easily transition to `out-of-memory pipelines <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`__. If you want to return a copy of the :class:`~anndata.AnnData` object and leave the passed `adata` unchanged, pass `copy=True` or `inplace=False`.
+To facilitate writing memory-efficient pipelines, by default,
+Scanpy tools operate *inplace* on `adata` and return `None` –
+this also allows to easily transition to `out-of-memory pipelines`_.
+If you want to return a copy of the :class:`~anndata.AnnData` object
+and leave the passed `adata` unchanged, pass `copy=True` or `inplace=False`.
 
+.. _out-of-memory pipelines: http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
 
 AnnData
 ^^^^^^^
-
 Scanpy is based on :mod:`anndata`, which provides the :class:`~anndata.AnnData` class.
 
-.. raw:: html
-
-    <img src="http://falexwolf.de/img/scanpy/anndata.svg" style="width: 300px">
+.. image:: http://falexwolf.de/img/scanpy/anndata.svg
+   :width: 300px
 
 At the most basic level, an :class:`~anndata.AnnData` object `adata` stores
 a data matrix (`adata.X`), dataframe-like annotation of observations
 (`adata.obs`) and variables (`adata.var`) and unstructured dict-like
-annotation (``adata.uns``). Values can be retrieved and appended via
+annotation (`adata.uns`). Values can be retrieved and appended via
 `adata.obs['key1']` and `adata.var['key2']`. Names of observations and
 variables can be accessed via `adata.obs_names` and `adata.var_names`,
 respectively. :class:`~anndata.AnnData` objects can be sliced like
 dataframes, for example, `adata_subset = adata[:, list_of_gene_names]`.
-For more, see this `blog post <http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/>`__.
+For more, see this `blog post`_.
+
+.. _blog post: http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
 
 To read a data file to an :class:`~anndata.AnnData` object, call::
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,12 @@
 .. include:: ../README.rst
    :end-line: 22
 
-Discuss usage on `Discourse <https://scanpy.discourse.group/>`__. See the code and discuss development on `GitHub <https://github.com/theislab/scanpy>`__.
-If Scanpy is useful for your research, consider citing `Genome Biology (2018) <https://doi.org/10.1186/s13059-017-1382-0>`__.
+Discuss usage on Discourse_. See the code and discuss development on GitHub_.
+If Scanpy is useful for your research, consider citing `Genome Biology (2018)`_.
+
+.. _Discourse: https://scanpy.discourse.group/
+.. _GitHub: https://github.com/theislab/scanpy
+.. _Genome Biology (2018): https://doi.org/10.1186/s13059-017-1382-0
 
 .. include:: release_notes.rst
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -3,54 +3,39 @@ Installation
 
 Anaconda
 ~~~~~~~~
-
-If you do not have a working Python 3.5 or 3.6 installation, consider
+If you do not have a working installation of Python 3.6 (or later), consider
 installing Miniconda_ (see `Installing Miniconda`_). Then run::
 
-    conda install seaborn scikit-learn statsmodels numba pytables
-    conda install -c conda-forge python-igraph louvain
+    conda install -c bioconda scanpy
 
-Pull Scanpy from `PyPI <https://pypi.org/project/scanpy>`__ (consider
-using ``pip3`` to access Python 3)::
+Otherwise, you might want to pull Scanpy `from PyPI`_:
 
-    pip install scanpy
+.. _from PyPI: https://pypi.org/project/scanpy
 
 PyPI only
 ~~~~~~~~~
-
 If you prefer to exclusively use PyPI run::
 
     pip install scanpy[louvain]
 
-or::
-    
-    pip install scanpy python-igraph louvain
+The extra `[louvain]` installs two packages that are needed for popular
+parts of scanpy but aren't requirements: python-igraph_ [Csardi06]_ and louvain_ [Traag17]_.
 
-The extra ``[louvain]`` installs two packages that are needed for
-parts of scanpy but aren't requirements: `python-igraph
-<http://igraph.org/python/>`__ [Csardi06]_ and `louvain
-<https://github.com/vtraag/louvain-igraph>`__ [Traag17]_.
-
-Bioconda
-~~~~~~~~
-
-Using bioconda_, simply run::
-
-    conda install -c bioconda scanpy
+.. _python-igraph: http://igraph.org/python/
+.. _louvain: https://github.com/vtraag/louvain-igraph
 
 Development Version
 ~~~~~~~~~~~~~~~~~~~
-
-To work with the latest version on `GitHub
-<https://github.com/theislab/scanpy>`__: clone the repository and ``cd`` into
+To work with the latest version `on GitHub`_: clone the repository and `cd` into
 its root directory. To install using symbolic links (stay up to date with your
-cloned version after you update with ``git pull``) call::
+cloned version after you update with `git pull`) call::
 
     pip install -e .
 
+.. _on GitHub: https://github.com/theislab/scanpy
+
 Docker
 ~~~~~~
-
 If you're using Docker_, you can use the minimal `fastgenomics/scanpy`_ image from the Docker Hub.
 
 .. _Docker: https://en.wikipedia.org/wiki/Docker_(software)
@@ -59,21 +44,32 @@ If you're using Docker_, you can use the minimal `fastgenomics/scanpy`_ image fr
 
 Troubleshooting
 ~~~~~~~~~~~~~~~
-
 If you get a `Permission denied` error, never use `sudo pip`. Instead, use virtual environments or::
 
     pip install --user scanpy
 
 **On MacOS**, if **not** using `conda`, you might need to install the C core of igraph via homebrew first
 
-- ``brew install igraph``
-- If python-igraph still fails to install, see `here <https://stackoverflow.com/questions/29589696/problems-compiling-c-core-of-igraph-with-python-2-7-9-anaconda-2-2-0-on-mac-osx>`__ or consider installing gcc via ``brew install gcc --without-multilib`` and exporting ``export CC="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"; export CXX="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"``, where ``X`` and ``x`` refers to the version of ``gcc``; in my case, the path reads ``/usr/local/Cellar/gcc/6.3.0_1/bin/gcc-6``.
+- `brew install igraph`
+- If python-igraph still fails to install, see the question on `compiling igraph`_.
+  Alternatively consider installing gcc via `brew install gcc --without-multilib`
+  and exporting the required variables::
 
-**On Windows**, there also often problems installing compiled packages such as `igraph`, but you can find precompiled packages on <https://www.lfd.uci.edu/~gohlke/pythonlibs/>. Download those and install them using `pip install ./path/to/file.whl`
+      export CC="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"
+      export CXX="/usr/local/Cellar/gcc/X.x.x/bin/gcc-X"
+
+  where `X` and `x` refers to the version of `gcc`;
+  in my case, the path reads `/usr/local/Cellar/gcc/6.3.0_1/bin/gcc-6`.
+
+**On Windows**, there also often problems installing compiled packages such as `igraph`,
+but you can find precompiled packages on Christoph Gohlke’s `unofficial binaries`_.
+Download those and install them using `pip install ./path/to/file.whl`
+
+.. _compiling igraph: https://stackoverflow.com/q/29589696/247482
+.. _unofficial binaries: https://www.lfd.uci.edu/~gohlke/pythonlibs/
 
 Installing Miniconda
 ~~~~~~~~~~~~~~~~~~~~
-
 After downloading Miniconda_, in a unix shell (Linux, Mac), run
 
 .. code:: shell
@@ -82,6 +78,8 @@ After downloading Miniconda_, in a unix shell (Linux, Mac), run
     chmod +x Miniconda3-latest-VERSION.sh
     ./Miniconda3-latest-VERSION.sh
 
-and accept all suggestions. Either reopen a new terminal or ``source ~/.bashrc`` on Linux/ ``source ~/.bash_profile`` on Mac. The whole process takes just a couple of minutes.
+and accept all suggestions.
+Either reopen a new terminal or `source ~/.bashrc` on Linux/ `source ~/.bash_profile` on Mac.
+The whole process takes just a couple of minutes.
 
 .. _Miniconda: http://conda.pydata.org/miniconda.html

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,4 +1,4 @@
-.. note::
+ries 1.4.5 :pr:`467` .. note::
 
     Also see the `release notes <https://anndata.readthedocs.io>`__ of :mod:`anndata`.
 
@@ -23,7 +23,10 @@
 On master
 ---------
 
-- :mod:`scanpy.queries` recieved many updates. This includes enrichment through `gprofiler <https://biit.cs.ut.ee/gprofiler/>`_ and more advanced biomart queries :noteversion:`1.4.5` :pr:`467` :smaller:`thanks to I Virshup`
+- :mod:`scanpy.queries` recieved many updates. This includes enrichment through gprofiler_ and more advanced biomart queries :noteversion:`1.4.5` :pr:`467` :smaller:`thanks to I Virshup`
+- Allow specifying a base for :func:`~scanpy.pp.log1p` :noteversion:`1.4.5` :pr:`931` :smaller:`thanks to G Eraslan`
+
+.. _gprofiler: https://biit.cs.ut.ee/gprofiler/
 
 Post v1.4 :small:`July 20, 2019`
 --------------------------------
@@ -74,8 +77,11 @@ Major updates:
 
 Two new possibilities for interactive exploration of analysis results:
 
-- CZI's `cellxgene <https://github.com/chanzuckerberg/cellxgene>`__ directly reads `.h5ad` files :smaller:`thanks to the cellxgene developers`
-- the `UCSC Single Cell Browser <https://github.com/maximilianh/cellBrowser>`__ requires exporting via :func:`~scanpy.external.exporting.cellbrowser` :noteversion:`1.3.6` :smaller:`thanks to M Haeussler`
+- CZI's cellxgene_ directly reads `.h5ad` files :smaller:`thanks to the cellxgene developers`
+- the `UCSC Single Cell Browser`_ requires exporting via :func:`~scanpy.external.exporting.cellbrowser` :noteversion:`1.3.6` :smaller:`thanks to M Haeussler`
+
+.. _cellxgene: https://github.com/chanzuckerberg/cellxgene
+.. _UCSC Single Cell Browser: https://github.com/maximilianh/cellBrowser
 
 Further updates:
 

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,6 +1,5 @@
-ries 1.4.5 :pr:`467` .. note::
-
-    Also see the `release notes <https://anndata.readthedocs.io>`__ of :mod:`anndata`.
+.. note::
+   Also see the `release notes <https://anndata.readthedocs.io>`__ of :mod:`anndata`.
 
 .. role:: small
 .. role:: smaller
@@ -8,16 +7,21 @@ ries 1.4.5 :pr:`467` .. note::
 
 .. sidebar:: Key Contributors
 
-    [`anndata <https://github.com/theislab/anndata/graphs/contributors>`__ & `scanpy <https://github.com/theislab/scanpy/graphs/contributors>`__ graphs; the ☀ signifies current maintainers]
+   [`anndata <https://github.com/theislab/anndata/graphs/contributors>`__ & `scanpy <https://github.com/theislab/scanpy/graphs/contributors>`__ graphs; the ☀ signifies current maintainers]
 
-    * `Isaac Virshup <https://twitter.com/ivirshup>`__: anndata overhaul, diverse contributions ☀
-    * Gökcen Eraslan: diverse contributions ☀
-    * Sergei Rybakov: diverse contributions ☀
-    * Fidel Ramirez: plotting ☀
-    * `Tom White <https://twitter.com/tom_e_white>`__: distributed computing
-    * Philipp Angerer: initial anndata conception/development, software quality ☀
-    * `Alex Wolf <https://twitter.com/falexwolf>`__: initial anndata & scanpy conception/development ☀
-    * `Fabian Theis <https://twitter.com/fabian_theis>`__ & lab: enabling guidance, support and environment
+   * `Isaac Virshup`_: anndata overhaul, diverse contributions ☀
+   * Gökcen Eraslan: diverse contributions ☀
+   * Sergei Rybakov: diverse contributions ☀
+   * Fidel Ramirez: plotting ☀
+   * `Tom White`_: distributed computing
+   * Philipp Angerer: initial anndata conception/development, software quality ☀
+   * `Alex Wolf`_: initial anndata & scanpy conception/development ☀
+   * `Fabian Theis`_ & lab: enabling guidance, support and environment
+
+.. _Isaac Virshup: https://twitter.com/ivirshup
+.. _Tom White: https://twitter.com/tom_e_white
+.. _Alex Wolf: https://twitter.com/falexwolf
+.. _Fabian Theis: https://twitter.com/fabian_theis
 
 
 On master
@@ -27,6 +31,7 @@ On master
 - Allow specifying a base for :func:`~scanpy.pp.log1p` :noteversion:`1.4.5` :pr:`931` :smaller:`thanks to G Eraslan`
 
 .. _gprofiler: https://biit.cs.ut.ee/gprofiler/
+
 
 Post v1.4 :small:`July 20, 2019`
 --------------------------------
@@ -77,7 +82,7 @@ Major updates:
 
 Two new possibilities for interactive exploration of analysis results:
 
-- CZI's cellxgene_ directly reads `.h5ad` files :smaller:`thanks to the cellxgene developers`
+- CZI’s cellxgene_ directly reads `.h5ad` files :smaller:`thanks to the cellxgene developers`
 - the `UCSC Single Cell Browser`_ requires exporting via :func:`~scanpy.external.exporting.cellbrowser` :noteversion:`1.3.6` :smaller:`thanks to M Haeussler`
 
 .. _cellxgene: https://github.com/chanzuckerberg/cellxgene
@@ -85,13 +90,13 @@ Two new possibilities for interactive exploration of analysis results:
 
 Further updates:
 
-- :func:`~scanpy.pp.highly_variable_genes` supersedes :func:`~scanpy.pp.filter_genes_dispersion`, it gives the same results but, by default, expects logarithmized data and doesn't subset :noteversion:`1.3.6` :smaller:`thanks to S Rybakov`
+- :func:`~scanpy.pp.highly_variable_genes` supersedes :func:`~scanpy.pp.filter_genes_dispersion`, it gives the same results but, by default, expects logarithmized data and doesn’t subset :noteversion:`1.3.6` :smaller:`thanks to S Rybakov`
 - :func:`~scanpy.pp.combat` reimplements Combat for batch effect correction [Johnson07]_ [Leek12]_, heavily based on the Python implementation of [Pedersen12]_, but with performance improvements, see :pr:`398` :noteversion:`1.3.7` :smaller:`thanks to M Lange`
 - :func:`~scanpy.tl.leiden` wraps the recent graph clustering package by [Traag18]_ :noteversion:`1.3.4` :smaller:`thanks to K Polanski`
 - :func:`~scanpy.external.pp.bbknn` wraps the recent batch correction package [Polanski19]_ :noteversion:`1.3.4` :smaller:`thanks to K Polanski`
 - :func:`~scanpy.external.tl.phenograph` wraps the graph clustering package Phenograph [Levine15]_  :noteversion:`1.3.7` :smaller:`thanks to A Mousa`
 - :func:`~scanpy.pp.calculate_qc_metrics` caculates a number of quality control metrics, similar to `calculateQCMetrics` from *Scater* [McCarthy17]_ :noteversion:`1.3.4` :smaller:`thanks to I Virshup`
-- :func:`~scanpy.read_10x_h5` throws more stringent errors and doesn't require speciying default genomes anymore, see :pr:`442` and :pr:`444` :noteversion:`1.3.8`  :smaller:`thanks to I Vishrup`
+- :func:`~scanpy.read_10x_h5` throws more stringent errors and doesn’t require speciying default genomes anymore, see :pr:`442` and :pr:`444` :noteversion:`1.3.8`  :smaller:`thanks to I Vishrup`
 - :func:`~scanpy.read_10x_h5` and :func:`~scanpy.read_10x_mtx` read Cell Ranger 3.0 outputs, see :pr:`334` :noteversion:`1.3.3`  :smaller:`thanks to Q Gong`
 
 
@@ -100,17 +105,21 @@ Version 1.3 :small:`September 3, 2018`
 
 RNA velocity in single cells [Manno18]_:
 
-- Scanpy and AnnData support loom's layers so that computations for single-cell RNA velocity [Manno18]_ become feasible :smaller:`thanks to S Rybakov and V Bergen`
-- the package `scvelo <https://github.com/theislab/scvelo>`__ perfectly harmonizes with Scanpy and is able to process loom files with splicing information produced by Velocyto [Manno18]_, it runs a lot faster than the count matrix analysis of Velocyto and provides several conceptual developments (preprint to come)
+- Scanpy and AnnData support loom’s layers so that computations for single-cell RNA velocity [Manno18]_ become feasible :smaller:`thanks to S Rybakov and V Bergen`
+- the package `scvelo`_ perfectly harmonizes with Scanpy and is able to process loom files with splicing information produced by Velocyto [Manno18]_, it runs a lot faster than the count matrix analysis of Velocyto and provides several conceptual developments (preprint to come)
 
-Plotting of marker genes and quality control, see this `section <https://scanpy.readthedocs.io/en/latest/api/plotting.html#generic>`__ and scroll down, a few examples are
+.. _scvelo: https://github.com/theislab/scvelo
 
-- :func:`~scanpy.pl.dotplot` for visualizing genes across conditions and clusters, see `here <https://gist.github.com/fidelram/2289b7a8d6da055fb058ac9a79ed485c>`__ :smaller:`thanks to F Ramirez`
+Plotting of :ref:`pl-generic` marker genes and quality control.
+
+- :func:`~scanpy.pl.dotplot` for visualizing genes across conditions and clusters, see `here`__ :smaller:`thanks to F Ramirez`
 - :func:`~scanpy.pl.heatmap` for pretty heatmaps, see :pr:`175` :smaller:`thanks to F Ramirez`
-- :func:`~scanpy.pl.violin` produces very compact overview figures with many panels, see `here <https://github.com/theislab/scanpy/pull/175>`__ :smaller:`thanks to F Ramirez`
+- :func:`~scanpy.pl.violin` produces very compact overview figures with many panels, see :pr:`175` :smaller:`thanks to F Ramirez`
 - :func:`~scanpy.pl.highest_expr_genes` for quality control, see :pr:`169`; plot genes with highest mean fraction of cells, similar to `plotQC` of *Scater* [McCarthy17]_ :smaller:`thanks to F Ramirez`
 
-There is a `section <https://scanpy.readthedocs.io/en/latest/api/#imputation>`__ on imputation:
+.. __: https://gist.github.com/fidelram/2289b7a8d6da055fb058ac9a79ed485c
+
+There is now a section on :ref:`pp-imputation`:
 
 - :func:`~scanpy.external.pp.magic` for imputation using data diffusion [vanDijk18]_ :smaller:`thanks to S Gigante`
 - :func:`~scanpy.external.pp.dca` for imputation and latent space construction using an autoencoder [Eraslan18]_
@@ -119,7 +128,7 @@ There is a `section <https://scanpy.readthedocs.io/en/latest/api/#imputation>`__
 Version 1.2 :small:`June 8, 2018`
 ---------------------------------
 
-- :func:`~scanpy.tl.paga` improved, see `theislab/paga <https://github.com/theislab/paga>`__; the default model changed, restore the previous default model by passing `model='v1.0'`
+- :func:`~scanpy.tl.paga` improved, see `theislab/paga`_; the default model changed, restore the previous default model by passing `model='v1.0'`
 
 
 Version 1.1 :small:`May 31, 2018`
@@ -141,18 +150,17 @@ Version 1.0 :small:`March 28, 2018`
 -----------------------------------
 
 Scanpy is much faster and more memory efficient. Preprocess, cluster and visualize
-1.3M cells in `6 h
-<https://github.com/theislab/scanpy_usage/blob/master/170522_visualizing_one_million_cells/>`__,
-130K cells in `14 min
-<https://github.com/theislab/scanpy_usage/blob/master/170522_visualizing_one_million_cells/logfile_130K.txt>`__
-and 68K cells in `3 min
-<https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170503_zheng17/zheng17.ipynb>`__.
+1.3M cells in 6h_, 130K cells in 14min_, and 68K cells in 3min_.
+
+.. _6h: https://github.com/theislab/scanpy_usage/blob/master/170522_visualizing_one_million_cells/
+.. _14min: https://github.com/theislab/scanpy_usage/blob/master/170522_visualizing_one_million_cells/logfile_130K.txt
+.. _3min: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170503_zheng17/zheng17.ipynb
 
 The API gained a preprocessing function :func:`~scanpy.pp.neighbors` and a
 class :func:`~scanpy.Neighbors` to which all basic graph computations are
 delegated.
 
-Upgrading to 1.0 isn't fully backwards compatible in the following changes:
+Upgrading to 1.0 isn’t fully backwards compatible in the following changes:
 
 - the graph-based tools :func:`~scanpy.tl.louvain`
   :func:`~scanpy.tl.dpt` :func:`~scanpy.tl.draw_graph`
@@ -164,17 +172,19 @@ Upgrading to 1.0 isn't fully backwards compatible in the following changes:
 - the default connectivity measure (dpt will look different using default
   settings) changed. setting `method='gauss'` in `sc.pp.neighbors` uses
   gauss kernel connectivities and reproduces the previous behavior,
-  see, for instance this `example
-  <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170502_paul15/paul15.ipynb>`__
+  see, for instance in the example paul15_.
 - namings of returned annotation have changed for less bloated AnnData
   objects, which means that some of the unstructured annotation of old
   AnnData files is not recognized anymore
 - replace occurances of `group_by` with `groupby` (consistency with
   `pandas`)
-- it is worth checking out the notebook examples to see changes, e.g., `here
-  <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170505_seurat/seurat.ipynb>`__
+- it is worth checking out the notebook examples to see changes, e.g.
+  the seurat_ example.
 - upgrading scikit-learn from 0.18 to 0.19 changed the implementation of PCA,
   some results might therefore look slightly different
+
+.. _paul15: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170502_paul15/paul15.ipynb
+.. _seurat: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170505_seurat/seurat.ipynb
 
 Further changes are:
 
@@ -196,19 +206,19 @@ Further changes are:
 - default cache directory is ``./cache/``, set `settings.cachedir` to change
   this; nested directories in this are avoided
 - show edges in scatter plots based on graph visualization
-  :func:`~scanpy.tl.draw_graph` and :func:`~scanpy.tl.umap` by passing
-  `edges=True`
+  :func:`~scanpy.tl.draw_graph` and :func:`~scanpy.tl.umap` by passing `edges=True`
 - :func:`~scanpy.pp.downsample_counts` for downsampling counts :smaller:`thanks to MD Luecken`
-- default 'louvain_groups' are called 'louvain'
-- 'X_diffmap' contains the zero component, plotting remains unchanged
+- default `'louvain_groups'` are called `'louvain'`
+- `'X_diffmap'` contains the zero component, plotting remains unchanged
 
 
 Version 0.4.4 :small:`February 26, 2018`
 ----------------------------------------
 
 - embed cells using :func:`~scanpy.tl.umap` [McInnes18]_: :pr:`92`
-- score sets of genes, e.g. for cell cycle, using :func:`~scanpy.tl.score_genes` [Satija15]_: `notebook <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/180209_cell_cycle/cell_cycle.ipynb>`__
+- score sets of genes, e.g. for `cell cycle`_, using :func:`~scanpy.tl.score_genes` [Satija15]_.
 
+.. _cell cycle: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/180209_cell_cycle/cell_cycle.ipynb
 
 Version 0.4.3 :small:`February 9, 2018`
 ---------------------------------------
@@ -222,37 +232,41 @@ Version 0.4.3 :small:`February 9, 2018`
 Version 0.4.2 :small:`January 7, 2018`
 --------------------------------------
 
-- amendments in `PAGA <https://github.com/theislab/paga>`__ and its plotting
-  functions
+- amendments in `theislab/paga`_ and its plotting functions
 
 
 Version 0.4 :small:`December 23, 2017`
 --------------------------------------
 
-- export to `SPRING <https://github.com/AllonKleinLab/SPRING/>`__ [Weinreb17]_
-  for interactive visualization of data: `tutorial
-  <https://github.com/theislab/scanpy_usage/tree/master/171111_SPRING_export>`__,
-  docs :mod:`scanpy.api`.
+- export to SPRING_ [Weinreb17]_ for interactive visualization of data:
+  `spring tutorial`_, docs :mod:`scanpy.api`.
 
+.. _SPRING: https://github.com/AllonKleinLab/SPRING/
+.. _spring tutorial: https://github.com/theislab/scanpy_usage/tree/master/171111_SPRING_export
 
 Version 0.3.2 :small:`November 29, 2017`
 ----------------------------------------
 
-- finding marker genes via :func:`~scanpy.pl.rank_genes_groups_violin` improved: `example <https://github.com/theislab/scanpy/issues/51>`__
+- finding marker genes via :func:`~scanpy.pl.rank_genes_groups_violin` improved:
+  For an example, see :issue:`51`.
 
 
 Version 0.3 :small:`November 16, 2017`
 --------------------------------------
 
 - :class:`~anndata.AnnData` can be :meth:`~anndata.AnnData.concatenate` d.
-- :class:`~anndata.AnnData` is available as a `separate package <https://pypi.org/project/anndata/>`__
-- results of PAGA are `simplified <https://github.com/theislab/paga>`__
+- :class:`~anndata.AnnData` is available as the anndata_ package.
+- results of PAGA are simplified: `theislab/paga`_
+
+.. _anndata: https://pypi.org/project/anndata/
 
 
 Version 0.2.9 :small:`October 25, 2017`
 ---------------------------------------
 
-Initial release of `partition-based graph abstraction (PAGA) <https://github.com/theislab/paga>`__.
+Initial release of *partition-based graph abstraction (PAGA)*: `theislab/paga`_
+
+.. _theislab/paga: https://github.com/theislab/paga
 
 
 Version 0.2.1 :small:`July 24, 2017`
@@ -268,4 +282,4 @@ Version 0.1 :small:`May 1, 2017`
 --------------------------------
 
 Scanpy computationally outperforms the Cell Ranger R kit and allows reproducing
-most of Seurat's guided clustering tutorial.
+most of Seurat’s guided clustering tutorial.

--- a/docs/release_notes.rst
+++ b/docs/release_notes.rst
@@ -1,5 +1,7 @@
 .. note::
-   Also see the `release notes <https://anndata.readthedocs.io>`__ of :mod:`anndata`.
+   Also see the `release notes`__ of :mod:`anndata`.
+
+.. __: https://anndata.readthedocs.io
 
 .. role:: small
 .. role:: smaller
@@ -7,7 +9,8 @@
 
 .. sidebar:: Key Contributors
 
-   [`anndata <https://github.com/theislab/anndata/graphs/contributors>`__ & `scanpy <https://github.com/theislab/scanpy/graphs/contributors>`__ graphs; the ☀ signifies current maintainers]
+   `anndata graph`_ & `scanpy graph`_;
+   the ☀ signifies current maintainers
 
    * `Isaac Virshup`_: anndata overhaul, diverse contributions ☀
    * Gökcen Eraslan: diverse contributions ☀
@@ -18,6 +21,8 @@
    * `Alex Wolf`_: initial anndata & scanpy conception/development ☀
    * `Fabian Theis`_ & lab: enabling guidance, support and environment
 
+.. _anndata graph: https://github.com/theislab/anndata/graphs/contributors
+.. _scanpy graph: https://github.com/theislab/scanpy/graphs/contributors
 .. _Isaac Virshup: https://twitter.com/ivirshup
 .. _Tom White: https://twitter.com/tom_e_white
 .. _Alex Wolf: https://twitter.com/falexwolf

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -6,32 +6,52 @@ Tutorials
 Clustering
 ----------
 
-For getting started, we recommend `Scanpy's reimplementation <https://scanpy-tutorials.readthedocs.io/en/latest/pbmc3k.html>`__ of Seurat's [Satija15]_ clustering tutorial for 3K PBMCs from 10x Genomics, containing preprocessing, clustering and the identification of cell types via known marker genes.
+For getting started, we recommend Scanpy’s reimplementation_ of Seurat’s [Satija15]_
+clustering tutorial for 3K PBMCs from 10x Genomics, containing preprocessing,
+clustering and the identification of cell types via known marker genes.
 
-For more possibilities on visualizing marker genes, see this `plotting gallery <https://scanpy-tutorials.readthedocs.io/en/latest/visualizing-marker-genes.html>`__.
+For more possibilities on visualizing marker genes, see this `plotting gallery`_.
 
-.. raw:: html
+.. image:: http://falexwolf.de/img/scanpy_usage/170505_seurat/filter_genes_dispersion.png
+   :width: 100px
+.. image:: http://falexwolf.de/img/scanpy_usage/170505_seurat/louvain.png
+   :width: 100px
+.. image:: http://falexwolf.de/img/scanpy_usage/170505_seurat/NKG7.png
+   :width: 100px
+.. image:: http://falexwolf.de/img/scanpy_usage/170505_seurat/violin.png
+   :width: 100px
+.. image:: http://falexwolf.de/img/scanpy_usage/170505_seurat/cell_types.png
+   :width: 200px
 
-   <img src="http://falexwolf.de/img/scanpy_usage/170505_seurat/filter_genes_dispersion.png" style="width: 100px"><img src="http://falexwolf.de/img/scanpy_usage/170505_seurat/louvain.png" style="width: 100px"><img src="http://falexwolf.de/img/scanpy_usage/170505_seurat/NKG7.png" style="width: 100px"><img src="http://falexwolf.de/img/scanpy_usage/170505_seurat/violin.png" style="width: 100px"><img src="http://falexwolf.de/img/scanpy_usage/170505_seurat/cell_types.png" style="width: 200px">
+.. _reimplementation: https://scanpy-tutorials.readthedocs.io/en/latest/pbmc3k.html
+.. _plotting gallery: https://scanpy-tutorials.readthedocs.io/en/latest/visualizing-marker-genes.html
 
 
 --------------------
 Trajectory Inference
 --------------------
 
-For trajectory inference on complex datasets, we offer several examples `here <https://github.com/theislab/paga>`__. Get started `here <https://nbviewer.jupyter.org/github/theislab/paga/blob/master/blood/paul15/paul15.ipynb>`__ for the following result on hematopoiesis.
+We offer several examples for `trajectory inference`_ on complex datasets.
+Get started with the `Paul PAGA`_ example for the following result on hematopoiesis:
 
-.. raw:: html
+.. image:: http://www.falexwolf.de/img/paga_paul15.png
+   :width: 450px
 
-   <img src="http://www.falexwolf.de/img/paga_paul15.png" style="width: 450px">
+You can extend this to multi-resolution analyses of whole animals,
+such as the `Planaria PAGA`_ example:
 
-You can extend this to multi-resolution analyses of whole animals, such as `here <https://nbviewer.jupyter.org/github/theislab/paga/blob/master/planaria/planaria.ipynb>`__.
+.. image:: http://www.falexwolf.de/img/paga_planaria.png
+   :width: 350px
 
-.. raw:: html
+The PAGA method behind this is described in [Wolf19]_.
+As a reference for simple pseudotime analyses, we provide the diffusion pseudotime analyses of [Haghverdi16]_
+for two hematopoiesis datasets: The `Paul DPT`_ example [Paul15]_ and the `Moignard DPT`_ example [Moignard15]_.
 
-   <img src="http://www.falexwolf.de/img/paga_planaria.png" style="width: 350px">
-
-The PAGA method behind this is described in [Wolf19]_. As a reference for simple pseudotime analyses, we provide the diffusion pseudotime analyses of [Haghverdi16]_ for two hematopoiesis datasets: `here <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170502_paul15/paul15.ipynb>`__ for [Paul15]_ and `here <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170501_moignard15/moignard15.ipynb>`__ for [Moignard15]_.
+.. _trajectory inference: https://github.com/theislab/paga
+.. _Paul PAGA: https://nbviewer.jupyter.org/github/theislab/paga/blob/master/blood/paul15/paul15.ipynb
+.. _Planaria PAGA: https://nbviewer.jupyter.org/github/theislab/paga/blob/master/planaria/planaria.ipynb
+.. _Paul DPT: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170502_paul15/paul15.ipynb
+.. _Moignard DPT: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170501_moignard15/moignard15.ipynb
 
 
 -----------------
@@ -41,47 +61,62 @@ Further Tutorials
 Conversion: AnnData, SingleCellExperiment, and Seurat objects
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See this `notebook <https://github.com/LuckyMD/Code_snippets/blob/master/Seurat_to_anndata.ipynb>`__
-for a tutorial on `anndata2ri`.
+See the `Seurat to AnnData`_ notebook for a tutorial on `anndata2ri`.
+
+.. _Seurat to AnnData: https://github.com/LuckyMD/Code_snippets/blob/master/Seurat_to_anndata.ipynb
 
 Regressing out cell cycle
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-See this `notebook <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/180209_cell_cycle/cell_cycle.ipynb>`__.
+See the `cell cycle`_ notebook.
 
+.. _cell cycle: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/180209_cell_cycle/cell_cycle.ipynb
 
 Scaling Computations
 ~~~~~~~~~~~~~~~~~~~~
 
-.. raw:: html
+.. image:: http://falexwolf.de/img/scanpy_usage/170522_visualizing_one_million_cells/tsne_1.3M.png
+   :width: 120px
+   :align: right
 
-   <img src="http://falexwolf.de/img/scanpy_usage/170522_visualizing_one_million_cells/tsne_1.3M.png" style="width: 120px; margin: -100px 50px 0px 0px" align="right">
+Visualize and cluster `1.3M neurons`_ from 10x Genomics.
 
-Visualize and cluster 1.3M neurons from 10x Genomics `here <https://github.com/theislab/scanpy_usage/tree/master/170522_visualizing_one_million_cells>`__.
-
+.. _1.3M neurons: https://github.com/theislab/scanpy_usage/tree/master/170522_visualizing_one_million_cells
 
 Simulations
 ~~~~~~~~~~~
 
 Simulating single cells using literature-curated gene regulatory networks [Wittmann09]_.
 
-.. raw:: html
+.. image:: http://falexwolf.de/img/scanpy_usage/170430_krumsiek11/timeseries.png
+   :width: 200px
+   :align: right
+.. image:: http://falexwolf.de/img/scanpy_usage/170430_krumsiek11/draw_graph.png
+   :width: 100px
+   :align: right
 
-   <img src="http://falexwolf.de/img/scanpy_usage/170430_krumsiek11/timeseries.png" style="width: 200px; margin: -15px 0px 0px 0px" align="right"><img src="http://falexwolf.de/img/scanpy_usage/170430_krumsiek11/draw_graph.png" style="width: 100px; margin: -15px 0px 0px -100px" align="right">
+- Notebook for `myeloid differentiation`_
+- Notebook for simple toggleswitch_
 
-- `notebook <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170430_krumsiek11/krumsiek11.ipynb>`__ for myeloid differentiation
-- `notebook <https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170430_krumsiek11/toggleswitch.ipynb>`__ for simple toggleswitch
-
+.. _myeloid differentiation: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170430_krumsiek11/krumsiek11.ipynb
+.. _toggleswitch: https://nbviewer.jupyter.org/github/theislab/scanpy_usage/blob/master/170430_krumsiek11/toggleswitch.ipynb
 
 Images
 ~~~~~~
 
-See a pseudotime-based vs. deep-learning based reconstruction of cell cycle from image data `here <https://github.com/theislab/scanpy_usage/tree/master/170529_images>`__ [Eulenberg17]_.
+See a pseudotime-based vs. deep-learning based `cell cycle reconstruction`_ from image data [Eulenberg17]_.
+
+.. _cell cycle reconstruction: https://github.com/theislab/scanpy_usage/tree/master/170529_images
 
 
 ..
     User Examples
     ~~~~~~~~~~~~~
 
-    January 12, 2018: `Exploring the mouse cell atlas <https://github.com/dpcook/fun_analysis/blob/master/tabula_muris/mouse_atlas_scanpy.ipynb>`__ by `David P. Cook <https://twitter.com/DavidPCook>`__. Data by `Tabula Muris Consortium <https://www.biorxiv.org/content/early/2017/12/20/237446>`__.
+    January 12, 2018: `Exploring the mouse cell atlas`_ by `David P. Cook`_.
+    Data by `Tabula Muris Consortium`_.
+
+    .. _Exploring the mouse cell atlas: https://github.com/dpcook/fun_analysis/blob/master/tabula_muris/mouse_atlas_scanpy.ipynb
+    .. _David P. Cook: https://twitter.com/DavidPCook
+    .. _Tabula Muris Consortium: https://www.biorxiv.org/content/early/2017/12/20/237446
 

--- a/scanpy/api/__init__.py
+++ b/scanpy/api/__init__.py
@@ -98,18 +98,21 @@ Batch effect correction
 Note that a simple batch correction method is available via
 :func:`scanpy.api.pp.regress_out`.
 
-``pp.bbknn`` is just an alias for :func:`bbknn.bbknn`. Refer to it for the documentation.
+`pp.bbknn` is just an alias for :func:`bbknn.bbknn`.
+Refer to it for the documentation.
 
 .. autosummary::
 
    pp.bbknn
    pp.mnn_correct
 
+.. _pp-imputation:
+
 Imputation
 ~~~~~~~~~~
 
-Note that the fundamental limitations of imputation are still under `debate
-<https://github.com/theislab/scanpy/issues/189>`__.
+Note that the fundamental limitations of imputation are still under debate
+(:issue:`189`)
 
 .. autosummary::
 

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -318,16 +318,24 @@ def _compute_connectivities_umap(
     from umap.umap_ import fuzzy_simplicial_set
 
     X = coo_matrix(([], ([], [])), shape=(n_obs, 1))
-    connectivities = fuzzy_simplicial_set(X, n_neighbors, None, None,
-                                          knn_indices=knn_indices, knn_dists=knn_dists,
-                                          set_op_mix_ratio=set_op_mix_ratio,
-                                          local_connectivity=local_connectivity)
+    connectivities = fuzzy_simplicial_set(
+        X,
+        n_neighbors,
+        None,
+        None,
+        knn_indices=knn_indices,
+        knn_dists=knn_dists,
+        set_op_mix_ratio=set_op_mix_ratio,
+        local_connectivity=local_connectivity,
+    )
 
     if isinstance(connectivities, tuple):
         # In umap-learn 0.4, this returns (result, sigmas, rhos)
         connectivities = connectivities[0]
 
-    distances = _get_sparse_matrix_from_indices_distances_umap(knn_indices, knn_dists, n_obs, n_neighbors)
+    distances = _get_sparse_matrix_from_indices_distances_umap(
+        knn_indices, knn_dists, n_obs, n_neighbors
+    )
 
     return distances, connectivities.tocsr()
 

--- a/scanpy/plotting/__init__.py
+++ b/scanpy/plotting/__init__.py
@@ -29,6 +29,7 @@ Plotting API
 .. note::
    See the :ref:`settings` section for all important plotting configurations.
 
+.. _pl-generic:
 
 Generic
 -------


### PR DESCRIPTION
I got rid of the margins for the floating images. I didn’t see much of a difference, and if they should be in the css sheet, not inline.