### PR TITLE
Change the default number of nearest neighbors search in Ingest

### DIFF
--- a/scanpy/tests/test_ingest.py
+++ b/scanpy/tests/test_ingest.py
@@ -87,6 +87,19 @@ def test_neighbors(adatas):
     assert percent_correct > 0.99
 
 
+@pytest.mark.parametrize('n', [3, 4])
+def test_neighbors_defaults(adatas, n):
+    adata_ref = adatas[0].copy()
+    adata_new = adatas[1].copy()
+
+    sc.pp.neighbors(adata_ref, n_neighbors=n)
+
+    ing = sc.tl.Ingest(adata_ref)
+    ing.fit(adata_new)
+    ing.neighbors()
+    assert ing._indices.shape[1] == n
+
+
 @pytest.mark.skipif(
     pkg_version("anndata") < sc.tl._ingest.ANNDATA_MIN_VERSION,
     reason="`AnnData.concatenate` does not concatenate `.obsm` in old anndata versions",

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -186,9 +186,11 @@ class Ingest:
     """
 
     def _init_umap(self, adata):
-        from umap import UMAP
+        import umap as u
 
-        self._umap = UMAP(
+        u.umap_._HAVE_PYNNDESCENT = False
+
+        self._umap = u.UMAP(
             metric=self._metric,
             random_state=adata.uns['umap']['params'].get('random_state', 0),
         )

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -396,7 +396,7 @@ class Ingest:
         self._adata_new = adata_new
         self._obsm['rep'] = self._same_rep()
 
-    def neighbors(self, k=10, queue_size=5, random_state=0):
+    def neighbors(self, k=None, queue_size=5, random_state=0):
         """\
         Calculate neighbors of `adata_new` observations in `adata`.
 
@@ -411,6 +411,9 @@ class Ingest:
 
         train = self._rep
         test = self._obsm['rep']
+
+        if k is None:
+            k = self._n_neighbors
 
         init = self._initialise_search(
             self._rp_forest, train, test, int(k * queue_size), rng_state=rng_state,


### PR DESCRIPTION
It was configurable with the default `k=10` before, now it uses n_neighbors from `sc.tl.neighbors`.
As discussed with @falexwolf .