### PR TITLE
Changing scanpy.pl.dotplot to return the matplotlib figure instead of GridSpec

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1775,7 +1775,7 @@ def dotplot(
 
     Returns
     -------
-    List of :class:`~matplotlib.axes.Axes`
+    :class:`~matplotlib.figure.Figure`
 
     Examples
     -------
@@ -2085,7 +2085,7 @@ def dotplot(
     size_legend.set_ylim(ymin, ymax + 0.5)
 
     _utils.savefig_or_show('dotplot', show=show, save=save)
-    return axs
+    return dot_ax.figure
 
 
 @_doc_params(show_save_ax=doc_show_save_ax, common_plot_args=doc_common_plot_args)

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -2085,7 +2085,7 @@ def dotplot(
     size_legend.set_ylim(ymin, ymax + 0.5)
 
     _utils.savefig_or_show('dotplot', show=show, save=save)
-    return dot_ax.figure,dot_ax
+    return dot_ax.figure, dot_ax
 
 
 @_doc_params(show_save_ax=doc_show_save_ax, common_plot_args=doc_common_plot_args)

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1775,7 +1775,7 @@ def dotplot(
 
     Returns
     -------
-    :class:`~matplotlib.figure.Figure`
+    Tuple of (:class:`~matplotlib.figure.Figure`,:class:`~matplotlib.axes.Axes`)
 
     Examples
     -------
@@ -2085,7 +2085,7 @@ def dotplot(
     size_legend.set_ylim(ymin, ymax + 0.5)
 
     _utils.savefig_or_show('dotplot', show=show, save=save)
-    return dot_ax.figure
+    return dot_ax.figure,dot_ax
 
 
 @_doc_params(show_save_ax=doc_show_save_ax, common_plot_args=doc_common_plot_args)


### PR DESCRIPTION
Fixes issue #979 

Note that if you wish to modify the figure in the same jupyter notebook cell in which the plotting function is called, you should set `show=False`:

```
fig,ax = sc.pl.dotplot(adata,var_names,show=False)
ax.set_xlabel('test')
```