### PR TITLE
Remove python 3.8 only code from download code

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -876,7 +876,8 @@ def _download(url: str, path: Path):
             urlretrieve(url, str(path), reporthook=update_to)
         except Exception:
             # Make sure file doesn’t exist half-downloaded
-            path.unlink(missing_ok=True)
+            if path.is_file():
+                path.unlink()
             raise
 
 

--- a/scanpy/tests/test_datasets.py
+++ b/scanpy/tests/test_datasets.py
@@ -70,3 +70,10 @@ def test_toggleswitch():
 
 def test_pbmc68k_reduced():
     sc.datasets.pbmc68k_reduced()
+
+
+def test_download_failure():
+    from urllib.error import HTTPError
+
+    with pytest.raises(HTTPError):
+        sc.datasets.ebi_expression_atlas("not_a_real_accession")


### PR DESCRIPTION
Fix (sorta) #1082

Removed a call that required python 3.8 plus. The added test doesn't fully cover this case, since it wouldn't have had the same error.