### PR TITLE
Add a CI build which uses anndata master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,12 @@ matrix:
         - black . --check --diff
         - python -m scanpy.tests.blackdiff 10
       after_success: skip
+    - name: "anndata dev"
+      python: "3.7"
+      install:
+        - pip install docutils sphinx
+        - pip install -e .[test,louvain,leiden,magic]
+        - pip install git+https://github.com/theislab/anndata
 python:
   - '3.6'
   - '3.7'


### PR DESCRIPTION
It doesn't look like I can make the install process a matrix expansion, so this only tests against one version of python for now.