### PR TITLE
Prevent unnecessary copying when plotting

### DIFF
--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -320,7 +320,8 @@ def _validate_palette(adata, key):
                 _palette = None
                 break
         _palette.append(color)
-    if _palette is not None:
+    # Don't modify if nothing changed
+    if (_palette is not None and list(_palette) != list(adata.uns[color_key])):
         adata.uns[color_key] = _palette
 
 


### PR DESCRIPTION
When combined with https://github.com/theislab/anndata/pull/298, fixes #1000.

Unfortunately, the tests here won't pass until the PR at anndata is in a release.

* Adds tests checking for copying when plotting a view
* Prevents setting color palette when it doesn't need to change