### PR TITLE
Fix deprecated louvain rapids method

### DIFF
--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -162,7 +162,7 @@ def louvain(
         g = cugraph.Graph()
         g.add_adj_list(offsets, indices, weights)
         logg.info('    using the "louvain" package of rapids')
-        louvain_parts, _ = cugraph.nvLouvain(g)
+        louvain_parts, _ = cugraph.louvain(g)
         groups = louvain_parts.to_pandas().sort_values('vertex')[['partition']].to_numpy().ravel()
     elif flavor == 'taynaud':
         # this is deprecated

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         louvain=['python-igraph', 'louvain>=0.6'],
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
-        rapids=['cudf', 'cuml', 'cugraph'],
+        rapids=['cudf>=0.9', 'cuml>=0.9', 'cugraph>=0.9'],
         magic=['magic-impute>=2.0'],
         doc=[
             'sphinx',


### PR DESCRIPTION
Hello,

GPU accelerated louvain community method call nvLouvain has been deprecated.
Now it should be run as follow: df, mod = cugraph.louvain(G)