### PR TITLE
Fixes highly_variable_genes failing with `batch_key` and `inplace=False`

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -342,7 +342,7 @@ def highly_variable_genes(
                 df['highly_variable_nbatches'].values,
                 df['highly_variable_intersection'].values,
             ])
-            dtypes.append([
+            dtypes.extend([
                 ('highly_variable_nbatches', int),
                 ('highly_variable_intersection', np.bool_),
             ])


### PR DESCRIPTION
Fixes issue #1033