### PR TITLE
Avoid large copy in subsample

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -988,9 +988,10 @@ def subsample(
         raise ValueError('Either pass `n_obs` or `fraction`.')
     obs_indices = np.random.choice(old_n_obs, size=new_n_obs, replace=False)
     if isinstance(data, AnnData):
-        adata = data.copy() if copy else data
-        adata._inplace_subset_obs(obs_indices)
-        return adata if copy else None
+        if copy:
+            return data[obs_indices].copy()
+        else:
+            data._inplace_subset_obs(obs_indices)
     else:
         X = data
         return X[obs_indices], obs_indices

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -102,6 +102,12 @@ def test_subsample():
     assert adata.n_obs == 4
 
 
+def test_subsample_copy():
+    adata = AnnData(np.ones((200, 10)))
+    assert sc.pp.subsample(adata, n_obs=40, copy=True).shape == (40, 10)
+    assert sc.pp.subsample(adata, fraction=0.1, copy=True).shape == (20, 10)
+
+
 def test_scale():
     adata = sc.datasets.pbmc68k_reduced()
     adata.X = adata.raw.X


### PR DESCRIPTION
Speed up `subsample` when we copy by not copying the whole thing (which we did for some reason).

Example of the speedup (where times are from `sc.pp.subsample(adata, frac=0.5, copy=True)`)

Dataset | On a3b71d9113ee14ac0 (this PR) | On  a23ad96ea013c7 (current master)
--------|--------------------------|--------------
`sc.datasets.pbmc3k_processed()` | 14.9 ms ± 249 µs | 24.3 ms ± 558 µs
9936 cell x 23000 gene dataset (w/ one layer) | 93.2 ms ± 1.82 ms| 191 ms ± 4 ms

Ping @gokceneraslan, since this touches code you also have a PR for.