### PR TITLE
Fixup #566 & #706

### DIFF
--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -397,8 +397,8 @@ def rank_genes_groups(
                 means[imask], vars[imask] = _get_mean_var(X[mask])
                 mean_rest, var_rest = _get_mean_var(X[mask_rest])
 
-                scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
-                    (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
+                scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / (
+                        (sqrt(ns[imask]) * sqrt(n_cells - ns[imask]) * sqrt(n_cells + 1)) / 12)
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -398,7 +398,7 @@ def rank_genes_groups(
                 mean_rest, var_rest = _get_mean_var(X[mask_rest])
 
                 scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / (
-                        (sqrt(ns[imask]) * sqrt(n_cells - ns[imask]) * sqrt((n_cells + 1) / 12))
+                        sqrt(ns[imask]) * sqrt(n_cells - ns[imask]) * sqrt((n_cells + 1) / 12))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -398,7 +398,7 @@ def rank_genes_groups(
                 mean_rest, var_rest = _get_mean_var(X[mask_rest])
 
                 scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / (
-                        (sqrt(ns[imask]) * sqrt(n_cells - ns[imask]) * sqrt(n_cells + 1)) / 12)
+                        (sqrt(ns[imask]) * sqrt(n_cells - ns[imask]) * sqrt((n_cells + 1) / 12))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))
 


### PR DESCRIPTION
I think the reason of issues(#566 & #706) is that the value of x*y*z in sqrt(x*y*z) is too large and overflow encountered in long_scalars.
After updating these codes, the ValueError disappeared in my PC.