### PR TITLE
make sure the newest umap is used in a test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,9 @@ matrix:
       python: "3.7"
       install:
         - pip install docutils sphinx
-        - pip install -e .[test,louvain,leiden,magic] umap-learn>=0.4
-        - pip install git+https://github.com/theislab/anndata
+        - pip install -e .[test,louvain,leiden,magic]
+        # also test new umap. remove once umap 0.4+ is used by other runs as well
+        - pip install umap-learn>=0.4 git+https://github.com/theislab/anndata
 python:
   - '3.6'
   - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
       python: "3.7"
       install:
         - pip install docutils sphinx
-        - pip install -e .[test,louvain,leiden,magic]
+        - pip install -e .[test,louvain,leiden,magic] umap-learn>=0.4
         - pip install git+https://github.com/theislab/anndata
 python:
   - '3.6'


### PR DESCRIPTION
@falexwolf @ivirshup we have a lot of fixes on master, let’s release 1.4.5.1 after this one.

As an aside I think our versioning is a bit weird: Why did we do a feature release called 1.4.5 and not 1.5? Why not semver-lite like python itself?

- major version (x.0) bumps for vast breaking changes
- minor version (1.x) bumps for new features and minor, long-deprecated breaking changes
- patch version (1.4.x) bumps for fixes