### PR TITLE
Make sc.queries.enrich work with result of sc.tl.filter_rank_genes_groups

### DIFF
--- a/scanpy/queries/_queries.py
+++ b/scanpy/queries/_queries.py
@@ -235,6 +235,9 @@ def enrich(
     {doc_org}
     gprofiler_kwargs
         Keyword arguments to pass to `GProfiler.profile`, see gprofiler_.
+    **kwargs
+        All other keyword arguments are passed to `sc.get.rank_genes_groups_df`. E.g.
+        pval_cutoff, log2fc_min.
 
     Returns
     -------
@@ -293,7 +296,7 @@ def _enrich_anndata(
         gene_symbols=gene_symbols,
     )
     if gene_symbols is not None:
-        gene_list = list(de[gene_symbols])
+        gene_list = list(de[gene_symbols].dropna())
     else:
-        gene_list = list(de["names"])
+        gene_list = list(de["names"].dropna())
     return enrich(gene_list, org=org, gprofiler_kwargs=gprofiler_kwargs)

--- a/scanpy/tests/test_queries.py
+++ b/scanpy/tests/test_queries.py
@@ -15,6 +15,10 @@ def test_enrich():
     enrich_list = sc.queries.enrich(list(de_genes))
     assert (enrich_anndata == enrich_list).all().all()
 
+    # theislab/scanpy/#1043
+    sc.tl.filter_rank_genes_groups(pbmc, min_fold_change=1)
+    sc.queries.enrich(pbmc, "1")
+
 
 @pytest.mark.internet
 def test_mito_genes():


### PR DESCRIPTION
Fixes #1043

But should `sc.get.rank_genes_groups_df`  also drop null values?