### PR TITLE
Change the default number of nearest neighbors search in Ingest

### DIFF
--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -180,7 +180,10 @@ class Ingest:
     def _init_umap(self, adata):
         from umap import UMAP
 
-        self._umap = UMAP(metric=adata.uns['neighbors']['params']['metric'])
+        self._umap = UMAP(
+            metric=adata.uns['neighbors']['params']['metric'],
+            random_state=adata.uns['umap']['params'].get('random_state', 0),
+        )
 
         self._umap.embedding_ = adata.obsm['X_umap']
         self._umap._raw_data = self._rep

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -253,6 +253,8 @@ class Ingest:
     def _init_neighbors(self, adata):
         from umap.distances import named_distances
 
+        self._n_neighbors = adata.uns['neighbors']['params']['n_neighbors']
+
         if 'use_rep' in adata.uns['neighbors']['params']:
             self._use_rep = adata.uns['neighbors']['params']['use_rep']
             self._rep = adata.X if self._use_rep == 'X' else adata.obsm[self._use_rep]
@@ -368,7 +370,7 @@ class Ingest:
         self._adata_new = adata_new
         self._obsm['rep'] = self._same_rep()
 
-    def neighbors(self, k=10, queue_size=5, random_state=0):
+    def neighbors(self, k=None, queue_size=5, random_state=0):
         """\
         Calculate neighbors of `adata_new` observations in `adata`.
 
@@ -380,6 +382,9 @@ class Ingest:
 
         random_state = check_random_state(random_state)
         rng_state = random_state.randint(INT32_MIN, INT32_MAX, 3).astype(np.int64)
+
+        if k is None:
+            k = self._n_neighbors
 
         train = self._rep
         test = self._obsm['rep']

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -131,7 +131,10 @@ def umap(
     if hasattr(init_coords, "dtype"):
         init_coords = check_array(init_coords, dtype=np.float32, accept_sparse=False)
 
+    if random_state != 0:
+        adata.uns['umap']['params']['random_state'] = random_state
     random_state = check_random_state(random_state)
+
     neigh_params = adata.uns['neighbors']['params']
     X = _choose_representation(
         adata, neigh_params.get('use_rep', None), neigh_params.get('n_pcs', None), silent=True)


### PR DESCRIPTION
It was configurable with the default `k=10` before, now it uses n_neighbors from `sc.tl.neighbors`.
As discussed with @falexwolf .