### PR TITLE
CITE-seq improvements

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ exclude = '''
         |_combat
         |_simple
         |_recipes
-        |_normalization
         |_highly_variable_genes
         |_deprecated/highly_variable_genes
     )
@@ -53,7 +52,6 @@ exclude = '''
         |test_combat
         |test_neighbors
         |test_readwrite
-        |test_clustering
         |test_preprocessing
         |test_rank_genes_groups
         |test_marker_gene_overlap

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -243,6 +243,7 @@ def var_df(
     return df
 
 
+
 def _get_obs_rep(adata, *, use_raw=False, layer=None, obsm=None, obsp=None):
     """
     Choose array aligned with obs annotation.
@@ -268,7 +269,6 @@ def _get_obs_rep(adata, *, use_raw=False, layer=None, obsm=None, obsp=None):
             "That was unexpected. Please report this bug at:\n\n\t"
             " https://github.com/theislab/scanpy/issues"
         )
-
 
 def _set_obs_rep(adata, val, *, use_raw=False, layer=None, obsm=None, obsp=None):
     """

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -243,7 +243,6 @@ def var_df(
     return df
 
 
-
 def _get_obs_rep(adata, *, use_raw=False, layer=None, obsm=None, obsp=None):
     """
     Choose array aligned with obs annotation.
@@ -269,6 +268,7 @@ def _get_obs_rep(adata, *, use_raw=False, layer=None, obsm=None, obsp=None):
             "That was unexpected. Please report this bug at:\n\n\t"
             " https://github.com/theislab/scanpy/issues"
         )
+
 
 def _set_obs_rep(adata, val, *, use_raw=False, layer=None, obsm=None, obsp=None):
     """

--- a/scanpy/preprocessing/__init__.py
+++ b/scanpy/preprocessing/__init__.py
@@ -7,6 +7,6 @@ from ._simple import normalize_per_cell, regress_out, downsample_counts
 from ._pca import pca
 from ._qc import calculate_qc_metrics
 from ._combat import combat
-from ._normalization import normalize_total
+from ._normalization import normalize_total, normalize_geometric
 
 from ..neighbors import neighbors

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -15,11 +15,11 @@ def _normalize_data(X, counts, after=None, copy=False):
     if issubclass(X.dtype.type, (int, np.integer)):
         X = X.astype(np.float32)  # TODO: Check if float64 should be used
     counts = np.asarray(counts)  # dask doesn't do medians
-    after = np.median(counts[counts>0], axis=0) if after is None else after
-    counts += (counts == 0)
+    after = np.median(counts[counts > 0], axis=0) if after is None else after
+    counts += counts == 0
     counts = counts / after
     if issparse(X):
-        sparsefuncs.inplace_row_scale(X, 1/counts)
+        sparsefuncs.inplace_row_scale(X, 1 / counts)
     else:
         np.divide(X, counts[:, None], out=X)
     return X
@@ -144,8 +144,8 @@ def normalize_total(
         counts_per_cell = np.ravel(counts_per_cell)
 
         # at least one cell as more than max_fraction of counts per cell
-        gene_subset = (adata.X > counts_per_cell[:, None]*max_fraction).sum(0)
-        gene_subset = (np.ravel(gene_subset) == 0)
+        gene_subset = (adata.X > counts_per_cell[:, None] * max_fraction).sum(0)
+        gene_subset = np.ravel(gene_subset) == 0
 
         msg += (
             ' The following highly-expressed genes are not considered during '
@@ -184,7 +184,7 @@ def normalize_total(
             norm_factor=counts_per_cell,
         )
 
-    for layer_name in (layers or ()):
+    for layer_name in layers or ():
         layer = adata.layers[layer_name]
         counts = np.ravel(layer.sum(1))
         if inplace:
@@ -193,10 +193,11 @@ def normalize_total(
             dat[layer_name] = _normalize_data(layer, counts, after, copy=True)
 
     logg.info(
-        '    finished ({time_passed})',
-        time=start,
+        '    finished ({time_passed})', time=start,
     )
     if key_added is not None:
-        logg.debug(f'and added {key_added!r}, counts per cell before normalization (adata.obs)')
+        logg.debug(
+            f'and added {key_added!r}, counts per cell before normalization (adata.obs)'
+        )
 
     return dat if not inplace else None

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -11,10 +11,10 @@ def adata_neighbors():
 def test_leiden_basic(adata_neighbors):
     sc.tl.leiden(adata_neighbors)
 
-@pytest.mark.parametrize('clustering,key', [
-    (sc.tl.louvain, 'louvain'),
-    (sc.tl.leiden, 'leiden'),
-])
+
+@pytest.mark.parametrize(
+    'clustering,key', [(sc.tl.louvain, 'louvain'), (sc.tl.leiden, 'leiden'),]
+)
 def test_clustering_subset(adata_neighbors, clustering, key):
     clustering(adata_neighbors, key_added=key)
 
@@ -24,9 +24,7 @@ def test_clustering_subset(adata_neighbors, clustering, key):
         ncells_in_c = adata_neighbors.obs[key].value_counts().loc[c]
         key_sub = str(key) + '_sub'
         clustering(
-            adata_neighbors,
-            restrict_to=(key, [c]),
-            key_added=key_sub,
+            adata_neighbors, restrict_to=(key, [c]), key_added=key_sub,
         )
         # Get new clustering labels
         new_partition = adata_neighbors.obs[key_sub]

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -1,5 +1,6 @@
 import pytest
 import scanpy as sc
+from scipy import sparse
 
 
 @pytest.fixture
@@ -50,5 +51,18 @@ def test_louvain_basic(adata_neighbors):
 
 def test_partition_type(adata_neighbors):
     import louvain
+
     sc.tl.louvain(adata_neighbors, partition_type=louvain.RBERVertexPartition)
     sc.tl.louvain(adata_neighbors, partition_type=louvain.SurpriseVertexPartition)
+
+
+def test_leiden_multiplex():
+    """Currently just tests that leiden_multiplex doesn't fail."""
+    adata = sc.AnnData(
+        X=sparse.random(100, 50, format="csr"),
+        obsp={
+            "rep1": sparse.random(100, 100, density=0.1, format="csr"),
+            "rep2": sparse.random(100, 100, density=0.1, format="csr"),
+        },
+    )
+    sc.tl.leiden_multiplex(adata, "rep1", "rep2")

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -63,4 +63,4 @@ def test_leiden_multiplex():
             "rep2": sparse.random(100, 100, density=0.1, format="csr"),
         },
     )
-    sc.tl.leiden_multiplex(adata, "rep1", "rep2")
+    sc.tl.leiden_multiplex(adata, ["rep1", "rep2"])

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -48,7 +48,7 @@ def test_normalize_total_view(typ, dtype):
 
 
 def test_normalize_geometric():
-    mtx = sparse.random(100, 50, density=.4, format="csr", dtype=np.float32)
+    mtx = sparse.random(100, 50, density=0.4, format="csr", dtype=np.float32)
     adata = AnnData(X=mtx.copy(), layers={"dense": mtx.toarray()})
     adata.obsm["df"] = adata.to_df()
 

--- a/scanpy/tools/__init__.py
+++ b/scanpy/tools/__init__.py
@@ -13,6 +13,7 @@ from ._paga import (
 from ._rank_genes_groups import rank_genes_groups, filter_rank_genes_groups
 from ._dpt import dpt
 from ._leiden import leiden
+from ._leiden_multiplex import leiden_multiplex
 from ._louvain import louvain
 from ._sim import sim
 from ._score_genes import score_genes, score_genes_cell_cycle

--- a/scanpy/tools/_leiden_multiplex.py
+++ b/scanpy/tools/_leiden_multiplex.py
@@ -1,0 +1,74 @@
+import scanpy as sc
+import leidenalg
+
+import pandas as pd
+import numpy as np
+
+# TODO: Work for n reps
+# TODO: Allow passing in the graphs
+def leiden_multiplex(
+    adata: "sc.AnnData",
+    rep1: str,
+    rep2: str,
+    w1=1.0,
+    w2=1.0,
+    res1: float = 1.0,
+    res2: float = None,
+    key_added: str = "leiden_multiplex",
+):
+    """Perform a multiplexed clustering on multiple graphs representation of the same data.
+
+    Overview: https://leidenalg.readthedocs.io/en/latest/multiplex.html.
+
+    Params
+    ------
+    adata
+    rep
+        Adjacency matrix of shape n_obs, n_obs
+    w
+        Layer weight for graph rep
+    res
+        Resolution parameter for this graph rep
+        If connectivity graphs calculated by umap are being used, you probably don't need to specify different values for this.
+    key_added
+        Key in .obs to add this clustering in.
+
+    Usage
+    -----
+    >>> sc.tl.leiden_multiplex(adata, "rna_connectivities", "protein_connectivities")
+    >>> sc.pl.umap(adata, color="leiden_multiplex")
+    """
+    if res2 is None:
+        res2 = res1
+
+    g1_rep = sc.get._get_obs_rep(adata, obsp=rep1)
+    g2_rep = sc.get._get_obs_rep(adata, obsp=rep2)
+
+    g1 = sc._utils.get_igraph_from_adjacency(g1_rep, directed=True)
+    g2 = sc._utils.get_igraph_from_adjacency(g2_rep, directed=True)
+
+    clustering = cluster_joint(g1, g2, res1, res2, w1=w1, w2=w2)
+
+    adata.obs[key_added] = pd.Categorical.from_codes(
+        clustering, categories=list(map(str, np.unique(clustering))),
+    )
+
+
+# Internal function, for after everything has been preprocessed and extracted
+def cluster_joint(
+    g1: "igraph.Graph",
+    g2: "igraph.Graph",
+    res1: float,
+    res2: float,
+    w1: float = 1.0,
+    w2: float = 1.0,
+):
+    part1 = leidenalg.RBConfigurationVertexPartition(
+        g1, weights="weight", resolution_parameter=res1
+    )
+    part2 = leidenalg.RBConfigurationVertexPartition(
+        g2, weights="weight", resolution_parameter=res2
+    )
+    optimiser = leidenalg.Optimiser()
+    optimiser.optimise_partition_multiplex([part1, part2], layer_weights=[w1, w2])
+    return np.array(part1.membership)

--- a/scanpy/tools/_leiden_multiplex.py
+++ b/scanpy/tools/_leiden_multiplex.py
@@ -3,7 +3,6 @@ from typing import List, Iterable, Union
 from itertools import repeat
 
 import scanpy as sc
-import leidenalg
 import igraph
 
 import pandas as pd
@@ -95,6 +94,7 @@ def cluster_joint(
 ):
     """Actually do the clustering.
     """
+    import leidenalg
     partitions = [
         leidenalg.RBConfigurationVertexPartition(
             rep, weights="weight", resolution_parameter=res


### PR DESCRIPTION
This is a bit of a catch all to improve cite-seq support. Currently a dependency of https://github.com/theislab/scanpy-tutorials/pull/14. I'll write a bit more about this after some sleep.

The main goals here are:

* Implement analysis functions for cite-seq data (like joint clustering, geometric mean normalization, etc.)
* Improve generality of existing APIs. Basically, if the antibody counts are in obsm, we should be able to apply most functions to that. This is not currently the case.