### PR TITLE
Restrict networkx to 1.X

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ importlib_metadata>=0.7; python_version < '3.8'
 scikit-learn>=0.21.2
 statsmodels>=0.10.0rc2
 patsy
-networkx
+networkx==1.*
 natsort
 joblib
 numba>=0.41.0


### PR DESCRIPTION
We use Graph.node attributes (see https://github.com/theislab/scanpy/blob/master/scanpy/plotting/_tools/paga.py#L776) which are removed in networkx 2.X. More details here: https://networkx.github.io/documentation/stable/release/migration_guide_from_1.x_to_2.0.html