### PR TITLE
Fix test_preprocessing_distributed

### DIFF
--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -90,7 +90,7 @@ class TestPreprocessingDistributed:
         temp_store = zarr.TempStore()
         chunks = adata_dist.X.chunks
         if isinstance(chunks[0], tuple):
-            chunks = (chunks[0][0],)+chunks[1]
+            chunks = (chunks[0][0],) + chunks[1]
         # write metadata using regular anndata
         adata.write_zarr(temp_store, chunks)
         if isinstance(adata_dist.X, da.Array):

--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -89,6 +89,8 @@ class TestPreprocessingDistributed:
         log1p(adata_dist)
         temp_store = zarr.TempStore()
         chunks = adata_dist.X.chunks
+        if isinstance(chunks[0], tuple):
+            chunks = (chunks[0][0],)+chunks[1]
         # write metadata using regular anndata
         adata.write_zarr(temp_store, chunks)
         if isinstance(adata_dist.X, da.Array):

--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -94,7 +94,7 @@ class TestPreprocessingDistributed:
         # write metadata using regular anndata
         adata.write_zarr(temp_store, chunks)
         if isinstance(adata_dist.X, da.Array):
-            adata_dist.X.to_zarr(temp_store.dir_path("X"))
+            adata_dist.X.to_zarr(temp_store.dir_path("X"), overwrite=True)
         else:
             adata_dist.X.to_zarr(temp_store.dir_path("X"), chunks)
         # read back as zarr directly and check it is the same as adata.X


### PR DESCRIPTION
I don't know what changes caused this, but now there are 2 problems with test_preprocessing_distributed.py.

When `adata_dist.X` is a dask array, `adata_dist.X.chunks` is `((2000, 2000, 2000, 2000, 2000), (1000,))`. It leads to an error in `adata.write_zarr(temp_store, chunks)` because zarr chunks should be a tuple with an integer entry per dimension, not a tuple of tuples.

The second problem is that  `adata_dist.X.to_zarr(temp_store.dir_path("X"))` causes an error because there is already `'X'` in `temp_store`, it needs to be overwritten.

This pr removes these problems but maybe logic of the function should be changed somehow instead of the test.