### PR TITLE
Require umap>=0.3.10 to prevent reports like #948

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ networkx
 natsort
 joblib
 numba>=0.41.0
-umap-learn>=0.3.0
+umap-learn>=0.3.10
 legacy-api-wrap
 setuptools_scm
 packaging


### PR DESCRIPTION
With all the numba breakage going around we should make sure people use the newest versions.