### PR TITLE
Fix 10x mtx reading functions for anndata 0.7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,6 @@ exclude = '''
         test_get
         |test_pca
         |test_combat
-        |test_read_10x
         |test_neighbors
         |test_readwrite
         |test_clustering

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -328,17 +328,17 @@ def _read_legacy_10x_mtx(
     ).T  # transpose the data
     genes = pd.read_csv(path / 'genes.tsv', header=None, sep='\t')
     if var_names == 'gene_symbols':
-        var_names = genes[1]
+        var_names = genes[1].values
         if make_unique:
             var_names = anndata.utils.make_index_unique(pd.Index(var_names))
         adata.var_names = var_names
         adata.var['gene_ids'] = genes[0].values
     elif var_names == 'gene_ids':
-        adata.var_names = genes[0]
+        adata.var_names = genes[0].values
         adata.var['gene_symbols'] = genes[1].values
     else:
         raise ValueError("`var_names` needs to be 'gene_symbols' or 'gene_ids'")
-    adata.obs_names = pd.read_csv(path / 'barcodes.tsv', header=None)[0]
+    adata.obs_names = pd.read_csv(path / 'barcodes.tsv', header=None)[0].values
     return adata
 
 
@@ -360,18 +360,18 @@ def _read_v3_10x_mtx(
     ).T  # transpose the data
     genes = pd.read_csv(path / 'features.tsv.gz', header=None, sep='\t')
     if var_names == 'gene_symbols':
-        var_names = genes[1]
+        var_names = genes[1].values
         if make_unique:
             var_names = anndata.utils.make_index_unique(pd.Index(var_names))
         adata.var_names = var_names
         adata.var['gene_ids'] = genes[0].values
     elif var_names == 'gene_ids':
-        adata.var_names = genes[0]
+        adata.var_names = genes[0].values
         adata.var['gene_symbols'] = genes[1].values
     else:
         raise ValueError("`var_names` needs to be 'gene_symbols' or 'gene_ids'")
     adata.var['feature_types'] = genes[2].values
-    adata.obs_names = pd.read_csv(path / 'barcodes.tsv.gz', header=None)[0]
+    adata.obs_names = pd.read_csv(path / 'barcodes.tsv.gz', header=None)[0].values
     return adata
 
 

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -17,38 +17,53 @@ def assert_anndata_equal(a1, a2):
     assert np.allclose(a1.X.todense(), a2.X.todense())
 
 
-def test_read_10x_v1():
-    v1_mtx = sc.read_10x_mtx(
-        ROOT / '1.2.0' / 'filtered_gene_bc_matrices' / 'hg19_chr21',
-        var_names='gene_symbols'
-    )
-    v1_h5 = sc.read_10x_h5(ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5')
-    assert_anndata_equal(v1_mtx, v1_h5)
+@pytest.mark.parametrize(
+    ['mtx_path', 'h5_path'],
+    [
+        pytest.param(
+            ROOT / '1.2.0' / 'filtered_gene_bc_matrices' / 'hg19_chr21',
+            ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5',
+        ),
+        pytest.param(
+            ROOT / '3.0.0' / 'filtered_feature_bc_matrix',
+            ROOT / '3.0.0' / 'filtered_feature_bc_matrix.h5',
+        ),
+    ],
+)
+def test_read_10x(tmp_path, mtx_path, h5_path):
+    mtx = sc.read_10x_mtx(mtx_path, var_names="gene_symbols")
+    h5 = sc.read_10x_h5(h5_path)
 
+    # Drop genome column for comparing v3
+    if "3.0.0" in str(h5_path):
+        h5.var.drop(columns="genome", inplace=True)
 
-def test_read_10x_v3():
-    v3_mtx = sc.read_10x_mtx(
-        ROOT / '3.0.0' / 'filtered_feature_bc_matrix',
-        var_names='gene_symbols',
-    )
-    v3_h5 = sc.read_10x_h5(ROOT / '3.0.0' / 'filtered_feature_bc_matrix.h5')
-    v3_h5.var.drop(columns="genome", inplace=True)
-    assert_anndata_equal(v3_mtx, v3_h5)
+    # Check equivalence
+    assert_anndata_equal(mtx, h5)
+
+    # Test that it can be written:
+    from_mtx_pth = Path(tmp_path) / "from_mtx.h5ad"
+    from_h5_pth = Path(tmp_path) / "from_h5.h5ad"
+
+    mtx.write(from_mtx_pth)
+    h5.write(from_h5_pth)
+
+    assert_anndata_equal(sc.read_h5ad(from_mtx_pth), sc.read_h5ad(from_h5_pth))
 
 
 def test_read_10x_h5_v1():
     spec_genome_v1 = sc.read_10x_h5(
-        ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5',
-        genome='hg19_chr21',
+        ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5', genome='hg19_chr21',
     )
-    nospec_genome_v1 = sc.read_10x_h5(ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5')
+    nospec_genome_v1 = sc.read_10x_h5(
+        ROOT / '1.2.0' / 'filtered_gene_bc_matrices_h5.h5'
+    )
     assert_anndata_equal(spec_genome_v1, nospec_genome_v1)
 
 
 def test_read_10x_h5():
     spec_genome_v3 = sc.read_10x_h5(
-        ROOT / '3.0.0' / 'filtered_feature_bc_matrix.h5',
-        genome='GRCh38_chr21',
+        ROOT / '3.0.0' / 'filtered_feature_bc_matrix.h5', genome='GRCh38_chr21',
     )
     nospec_genome_v3 = sc.read_10x_h5(ROOT / '3.0.0' / 'filtered_feature_bc_matrix.h5')
     assert_anndata_equal(spec_genome_v3, nospec_genome_v3)


### PR DESCRIPTION
Example of this kind of bug in https://github.com/theislab/anndata/issues/293

* Now `read_10x_mtx` does not set an integer name for obs_name/ var_name indices
* Additionally improved code re-use and things tested in 10x reading tests