### PR TITLE
Migrate to actually working version comparison.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ numba>=0.41.0
 umap-learn>=0.3.0
 legacy-api-wrap
 setuptools_scm
+packaging

--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -1,6 +1,6 @@
 # some technical stuff
 import sys
-from ._utils import version, check_versions, annotate_doc_types
+from ._utils import pkg_version, check_versions, annotate_doc_types
 
 __author__ = ', '.join([
     'Alex Wolf',
@@ -26,10 +26,10 @@ try:
     __version__ = get_version(root='..', relative_to=__file__)
     del get_version
 except (LookupError, ImportError):
-    __version__ = version(__name__)
+    __version__ = pkg_version(__name__)
 
 check_versions()
-del version, check_versions
+del pkg_version, check_versions
 
 # the actual API
 from ._settings import settings, Verbosity  # start with settings as several tools are using it

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -14,6 +14,7 @@ from typing import Union, Callable, Optional, Mapping, Any, Dict, Tuple
 import numpy as np
 from anndata import AnnData
 from textwrap import dedent
+from packaging import version
 
 from ._settings import settings
 from ._compat import Literal
@@ -22,28 +23,26 @@ from . import logging as logg
 EPS = 1e-15
 
 
-def version(package):
+def pkg_version(package):
     try:
-        from importlib.metadata import version
+        from importlib.metadata import version as v
     except ImportError:  # < Python 3.8: Use backport module
-        from importlib_metadata import version
-    return version(package)
+        from importlib_metadata import version as v
+    return version.parse(v(package))
 
 
 def check_versions():
-    from distutils.version import LooseVersion
+    anndata_version = pkg_version("anndata")
+    umap_version = pkg_version("umap-learn")
 
-    anndata_version = version("anndata")
-    umap_version = version("umap-learn")
-
-    if anndata_version < LooseVersion('0.6.10'):
+    if anndata_version < version.parse('0.6.10'):
         from . import __version__
         raise ImportError(
             f'Scanpy {__version__} needs anndata version >=0.6.10, '
             f'not {anndata_version}.\nRun `pip install anndata -U --no-deps`.'
         )
 
-    if umap_version < LooseVersion('0.3.0'):
+    if umap_version < version.parse('0.3.0'):
         from . import __version__
         # make this a warning, not an error
         # it might be useful for people to still be able to run it

--- a/scanpy/external/tl/_pypairs.py
+++ b/scanpy/external/tl/_pypairs.py
@@ -5,6 +5,7 @@ from typing import Mapping, Optional, Collection, Union, Tuple, List, Dict
 
 import pandas as pd
 from anndata import AnnData
+from packaging import version
 
 from ... import settings
 
@@ -142,10 +143,10 @@ def cyclone(
 
 def _check_import():
     try:
-        from pypairs import __version__ as pypairsversion
-        from distutils.version import LooseVersion
-
-        if LooseVersion(pypairsversion) < LooseVersion("v3.0.9"):
-            raise ImportError('Please only use `pypairs` >= v3.0.9 ')
+        import pypairs
     except ImportError:
         raise ImportError('You need to install the package `pypairs`.')
+
+    min_version = version.parse("3.0.9")
+    if version.parse(pypairs.__version__) < min_version:
+        raise ImportError(f'Please only use `pypairs` >= {min_version}')

--- a/scanpy/tests/test_ingest.py
+++ b/scanpy/tests/test_ingest.py
@@ -1,10 +1,12 @@
 import pytest
 import numpy as np
-import scanpy as sc
-from scanpy.preprocessing._simple import N_PCS
 
 from sklearn.neighbors import KDTree
 from umap import UMAP
+
+import scanpy as sc
+from scanpy.preprocessing._simple import N_PCS
+from scanpy._utils import pkg_version
 
 
 X = np.array(
@@ -85,6 +87,10 @@ def test_neighbors(adatas):
     assert percent_correct > 0.99
 
 
+@pytest.mark.skipif(
+    pkg_version("anndata") < sc.tl._ingest.ANNDATA_MIN_VERSION,
+    reason="`AnnData.concatenate` does not concatenate `.obsm` in old anndata versions",
+)
 def test_ingest_function(adatas):
     adata_ref = adatas[0].copy()
     adata_new = adatas[1].copy()
@@ -129,6 +135,6 @@ def test_ingest_map_embedding_umap():
 
     reducer = UMAP(min_dist=0.5, random_state=0, n_neighbors=4)
     reducer.fit(X)
-    umap_transformed_T = reducer.transform(T)
+    umap_transformed_t = reducer.transform(T)
 
-    assert np.allclose(ing._obsm['X_umap'], umap_transformed_T)
+    assert np.allclose(ing._obsm['X_umap'], umap_transformed_t)


### PR DESCRIPTION
We have to get rid of `distutils.version`, neither `LooseVersion` nor `StrictVersion` parse PEP 404 versions as we use them and are therefore useless for us.