### PR TITLE
Fix rank_genes_groups overflow in Windows

### DIFF
--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -341,7 +341,7 @@ def rank_genes_groups(
                     left = right
 
                 scores = (scores - (n_active * ((n_active + m_active + 1) / 2))) / sqrt(
-                    (n_active * m_active * (1 / 12.0) * (n_active + m_active + 1)))
+                    (n_active * m_active / 12 * (n_active + m_active + 1)))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores))
 
@@ -398,7 +398,7 @@ def rank_genes_groups(
                 mean_rest, var_rest = _get_mean_var(X[mask_rest])
 
                 scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
-                    (ns[imask] * (n_cells - ns[imask]) *( 1 / 12.0) * (n_cells + 1)))
+                    (ns[imask] * (n_cells - ns[imask]) / 12 * (n_cells + 1)))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -340,8 +340,8 @@ def rank_genes_groups(
                     scores[left:right] = np.sum(ranks.loc[0:n_active, :])
                     left = right
 
-                scores = (scores - (n_active * (n_active + m_active + 1) / 2)) / sqrt(
-                    (n_active * m_active * (n_active + m_active + 1) / 12))
+                scores = (scores - (n_active * ((n_active + m_active + 1) / 2))) / sqrt(
+                    (n_active * m_active * (1 / 12.0) * (n_active + m_active + 1)))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores))
 
@@ -398,7 +398,7 @@ def rank_genes_groups(
                 mean_rest, var_rest = _get_mean_var(X[mask_rest])
 
                 scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
-                    (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
+                    (ns[imask] * (n_cells - ns[imask]) *( 1 / 12.0) * (n_cells + 1)))
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))
 


### PR DESCRIPTION
Reorder operations to avoid overflows.

Behavior Fixed:
```py
import scanpy as sc
import numpy as np
X = np.random.randint(0,1000, size= (3000,2000))
ann = sc.AnnData(np.log(X+1))
gsize = X.shape [0] / 2
ann.obs['group'] = ['a']* int (gsize) + ['b']*int (gsize)
sc.tl.rank_genes_groups(ann, 'group', method = 'wilcoxon', n_genes=2000)
```
```pytb
... storing 'group' as categorical
C:\Users\patou\Anaconda-p3.7\envs\py36\lib\site-packages\scanpy\tools\_rank_genes_groups.py:372: RuntimeWarning: overflow encountered in long_scalars
  (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-bccdb587a644> in <module>
      5 gsize = X.shape [0] / 2
      6 ann.obs['group'] = ['a']* int (gsize) + ['b']*int (gsize)
----> 7 sc.tl.rank_genes_groups(ann, 'group', method = 'wilcoxon', n_genes=2000)
      8
      9

~\Anaconda-p3.7\envs\py36\lib\site-packages\scanpy\tools\_rank_genes_groups.py in rank_genes_groups(adata, groupby, use_raw, groups, reference, n_genes, rankby_abs, key_added, copy, method, corr_method, **kwds)
    370                 scores[imask, :] = (scores[imask, :] - (ns[imask] * (n_cells + 1) / 2)) / sqrt(
    371                     (ns[imask] * (n_cells - ns[imask]) * (n_cells + 1) / 12))
--> 372
    373                 scores[np.isnan(scores)] = 0
    374                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[imask,:]))

ValueError: math domain error
```

After the fix, the same code no longer raises an error
