### PR TITLE
pp.neighbors saves to obsp and uses key_added argument

### DIFF
--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -701,16 +701,16 @@ class NeighborsView:
             return key in self._neighbors_dict
 
 
-def _choose_graph(adata, obsp_key, neighbors_key):
+def _choose_graph(adata, obsp, neighbors_key):
     """Choose connectivities from neighbbors or another obsp column"""
-    if obsp_key is not None and neighbors_key is not None:
+    if obsp is not None and neighbors_key is not None:
         raise ValueError(
-            'You can\'t specify both obsp_key, neighbors_key. '
+            'You can\'t specify both obsp, neighbors_key. '
             'Please select only one.'
         )
 
-    if obsp_key is not None:
-        return adata.obsp[obsp_key]
+    if obsp is not None:
+        return adata.obsp[obsp]
     else:
         neighbors = NeighborsView(adata, neighbors_key)
         if 'connectivities' not in neighbors:

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -570,3 +570,42 @@ def lazy_import(full_name):
         # Make module with proper locking and get it inserted into sys.modules.
         loader.exec_module(module)
         return module
+
+
+# --------------------------------------------------------------------------------
+# Neighbors
+# --------------------------------------------------------------------------------
+
+class NeighborsView:
+    def __init__(self, adata, key=None):
+        self._connectivities = None
+        self._distances = None
+
+        if key is None or key == 'neighbors':
+            self._neighbors_dict = adata.uns['neighbors']
+            if 'connectivities' in adata.obsp and 'distances' in adata.obsp:
+                self._connectivities = adata.obsp['connectivities']
+                self._distances = adata.obsp['distances']
+            else:
+                self._connectivities = self._neighbors_dict['connectivities']
+                self._distances = self._neighbors_dict['distances']
+        else:
+            self._neighbors_dict = adata.uns[key]
+            self._connectivities = adata.obsp[self._neighbors_dict['connectivities_key']]
+            self._distances = adata.obsp[self._neighbors_dict['distances_key']]
+
+    def __getitem__(self, key):
+        if key == 'distances':
+            return self._distances
+        elif key == 'connectivities':
+            return self._connectivities
+        else:
+            return self._neighbors_dict[key]
+
+    def __contains__(self, key):
+        if key == 'distances':
+            return self._distances is not None
+        elif key == 'connectivities':
+            return self._connectivities is not None
+        else:
+            return key in self._neighbors_dict

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -583,16 +583,25 @@ class NeighborsView:
 
         if key is None or key == 'neighbors':
             self._neighbors_dict = adata.uns['neighbors']
-            if 'connectivities' in adata.obsp and 'distances' in adata.obsp:
-                self._connectivities = adata.obsp['connectivities']
-                self._distances = adata.obsp['distances']
-            else:
-                self._connectivities = self._neighbors_dict['connectivities']
-                self._distances = self._neighbors_dict['distances']
+            conns_key = 'connectivities'
+            dists_key = 'distances'
+
+            if conns_key in adata.obsp:
+                self._connectivities = adata.obsp[conns_key]
+            elif conns_key in self._neighbors_dict:
+                self._connectivities = self._neighbors_dict[conns_key]
+
+            if dists_key in adata.obsp:
+                self._distances = adata.obsp[dists_key]
+            elif dists_key in self._neighbors_dict:
+                self._distances = self._neighbors_dict[dists_key]
         else:
             self._neighbors_dict = adata.uns[key]
-            self._connectivities = adata.obsp[self._neighbors_dict['connectivities_key']]
-            self._distances = adata.obsp[self._neighbors_dict['distances_key']]
+            conns_key = self._neighbors_dict['connectivities_key']
+            dists_key = self._neighbors_dict['distances_key']
+            
+            self._connectivities = adata.obsp[conns_key]
+            self._distances = adata.obsp[dists_key]
 
     def __getitem__(self, key):
         if key == 'distances':

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -681,3 +681,23 @@ class NeighborsView:
             return self._connectivities is not None
         else:
             return key in self._neighbors_dict
+
+
+def _choose_graph(adata, obsp_key, neighbors_key):
+    """Choose connectivities from neighbbors or another obsp column"""
+    if obsp_key is not None and neighbors_key is not None:
+        raise ValueError(
+            'You can\'t specify both obsp_key, neighbors_key. '
+            'Please select only one.'
+        )
+
+    if obsp_key is not None:
+        return adata.obsp[obsp_key]
+    else:
+        neighbors = NeighborsView(adata, neighbors_key)
+        if 'connectivities' not in neighbors:
+            raise ValueError(
+                'You need to run `pp.neighbors` first '
+                'to compute a neighborhood graph.'
+            )
+        return neighbors['connectivities']

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -648,29 +648,29 @@ class NeighborsView:
             if 'neighbors' not in adata.uns:
                 raise KeyError('No "neighbors" in .uns')
             self._neighbors_dict = adata.uns['neighbors']
-            conns_key = 'connectivities'
-            dists_key = 'distances'
+            self._conns_key = 'connectivities'
+            self._dists_key = 'distances'
         else:
             if key not in adata.uns:
                 raise KeyError(f'No "{key}" in .uns')
             self._neighbors_dict = adata.uns[key]
-            conns_key = self._neighbors_dict['connectivities_key']
-            dists_key = self._neighbors_dict['distances_key']
+            self._conns_key = self._neighbors_dict['connectivities_key']
+            self._dists_key = self._neighbors_dict['distances_key']
 
         if conns_key in adata.obsp:
-            self._connectivities = adata.obsp[conns_key]
+            self._connectivities = adata.obsp[self._conns_key]
         if dists_key in adata.obsp:
-            self._distances = adata.obsp[dists_key]
+            self._distances = adata.obsp[self._dists_key]
 
     def __getitem__(self, key):
         if key == 'distances':
             if 'distances' not in self:
-                raise KeyError(f'No "{self._neighbors_dict["distances_key"]}" in .obsp')
+                raise KeyError(f'No "{self._dists_key}" in .obsp')
             return self._distances
         elif key == 'connectivities':
             if 'connectivities' not in self:
                 raise KeyError(
-                    f'No "{self._neighbors_dict["connectivities_key"]}" in .obsp'
+                    f'No "{self._conns_key}" in .obsp'
                 )
             return self._connectivities
         else:

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -657,9 +657,9 @@ class NeighborsView:
             self._conns_key = self._neighbors_dict['connectivities_key']
             self._dists_key = self._neighbors_dict['distances_key']
 
-        if conns_key in adata.obsp:
+        if self._conns_key in adata.obsp:
             self._connectivities = adata.obsp[self._conns_key]
-        if dists_key in adata.obsp:
+        if self._dists_key in adata.obsp:
             self._distances = adata.obsp[self._dists_key]
 
     def __getitem__(self, key):
@@ -669,9 +669,7 @@ class NeighborsView:
             return self._distances
         elif key == 'connectivities':
             if 'connectivities' not in self:
-                raise KeyError(
-                    f'No "{self._conns_key}" in .obsp'
-                )
+                raise KeyError(f'No "{self._conns_key}" in .obsp')
             return self._connectivities
         else:
             return self._neighbors_dict[key]

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -49,6 +49,7 @@ def check_versions():
 
     if anndata_version < version.parse('0.6.10'):
         from . import __version__
+
         raise ImportError(
             f'Scanpy {__version__} needs anndata version >=0.6.10, '
             f'not {anndata_version}.\nRun `pip install anndata -U --no-deps`.'
@@ -56,11 +57,11 @@ def check_versions():
 
     if umap_version < version.parse('0.3.0'):
         from . import __version__
+
         # make this a warning, not an error
         # it might be useful for people to still be able to run it
         logg.warning(
-            f'Scanpy {__version__} needs umap '
-            f'version >=0.3.0, not {umap_version}.'
+            f'Scanpy {__version__} needs umap ' f'version >=0.3.0, not {umap_version}.'
         )
 
 
@@ -98,11 +99,11 @@ def deprecated_arg_names(arg_mapping: Mapping[str, str]):
     arg_mapping
         Mapping from deprecated argument name to current argument name.
     """
+
     def decorator(func):
         @wraps(func)
         def func_wrapper(*args, **kwargs):
-            warnings.simplefilter(
-                'always', DeprecationWarning)  # turn off filter
+            warnings.simplefilter('always', DeprecationWarning)  # turn off filter
             for old, new in arg_mapping.items():
                 if old in kwargs:
                     warnings.warn(
@@ -117,7 +118,9 @@ def deprecated_arg_names(arg_mapping: Mapping[str, str]):
             # reset filter
             warnings.simplefilter('default', DeprecationWarning)
             return func(*args, **kwargs)
+
         return func_wrapper
+
     return decorator
 
 
@@ -125,7 +128,9 @@ def _one_of_ours(obj, root: str):
     return (
         hasattr(obj, "__name__")
         and not obj.__name__.split(".")[-1].startswith("_")
-        and getattr(obj, '__module__', getattr(obj, '__qualname__', obj.__name__)).startswith(root)
+        and getattr(
+            obj, '__module__', getattr(obj, '__qualname__', obj.__name__)
+        ).startswith(root)
     )
 
 
@@ -155,10 +160,12 @@ def _doc_params(**kwds):
     """\
     Docstrings should start with "\" in the first line for proper formatting.
     """
+
     def dec(obj):
         obj.__orig_doc__ = obj.__doc__
         obj.__doc__ = dedent(obj.__doc__).format_map(kwds)
         return obj
+
     return dec
 
 
@@ -170,6 +177,7 @@ def _doc_params(**kwds):
 def get_igraph_from_adjacency(adjacency, directed=None):
     """Get igraph graph from adjacency matrix."""
     import igraph as ig
+
     sources, targets = adjacency.nonzero()
     weights = adjacency[sources, targets]
     if isinstance(weights, np.matrix):
@@ -191,6 +199,7 @@ def get_igraph_from_adjacency(adjacency, directed=None):
 
 def get_sparse_from_igraph(graph, weight_attr=None):
     from scipy.sparse import csr_matrix
+
     edges = graph.get_edgelist()
     if weight_attr is None:
         weights = [1] * len(edges)
@@ -250,7 +259,9 @@ def compute_association_matrix_of_groups(
         reference labels, entries are proportional to degree of association.
     """
     if normalization not in {'prediction', 'reference'}:
-        raise ValueError('`normalization` needs to be either "prediction" or "reference".')
+        raise ValueError(
+            '`normalization` needs to be either "prediction" or "reference".'
+        )
     sanitize_anndata(adata)
     cats = adata.obs[reference].cat.categories
     for cat in cats:
@@ -261,9 +272,9 @@ def compute_association_matrix_of_groups(
             )
     asso_names = []
     asso_matrix = []
-    for ipred_group, pred_group in enumerate(
-            adata.obs[prediction].cat.categories):
-        if '?' in pred_group: pred_group = str(ipred_group)
+    for ipred_group, pred_group in enumerate(adata.obs[prediction].cat.categories):
+        if '?' in pred_group:
+            pred_group = str(ipred_group)
         # starting from numpy version 1.13, subtractions of boolean arrays are deprecated
         mask_pred = adata.obs[prediction].values == pred_group
         mask_pred_int = mask_pred.astype(np.int8)
@@ -277,20 +288,25 @@ def compute_association_matrix_of_groups(
             if normalization == 'prediction':
                 # compute which fraction of the predicted group is contained in
                 # the ref group
-                ratio_contained = (np.sum(mask_pred_int) -
-                    np.sum(mask_ref_or_pred - mask_ref)) / np.sum(mask_pred_int)
+                ratio_contained = (
+                    np.sum(mask_pred_int) - np.sum(mask_ref_or_pred - mask_ref)
+                ) / np.sum(mask_pred_int)
             else:
                 # compute which fraction of the reference group is contained in
                 # the predicted group
-                ratio_contained = (np.sum(mask_ref) -
-                    np.sum(mask_ref_or_pred - mask_pred_int)) / np.sum(mask_ref)
+                ratio_contained = (
+                    np.sum(mask_ref) - np.sum(mask_ref_or_pred - mask_pred_int)
+                ) / np.sum(mask_ref)
             asso_matrix[-1] += [ratio_contained]
-        name_list_pred = [cats[i] if cats[i] not in settings.categories_to_ignore else ''
-                          for i in np.argsort(asso_matrix[-1])[::-1]
-                          if asso_matrix[-1][i] > threshold]
+        name_list_pred = [
+            cats[i] if cats[i] not in settings.categories_to_ignore else ''
+            for i in np.argsort(asso_matrix[-1])[::-1]
+            if asso_matrix[-1][i] > threshold
+        ]
         asso_names += ['\n'.join(name_list_pred[:max_n_names])]
-    Result = namedtuple('compute_association_matrix_of_groups',
-                        ['asso_names', 'asso_matrix'])
+    Result = namedtuple(
+        'compute_association_matrix_of_groups', ['asso_names', 'asso_matrix']
+    )
     return Result(asso_names=asso_names, asso_matrix=np.array(asso_matrix))
 
 
@@ -328,16 +344,26 @@ def identify_groups(ref_labels, pred_labels, return_overlaps=False):
     associated_predictions = {}
     associated_overlaps = {}
     for ref_label in ref_unique:
-        sub_pred_unique, sub_pred_counts = np.unique(pred_labels[ref_label == ref_labels], return_counts=True)
-        relative_overlaps_pred = [sub_pred_counts[i] / pred_dict[n] for i, n in enumerate(sub_pred_unique)]
-        relative_overlaps_ref = [sub_pred_counts[i] / ref_dict[ref_label] for i, n in enumerate(sub_pred_unique)]
+        sub_pred_unique, sub_pred_counts = np.unique(
+            pred_labels[ref_label == ref_labels], return_counts=True
+        )
+        relative_overlaps_pred = [
+            sub_pred_counts[i] / pred_dict[n] for i, n in enumerate(sub_pred_unique)
+        ]
+        relative_overlaps_ref = [
+            sub_pred_counts[i] / ref_dict[ref_label]
+            for i, n in enumerate(sub_pred_unique)
+        ]
         relative_overlaps = np.c_[relative_overlaps_pred, relative_overlaps_ref]
         relative_overlaps_min = np.min(relative_overlaps, axis=1)
         pred_best_index = np.argsort(relative_overlaps_min)[::-1]
         associated_predictions[ref_label] = sub_pred_unique[pred_best_index]
         associated_overlaps[ref_label] = relative_overlaps[pred_best_index]
-    if return_overlaps: return associated_predictions, associated_overlaps
-    else: return associated_predictions
+    if return_overlaps:
+        return associated_predictions, associated_overlaps
+    else:
+        return associated_predictions
+
 
 # --------------------------------------------------------------------------------
 # Other stuff
@@ -352,8 +378,7 @@ def sanitize_anndata(adata):
 def view_to_actual(adata):
     if adata.is_view:
         warnings.warn(
-            "Revieved a view of an AnnData. Making a copy.",
-            stacklevel=2,
+            "Revieved a view of an AnnData. Making a copy.", stacklevel=2,
         )
         adata._init_as_actual(adata.copy())
 
@@ -375,7 +400,7 @@ def moving_average(a: np.ndarray, n: int):
     """
     ret = np.cumsum(a, dtype=float)
     ret[n:] = ret[n:] - ret[:-n]
-    return ret[n - 1:] / n
+    return ret[n - 1 :] / n
 
 
 # --------------------------------------------------------------------------------
@@ -384,9 +409,7 @@ def moving_average(a: np.ndarray, n: int):
 
 
 def update_params(
-    old_params: Mapping[str, Any],
-    new_params: Mapping[str, Any],
-    check=False,
+    old_params: Mapping[str, Any], new_params: Mapping[str, Any], check=False,
 ) -> Dict[str, Any]:
     """\
     Update old_params with new_params.
@@ -410,10 +433,13 @@ def update_params(
     if new_params:  # allow for new_params to be None
         for key, val in new_params.items():
             if key not in old_params and check:
-                raise ValueError('\'' + key
-                                 + '\' is not a valid parameter key, '
-                                 + 'consider one of \n'
-                                 + str(list(old_params.keys())))
+                raise ValueError(
+                    '\''
+                    + key
+                    + '\' is not a valid parameter key, '
+                    + 'consider one of \n'
+                    + str(list(old_params.keys()))
+                )
             if val is not None:
                 updated_params[key] = val
     return updated_params
@@ -431,8 +457,9 @@ def select_groups(adata, groups_order_subset='all', key='groups'):
     if key + '_masks' in adata.uns:
         groups_masks = adata.uns[key + '_masks']
     else:
-        groups_masks = np.zeros((len(adata.obs[key].cat.categories),
-                                 adata.obs[key].values.size), dtype=bool)
+        groups_masks = np.zeros(
+            (len(adata.obs[key].cat.categories), adata.obs[key].values.size), dtype=bool
+        )
         for iname, name in enumerate(adata.obs[key].cat.categories):
             # if the name is not found, fallback to index retrieval
             if adata.obs[key].cat.categories[iname] in adata.obs[key].values:
@@ -445,18 +472,23 @@ def select_groups(adata, groups_order_subset='all', key='groups'):
         groups_ids = []
         for name in groups_order_subset:
             groups_ids.append(
-                np.where(adata.obs[key].cat.categories.values == name)[0][0])
+                np.where(adata.obs[key].cat.categories.values == name)[0][0]
+            )
         if len(groups_ids) == 0:
             # fallback to index retrieval
             groups_ids = np.where(
-                np.in1d(np.arange(len(adata.obs[key].cat.categories)).astype(str),
-                                          np.array(groups_order_subset)))[0]
+                np.in1d(
+                    np.arange(len(adata.obs[key].cat.categories)).astype(str),
+                    np.array(groups_order_subset),
+                )
+            )[0]
         if len(groups_ids) == 0:
             logg.debug(
                 f'{np.array(groups_order_subset)} invalid! specify valid '
                 f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
+
             exit(0)
         groups_masks = groups_masks[groups_ids]
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
@@ -475,15 +507,14 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
     http://stackoverflow.com/questions/22373927/get-traceback-of-warnings
     """
     import traceback
+
     traceback.print_stack()
     log = file if hasattr(file, 'write') else sys.stderr
     settings.write(warnings.formatwarning(message, category, filename, lineno, line))
 
 
 def subsample(
-    X: np.ndarray,
-    subsample: int = 1,
-    seed: int = 0,
+    X: np.ndarray, subsample: int = 1, seed: int = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """\
     Subsample a fraction of 1/subsample samples from the rows of X.
@@ -515,7 +546,7 @@ def subsample(
     else:
         if seed < 0:
             raise ValueError(f'Invalid seed value < 0: {seed}')
-        n = int(X.shape[0]/subsample)
+        n = int(X.shape[0] / subsample)
         np.random.seed(seed)
         Xsampled, rows = subsample_n(X, n=n)
     logg.debug(f'... subsampled to {n} of {X.shape[0]} data points')
@@ -556,6 +587,7 @@ def check_presence_download(filename: Path, backup_url):
     """Check if file is present otherwise download."""
     if not filename.is_file():
         from .readwrite import _download
+
         _download(backup_url, filename)
 
 
@@ -576,37 +608,70 @@ def lazy_import(full_name):
 # Neighbors
 # --------------------------------------------------------------------------------
 
+
 class NeighborsView:
+    """Convenience class for accessing neighbors graph representations.
+
+    Allows to access neighbors distances, connectivities and settings
+    dictionary in a uniform manner.
+
+    Parameters
+    ----------
+
+    adata
+        AnnData object.
+    key
+        This defines where to look for neighbors dictionary,
+        connectivities, distances.
+
+        neigh = NeighborsView(adata, key)
+        neigh['distances']
+        neigh['connectivities']
+        neigh['params']
+        'connectivities' in neigh
+        'params' in neigh
+
+        is the same as
+
+        adata.obsp[adata.uns[key]['distances_key']]
+        adata.obsp[adata.uns[key]['connectivities_key']]
+        adata.uns[key]['params']
+        adata.uns[key]['connectivities_key'] in adata.obsp
+        'params' in adata.uns[key]
+    """
+
     def __init__(self, adata, key=None):
         self._connectivities = None
         self._distances = None
 
         if key is None or key == 'neighbors':
+            if 'neighbors' not in adata.uns:
+                raise KeyError('No "neighbors" in .uns')
             self._neighbors_dict = adata.uns['neighbors']
             conns_key = 'connectivities'
             dists_key = 'distances'
-
-            if conns_key in adata.obsp:
-                self._connectivities = adata.obsp[conns_key]
-            elif conns_key in self._neighbors_dict:
-                self._connectivities = self._neighbors_dict[conns_key]
-
-            if dists_key in adata.obsp:
-                self._distances = adata.obsp[dists_key]
-            elif dists_key in self._neighbors_dict:
-                self._distances = self._neighbors_dict[dists_key]
         else:
+            if key not in adata.uns:
+                raise KeyError(f'No "{key}" in .uns')
             self._neighbors_dict = adata.uns[key]
             conns_key = self._neighbors_dict['connectivities_key']
             dists_key = self._neighbors_dict['distances_key']
-            
+
+        if conns_key in adata.obsp:
             self._connectivities = adata.obsp[conns_key]
+        if dists_key in adata.obsp:
             self._distances = adata.obsp[dists_key]
 
     def __getitem__(self, key):
         if key == 'distances':
+            if 'distances' not in self:
+                raise KeyError(f'No "{self._neighbors_dict["distances_key"]}" in .obsp')
             return self._distances
         elif key == 'connectivities':
+            if 'connectivities' not in self:
+                raise KeyError(
+                    f'No "{self._neighbors_dict["connectivities_key"]}" in .obsp'
+                )
             return self._connectivities
         else:
             return self._neighbors_dict[key]

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -609,6 +609,15 @@ def lazy_import(full_name):
 # --------------------------------------------------------------------------------
 
 
+def _fallback_to_uns(dct, conns, dists, conns_key, dists_key):
+    if conns is None and conns_key in dct:
+        conns = dct[conns_key]
+    if dists is None and dists_key in dct:
+        dists = dct[dists_key]
+
+    return conns, dists
+
+
 class NeighborsView:
     """Convenience class for accessing neighbors graph representations.
 
@@ -661,6 +670,15 @@ class NeighborsView:
             self._connectivities = adata.obsp[self._conns_key]
         if self._dists_key in adata.obsp:
             self._distances = adata.obsp[self._dists_key]
+
+        # fallback to uns
+        self._connectivities, self._distances = _fallback_to_uns(
+            self._neighbors_dict,
+            self._connectivities,
+            self._distances,
+            self._conns_key,
+            self._dists_key,
+        )
 
     def __getitem__(self, key):
         if key == 'distances':

--- a/scanpy/external/exporting.py
+++ b/scanpy/external/exporting.py
@@ -24,6 +24,7 @@ def spring_project(
     cell_groupings: Union[str, Iterable[str], None] = None,
     custom_color_tracks: Union[str, Iterable[str], None] = None,
     total_counts_key: str = 'n_counts',
+    neighbors_key: Optional[str] = None,
     overwrite: bool = False,
 ):
     """\
@@ -61,7 +62,10 @@ def spring_project(
     """
 
     # need to get nearest neighbors first
-    if 'neighbors' not in adata.uns:
+    if neighbors_key is None:
+        neighbors_key = 'neighbors'
+
+    if neighbors_key not in adata.uns:
         raise ValueError('Run `sc.pp.neighbors` first.')
 
     # check that requested 2-D embedding has been generated
@@ -174,7 +178,7 @@ def spring_project(
     _write_cell_groupings(subplot_dir / 'categorical_coloring_data.json', categorical_coloring_data)
 
     # Write graph in two formats for backwards compatibility
-    edges = _get_edges(adata)
+    edges = _get_edges(adata, neighbors_key)
     _write_graph(subplot_dir / 'graph_data.json', E.shape[0], edges)
     _write_edges(subplot_dir / 'edges.csv', edges)
 
@@ -211,11 +215,12 @@ def spring_project(
 # --------------------------------------------------------------------------------
 
 
-def _get_edges(adata):
+def _get_edges(adata, neighbors_key=None):
+    neighbors = NeighborsView(adata, neighbors_key)
     if 'distances' in adata.uns['neighbors']:  # these are sparse matrices
-        matrix = adata.uns['neighbors']['distances']
+        matrix = neighbors['distances']
     else:
-        matrix = adata.uns['neighbors']['connectivities']
+        matrix = neighbors['connectivities']
     matrix = matrix.tocoo()
     edges = [(i,j) for i, j in zip(matrix.row, matrix.col)]
 

--- a/scanpy/external/exporting.py
+++ b/scanpy/external/exporting.py
@@ -217,7 +217,7 @@ def spring_project(
 
 def _get_edges(adata, neighbors_key=None):
     neighbors = NeighborsView(adata, neighbors_key)
-    if 'distances' in adata.uns['neighbors']:  # these are sparse matrices
+    if 'distances' in neighbors:  # these are sparse matrices
         matrix = neighbors['distances']
     else:
         matrix = neighbors['connectivities']

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -512,6 +512,8 @@ class Neighbors:
         Annotated data object.
     n_dcs
         Number of diffusion components to use.
+    neighbors_key
+        Where to look in .uns and .obsp for neighbors data
     """
 
     def __init__(self, adata: AnnData, n_dcs: Optional[int] = None, neighbors_key: Optional[str] = None):

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -86,6 +86,13 @@ def neighbors(
         A known metric’s name or a callable that returns a distance.
     metric_kwds
         Options for the metric.
+    key_added
+        If not specified, the neighbors data is stored in .uns['neighbors'],
+        distances and connectivities are stored in .obsp['distances'] and
+        .obsp['connectivities'] respectively.
+        If specified, the neighbors data is added to .uns[key_added],
+        distances are stored in .obsp[key_added+'_distances'] and
+        connectivities in .obsp[key_added+'_connectivities'].
     copy
         Return a copy instead of writing to adata.
 

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -30,6 +30,12 @@ edges_width
     Width of edges.
 edges_color
     Color of edges. See :func:`~networkx.drawing.nx_pylab.draw_networkx_edges`.
+neighbors_key
+    Where to look for neighbors connectivities.
+    If not specified, this looks .obsp['connectivities'] for connectivities
+    (default storage place for pp.neighbors).
+    If specified, this looks
+    .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
 arrows
     Show arrows (requires to run :func:`scvelo.tl.velocity_embedding` before).
     Deprecated in favor of :func:`scvelo.pl.velocity_embedding` and friends.

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -52,6 +52,7 @@ def embedding(
     edges: bool = False,
     edges_width: float = 0.1,
     edges_color: Union[str, Sequence[float], Sequence[str]] = 'grey',
+    neighbors_key: Optional[str] = None,
     arrows: bool = False,
     arrows_kwds: Optional[Mapping[str, Any]] = None,
     groups: Optional[str] = None,
@@ -421,7 +422,7 @@ def embedding(
         ax.autoscale_view()
 
         if edges:
-            _utils.plot_edges(ax, adata, basis, edges_width, edges_color)
+            _utils.plot_edges(ax, adata, basis, edges_width, edges_color, neighbors_key)
         if arrows:
             _utils.plot_arrows(ax, adata, basis, arrows_kwds)
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -17,6 +17,7 @@ from cycler import Cycler, cycler
 from .. import logging as logg
 from .._settings import settings
 from .._compat import Literal
+from .._utils import NeighborsView
 from . import palettes
 
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -482,14 +482,18 @@ def add_colors_for_categorical_sample_annotation(
         _set_default_colors_for_categorical_obs(adata, key)
 
 
-def plot_edges(axs, adata, basis, edges_width, edges_color):
+def plot_edges(axs, adata, basis, edges_width, edges_color, neighbors_key=None):
     import networkx as nx
 
     if not isinstance(axs, cabc.Sequence):
         axs = [axs]
-    if 'neighbors' not in adata.uns:
+
+    if neighbors_key is None:
+        neighbors_key = 'neighbors'
+    if neighbors_key not in adata.uns:
         raise ValueError('`edges=True` requires `pp.neighbors` to be run before.')
-    g = nx.Graph(adata.uns['neighbors']['connectivities'])
+    neighbors = NeighborsView(adata, neighbors_key)
+    g = nx.Graph(neighbors['connectivities'])
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         for ax in axs:

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -46,8 +46,8 @@ def test_neighbors_key_obsp(field):
     else:
         arg = {field: adata1.uns[key]['connectivities_key']}
 
-    sc.tl.draw_graph(adata, layout='fr', random_state=0)
-    sc.tl.draw_graph(adata1, layout='fr', random_state=0, **arg)
+    sc.tl.draw_graph(adata, layout='fr', random_state=1)
+    sc.tl.draw_graph(adata1, layout='fr', random_state=1, **arg)
 
     assert adata.uns['draw_graph']['params'] == adata1.uns['draw_graph']['params']
     assert np.allclose(adata.obsm['X_draw_graph_fr'], adata1.obsm['X_draw_graph_fr'])

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -16,5 +16,9 @@ def test_neighbors_key_added():
     dists_key = adata.uns[key]['distances_key']
 
     assert adata.uns['neighbors']['params'] == adata.uns[key]['params']
-    assert np.allclose(adata.obsp['connectivities'].toarray(), adata.obsp[conns_key].toarray())
-    assert np.allclose(adata.obsp['distances'].toarray(), adata.obsp[dists_key].toarray())
+    assert np.allclose(
+        adata.obsp['connectivities'].toarray(), adata.obsp[conns_key].toarray()
+    )
+    assert np.allclose(
+        adata.obsp['distances'].toarray(), adata.obsp[dists_key].toarray()
+    )

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -1,5 +1,6 @@
 import scanpy as sc
 import numpy as np
+import pytest
 
 X = np.array([[1, 0], [3, 0], [5, 6], [0, 4]])
 n_neighbors = 3
@@ -22,3 +23,43 @@ def test_neighbors_key_added():
     assert np.allclose(
         adata.obsp['distances'].toarray(), adata.obsp[dists_key].toarray()
     )
+
+
+# test functions with neighbors_key and obsp
+@pytest.mark.parametrize('field', ['neighbors_key', 'obsp'])
+def test_neighbors_key_obsp(field):
+    adata = sc.AnnData(X)
+    adata1 = adata.copy()
+
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0)
+    sc.pp.neighbors(adata1, n_neighbors=n_neighbors, random_state=0, key_added=key)
+
+    # no obsp in umap
+    if field == 'neighbors_key':
+        sc.tl.umap(adata, random_state=0)
+        sc.tl.umap(adata1, random_state=0, neighbors_key=key)
+
+        assert adata.uns['umap']['params'] == adata1.uns['umap']['params']
+        assert np.allclose(adata.obsm['X_umap'], adata1.obsm['X_umap'])
+
+        arg = {field: key}
+    else:
+        arg = {field: adata1.uns[key]['connectivities_key']}
+
+    sc.tl.draw_graph(adata, layout='fr', random_state=0)
+    sc.tl.draw_graph(adata1, layout='fr', random_state=0, **arg)
+
+    assert adata.uns['draw_graph']['params'] == adata1.uns['draw_graph']['params']
+    assert np.allclose(adata.obsm['X_draw_graph_fr'], adata1.obsm['X_draw_graph_fr'])
+
+    sc.tl.leiden(adata, random_state=0)
+    sc.tl.leiden(adata1, random_state=0, **arg)
+
+    assert adata.uns['leiden']['params'] == adata1.uns['leiden']['params']
+    assert np.all(adata.obs['leiden'] == adata1.obs['leiden'])
+
+    sc.tl.louvain(adata, random_state=0)
+    sc.tl.louvain(adata1, random_state=0, **arg)
+
+    assert adata.uns['louvain']['params'] == adata1.uns['louvain']['params']
+    assert np.all(adata.obs['louvain'] == adata1.obs['louvain'])

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -1,0 +1,20 @@
+import scanpy as sc
+import numpy as np
+
+X = np.array([[1, 0], [3, 0], [5, 6], [0, 4]])
+n_neighbors = 3
+key = 'test'
+
+
+def test_neighbors_key_added():
+    adata = sc.AnnData(X)
+
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0)
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0, key_added=key)
+
+    conns_key = adata.uns[key]['connectivities_key']
+    dists_key = adata.uns[key]['distances_key']
+
+    assert adata.uns['neighbors']['params'] == adata.uns[key]['params']
+    assert np.allclose(adata.obsp['connectivities'].toarray(), adata.obsp[conns_key].toarray())
+    assert np.allclose(adata.obsp['distances'].toarray(), adata.obsp[dists_key].toarray())

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -1,9 +1,10 @@
 from anndata import AnnData
+from typing import Optional
 
 from ._dpt import _diffmap
 
 
-def diffmap(adata: AnnData, n_comps: int = 15, copy: bool = False):
+def diffmap(adata: AnnData, n_comps: int = 15, copy: bool = False, neighbors_key: Optional[str] = None):
     """\
     Diffusion Maps [Coifman05]_ [Haghverdi15]_ [Wolf18]_.
 
@@ -39,12 +40,15 @@ def diffmap(adata: AnnData, n_comps: int = 15, copy: bool = False):
         Array of size (number of eigen vectors).
         Eigenvalues of transition matrix.
     """
-    if 'neighbors' not in adata.uns:
+    if neighbors_key is None:
+        neighbors_key = 'neighbors'
+
+    if neighbors_key not in adata.uns:
         raise ValueError(
             'You need to run `pp.neighbors` first to compute a neighborhood graph.'
         )
     if n_comps <= 2:
         raise ValueError('Provide any value greater than 2 for `n_comps`. ')
     adata = adata.copy() if copy else adata
-    _diffmap(adata, n_comps=n_comps)
+    _diffmap(adata, n_comps=n_comps, neighbors_key)
     return adata if copy else None

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -7,8 +7,8 @@ from ._dpt import _diffmap
 def diffmap(
     adata: AnnData,
     n_comps: int = 15,
-    copy: bool = False,
     neighbors_key: Optional[str] = None,
+    copy: bool = False,
 ):
     """\
     Diffusion Maps [Coifman05]_ [Haghverdi15]_ [Wolf18]_.
@@ -31,6 +31,14 @@ def diffmap(
         Annotated data matrix.
     n_comps
         The number of dimensions of the representation.
+    neighbors_key
+        If not specified, diffmap looks .uns['neighbors'] for neighbors settings
+        and .obsp['connectivities'], .obsp['distances'] for connectivities and
+        distances respectively (default storage places for pp.neighbors).
+        If specified, diffmap looks .uns[neighbors_key] for neighbors settings and
+        .obsp[.uns[neighbors_key]['connectivities_key']],
+        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
+        respectively.
     copy
         Return a copy instead of writing to adata.
 

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -4,7 +4,12 @@ from typing import Optional
 from ._dpt import _diffmap
 
 
-def diffmap(adata: AnnData, n_comps: int = 15, copy: bool = False, neighbors_key: Optional[str] = None):
+def diffmap(
+    adata: AnnData,
+    n_comps: int = 15,
+    copy: bool = False,
+    neighbors_key: Optional[str] = None,
+):
     """\
     Diffusion Maps [Coifman05]_ [Haghverdi15]_ [Wolf18]_.
 

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -50,5 +50,5 @@ def diffmap(adata: AnnData, n_comps: int = 15, copy: bool = False, neighbors_key
     if n_comps <= 2:
         raise ValueError('Provide any value greater than 2 for `n_comps`. ')
     adata = adata.copy() if copy else adata
-    _diffmap(adata, n_comps=n_comps, neighbors_key)
+    _diffmap(adata, n_comps=n_comps, neighbors_key=neighbors_key)
     return adata if copy else None

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -84,6 +84,14 @@ def dpt(
         If a very small branch is detected upon splitting, shift away from
         maximum correlation in Kendall tau criterion of [Haghverdi16]_ to
         stabilize the splitting.
+    neighbors_key
+        If not specified, dpt looks .uns['neighbors'] for neighbors settings
+        and .obsp['connectivities'], .obsp['distances'] for connectivities and
+        distances respectively (default storage places for pp.neighbors).
+        If specified, dpt looks .uns[neighbors_key] for neighbors settings and
+        .obsp[.uns[neighbors_key]['connectivities_key']],
+        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
+        respectively.    
     copy
         Copy instance before computation and return a copy.
         Otherwise, perform computation inplace and return `None`.

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -175,7 +175,7 @@ class DPT(Neighbors):
 
     def __init__(self, adata, n_dcs=None, min_group_size=0.01,
                  n_branchings=0, allow_kendall_tau_shift=False, neighbors_key=None):
-        super(DPT, self).__init__(adata, n_dcs=n_dcs, neighbors_key)
+        super(DPT, self).__init__(adata, n_dcs=n_dcs, neighbors_key=neighbors_key)
         self.flavor = 'haghverdi16'
         self.n_branchings = n_branchings
         self.min_group_size = min_group_size if min_group_size >= 1 else int(min_group_size * self._adata.shape[0])

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -91,7 +91,7 @@ def dpt(
         If specified, dpt looks .uns[neighbors_key] for neighbors settings and
         .obsp[.uns[neighbors_key]['connectivities_key']],
         .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
-        respectively.    
+        respectively.
     copy
         Copy instance before computation and return a copy.
         Otherwise, perform computation inplace and return `None`.

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -10,9 +10,9 @@ from .. import logging as logg
 from ..neighbors import Neighbors, OnFlySymMatrix
 
 
-def _diffmap(adata, n_comps=15):
+def _diffmap(adata, n_comps=15, neighbors_key=None):
     start = logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
-    dpt = DPT(adata)
+    dpt = DPT(adata, neighbors_key)
     dpt.compute_transitions()
     dpt.compute_eigen(n_comps=n_comps)
     adata.obsm['X_diffmap'] = dpt.eigen_basis
@@ -34,6 +34,7 @@ def dpt(
     n_branchings: int = 0,
     min_group_size: float = 0.01,
     allow_kendall_tau_shift: bool = True,
+    neighbors_key: Optional[str] = None,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -107,7 +108,10 @@ def dpt(
     """
     # standard errors, warnings etc.
     adata = adata.copy() if copy else adata
-    if 'neighbors' not in adata.uns:
+
+    if neighbors_key is None:
+        neighbors_key = 'neighbors'
+    if neighbors_key not in adata.uns:
         raise ValueError(
             'You need to run `pp.neighbors` and `tl.diffmap` first.')
     if 'iroot' not in adata.uns and 'xroot' not in adata.var:
@@ -122,11 +126,12 @@ def dpt(
             'Trying to run `tl.dpt` without prior call of `tl.diffmap`. '
             'Falling back to `tl.diffmap` with default parameters.'
         )
-        _diffmap(adata)
+        _diffmap(adata, neighbors_key=neighbors_key)
     # start with the actual computation
     dpt = DPT(adata, n_dcs=n_dcs, min_group_size=min_group_size,
               n_branchings=n_branchings,
-              allow_kendall_tau_shift=allow_kendall_tau_shift)
+              allow_kendall_tau_shift=allow_kendall_tau_shift,
+              neighbors_key=neighbors_key)
     start = logg.info(f'computing Diffusion Pseudotime using n_dcs={n_dcs}')
     if n_branchings > 1: logg.info('    this uses a hierarchical implementation')
     if dpt.iroot is not None:
@@ -169,8 +174,8 @@ class DPT(Neighbors):
     """
 
     def __init__(self, adata, n_dcs=None, min_group_size=0.01,
-                 n_branchings=0, allow_kendall_tau_shift=False):
-        super(DPT, self).__init__(adata, n_dcs=n_dcs)
+                 n_branchings=0, allow_kendall_tau_shift=False, neighbors_key=None):
+        super(DPT, self).__init__(adata, n_dcs=n_dcs, neighbors_key)
         self.flavor = 'haghverdi16'
         self.n_branchings = n_branchings
         self.min_group_size = min_group_size if min_group_size >= 1 else int(min_group_size * self._adata.shape[0])

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -109,10 +109,11 @@ def draw_graph(
         init_coords = adata.obsm[init_pos]
     elif init_pos == 'paga' or init_pos:
         init_coords = get_init_pos_from_paga(
-            adata, adjacency,
+            adata,
+            adjacency,
             random_state=random_state,
             neighbors_key=neighbors_key,
-            obsp=obsp
+            obsp=obsp,
         )
     else:
         np.random.seed(random_state)

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -1,6 +1,7 @@
 from typing import Union, Optional
 
 import numpy as np
+import random
 from anndata import AnnData
 from scipy.sparse import spmatrix
 
@@ -160,6 +161,9 @@ def draw_graph(
         )
         positions = np.array(positions)
     else:
+        # igraph doesn't use numpy seed
+        random.seed(random_state)
+        
         g = _utils.get_igraph_from_adjacency(adjacency)
         if layout in {'fr', 'drl', 'kk', 'grid_fr'}:
             ig_layout = g.layout(layout, seed=init_coords.tolist(), **kwds)

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -25,7 +25,7 @@ def draw_graph(
     adjacency: Optional[spmatrix] = None,
     key_added_ext: Optional[str] = None,
     neighbors_key: Optional[str] = None,
-    obsp_key: Optional[str] = None,
+    obsp: Optional[str] = None,
     copy: bool = False,
     **kwds,
 ):
@@ -79,9 +79,9 @@ def draw_graph(
         (default storage place for pp.neighbors).
         If specified, draw_graph looks
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
-    obsp_key
-        Use .obsp[obsp_key] as adjacency. You can't specify both
-        obsp_key and neighbors_key at the same time.
+    obsp
+        Use .obsp[obsp] as adjacency. You can't specify both
+        `obsp` and `neighbors_key` at the same time.
     copy
         Return a copy instead of writing to adata.
     **kwds
@@ -103,7 +103,7 @@ def draw_graph(
         raise ValueError(f'Provide a valid layout, one of {_LAYOUTS}.')
     adata = adata.copy() if copy else adata
     if adjacency is None:
-        adjacency = _choose_graph(adata, obsp_key, neighbors_key)
+        adjacency = _choose_graph(adata, obsp, neighbors_key)
     # init coordinates
     if init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -8,7 +8,7 @@ from .. import _utils
 from .. import logging as logg
 from ._utils import get_init_pos_from_paga
 from .._compat import Literal
-from .._utils import AnyRandom, NeighborsView
+from .._utils import AnyRandom, _choose_graph
 
 
 _LAYOUTS = ('fr', 'drl', 'kk', 'grid_fr', 'lgl', 'rt', 'rt_circular', 'fa')
@@ -25,6 +25,7 @@ def draw_graph(
     adjacency: Optional[spmatrix] = None,
     key_added_ext: Optional[str] = None,
     neighbors_key: Optional[str] = None,
+    obsp_key: Optional[str] = None,
     copy: bool = False,
     **kwds,
 ):
@@ -64,8 +65,7 @@ def draw_graph(
         For layouts with random initialization like 'fr', change this to use
         different intial states for the optimization. If `None`, no seed is set.
     adjacency
-        Sparse adjacency matrix of the graph, defaults to
-        `adata.uns['neighbors']['connectivities']`.
+        Sparse adjacency matrix of the graph, defaults to neighbors connectivities.
     key_added_ext
         By default, append `layout`.
     proceed
@@ -79,6 +79,9 @@ def draw_graph(
         (default storage place for pp.neighbors).
         If specified, draw_graph looks
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
+    obsp_key
+        Use .obsp[obsp_key] as adjacency. You can't specify both
+        obsp_key and neighbors_key at the same time.
     copy
         Return a copy instead of writing to adata.
     **kwds
@@ -99,13 +102,8 @@ def draw_graph(
     if layout not in _LAYOUTS:
         raise ValueError(f'Provide a valid layout, one of {_LAYOUTS}.')
     adata = adata.copy() if copy else adata
-    if adjacency is None and 'neighbors' not in adata.uns:
-        raise ValueError(
-            'You need to run `pp.neighbors` first to compute a neighborhood graph.'
-        )
     if adjacency is None:
-        neighbors = NeighborsView(adata, neighbors_key)
-        adjacency = neighbors['connectivities']
+        adjacency = _choose_graph(adata, obsp_key, neighbors_key)
     # init coordinates
     if init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -74,6 +74,11 @@ def draw_graph(
         `'paga'`/`True`, `None`/`False`, or any valid 2d-`.obsm` key.
         Use precomputed coordinates for initialization.
         If `False`/`None` (the default), initialize randomly.
+    neighbors_key
+        If not specified, draw_graph looks .obsp['connectivities'] for connectivities
+        (default storage place for pp.neighbors).
+        If specified, draw_graph looks
+        .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
     copy
         Return a copy instead of writing to adata.
     **kwds

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -163,7 +163,7 @@ def draw_graph(
     else:
         # igraph doesn't use numpy seed
         random.seed(random_state)
-        
+
         g = _utils.get_igraph_from_adjacency(adjacency)
         if layout in {'fr', 'drl', 'kk', 'grid_fr'}:
             ig_layout = g.layout(layout, seed=init_coords.tolist(), **kwds)

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -109,7 +109,10 @@ def draw_graph(
         init_coords = adata.obsm[init_pos]
     elif init_pos == 'paga' or init_pos:
         init_coords = get_init_pos_from_paga(
-            adata, adjacency, random_state=random_state, neighbors_key=neighbors_key
+            adata, adjacency,
+            random_state=random_state,
+            neighbors_key=neighbors_key,
+            obsp=obsp
         )
     else:
         np.random.seed(random_state)

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -8,7 +8,7 @@ from .. import _utils
 from .. import logging as logg
 from ._utils import get_init_pos_from_paga
 from .._compat import Literal
-from .._utils import AnyRandom
+from .._utils import AnyRandom, NeighborsView
 
 
 _LAYOUTS = ('fr', 'drl', 'kk', 'grid_fr', 'lgl', 'rt', 'rt_circular', 'fa')
@@ -24,6 +24,7 @@ def draw_graph(
     n_jobs: Optional[int] = None,
     adjacency: Optional[spmatrix] = None,
     key_added_ext: Optional[str] = None,
+    neighbors_key: Optional[str] = None,
     copy: bool = False,
     **kwds,
 ):
@@ -98,13 +99,14 @@ def draw_graph(
             'You need to run `pp.neighbors` first to compute a neighborhood graph.'
         )
     if adjacency is None:
-        adjacency = adata.uns['neighbors']['connectivities']
+        neighbors = NeighborsView(adata, neighbors_key)
+        adjacency = neighbors['connectivities']
     # init coordinates
     if init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]
     elif init_pos == 'paga' or init_pos:
         init_coords = get_init_pos_from_paga(
-            adata, adjacency, random_state=random_state
+            adata, adjacency, random_state=random_state, neighbors_key=neighbors_key
         )
     else:
         np.random.seed(random_state)

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -70,6 +70,13 @@ def ingest(
     labeling_method
         The method to map labels in `adata_ref.obs` to `adata.obs`.
         The only supported value is 'knn'.
+    neighbors_key
+        If not specified, ingest looks adata_ref.uns['neighbors']
+        for neighbors settings and adata_ref.obsp['distances'] for
+        distances (default storage places for pp.neighbors).
+        If specified, ingest looks adata_ref.uns[neighbors_key] for
+        neighbors settings and adata_ref.obsp[neighbors_key+'_distances']
+        for distances.
     inplace
         Only works if `return_joint=False`.
         Add labels and embeddings to the passed `adata` (if `True`)

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -11,7 +11,7 @@ from anndata import AnnData
 from ..preprocessing._simple import N_PCS
 from ..neighbors import _rp_forest_generate
 from .. import logging as logg
-from .._utils import pkg_version
+from .._utils import pkg_version, NeighborsView
 
 ANNDATA_MIN_VERSION = version.parse("0.7rc1")
 
@@ -22,6 +22,7 @@ def ingest(
     obs: Optional[Union[str, Iterable[str]]] = None,
     embedding_method: Union[str, Iterable[str]] = ('umap', 'pca'),
     labeling_method: str = 'knn',
+    neighbors_key: Optional[str] = None,
     inplace: bool = True,
     **kwargs,
 ):
@@ -114,7 +115,7 @@ def ingest(
     if len(labeling_method) == 1 and len(obs or []) > 1:
         labeling_method = labeling_method * len(obs)
 
-    ing = Ingest(adata_ref)
+    ing = Ingest(adata_ref, neighbors_key)
     ing.fit(adata)
 
     for method in embedding_method:
@@ -181,7 +182,7 @@ class Ingest:
         from umap import UMAP
 
         self._umap = UMAP(
-            metric=adata.uns['neighbors']['params']['metric'],
+            metric=self._metric,
             random_state=adata.uns['umap']['params'].get('random_state', 0),
         )
 
@@ -189,10 +190,8 @@ class Ingest:
         self._umap._raw_data = self._rep
         self._umap._sparse_data = issparse(self._rep)
         self._umap._small_data = self._rep.shape[0] < 4096
-        self._umap._metric_kwds = adata.uns['neighbors']['params'].get(
-            'metric_kwds', {}
-        )
-        self._umap._n_neighbors = adata.uns['neighbors']['params']['n_neighbors']
+        self._umap._metric_kwds = self._metric_kwds
+        self._umap._n_neighbors = self._n_neighbors
         self._umap._initial_alpha = self._umap.learning_rate
 
         if self._random_init is not None or self._tree_init is not None:
@@ -250,35 +249,43 @@ class Ingest:
         self._initialise_search = _initialise_search
         self._search = _search
 
-    def _init_neighbors(self, adata):
+    def _init_neighbors(self, adata, neighbors_key):
         from umap.distances import named_distances
 
-        if 'use_rep' in adata.uns['neighbors']['params']:
-            self._use_rep = adata.uns['neighbors']['params']['use_rep']
+        neighbors = NeighborsView(adata, neighbors_key)
+
+        self._n_neighbors = neighbors['params']['n_neighbors']
+
+        if 'use_rep' in neighbors['params']:
+            self._use_rep = neighbors['params']['use_rep']
             self._rep = adata.X if self._use_rep == 'X' else adata.obsm[self._use_rep]
-        elif 'n_pcs' in adata.uns['neighbors']['params']:
+        elif 'n_pcs' in neighbors['params']:
             self._use_rep = 'X_pca'
-            self._n_pcs = adata.uns['neighbors']['params']['n_pcs']
+            self._n_pcs = neighbors['params']['n_pcs']
             self._rep = adata.obsm['X_pca'][:, : self._n_pcs]
         elif adata.n_vars > N_PCS and 'X_pca' in adata.obsm.keys():
             self._use_rep = 'X_pca'
             self._rep = adata.obsm['X_pca'][:, :N_PCS]
             self._n_pcs = self._rep.shape[1]
 
-        if 'metric_kwds' in adata.uns['neighbors']['params']:
-            dist_args = tuple(adata.uns['neighbors']['params']['metric_kwds'].values())
+        if 'metric_kwds' in neighbors['params']:
+            self._metric_kwds = neighbors['params']['metric_kwds']
+            dist_args = tuple(self._metric_kwds.values())
         else:
+            self._metric_kwds = {}
             dist_args = ()
-        dist_func = named_distances[adata.uns['neighbors']['params']['metric']]
+
+        self._metric = neighbors['params']['metric']
+        dist_func = named_distances[self._metric]
 
         self._init_search(dist_func, dist_args)
 
-        search_graph = adata.uns['neighbors']['distances'].copy()
+        search_graph = neighbors['distances'].copy()
         search_graph.data = (search_graph.data > 0).astype(np.int8)
         self._search_graph = search_graph.maximum(search_graph.transpose())
 
-        if 'rp_forest' in adata.uns['neighbors']:
-            self._rp_forest = _rp_forest_generate(adata.uns['neighbors']['rp_forest'])
+        if 'rp_forest' in neighbors:
+            self._rp_forest = _rp_forest_generate(neighbors['rp_forest'])
         else:
             self._rp_forest = None
 
@@ -294,7 +301,7 @@ class Ingest:
         else:
             self._pca_basis = adata.varm['PCs']
 
-    def __init__(self, adata):
+    def __init__(self, adata, neighbors_key=None):
         # assume rep is X if all initializations fail to identify it
         self._rep = adata.X
         self._use_rep = 'X'
@@ -307,8 +314,15 @@ class Ingest:
         if 'pca' in adata.uns:
             self._init_pca(adata)
 
-        if 'neighbors' in adata.uns:
-            self._init_neighbors(adata)
+        if neighbors_key is None:
+            neighbors_key = 'neighbors'
+
+        if neighbors_key in adata.uns:
+            self._init_neighbors(adata, neighbors_key)
+        else:
+            raise ValueError(
+                f'There is no neighbors data in `adata.uns["{neighbors_key}"]`.\n'
+                'Please run pp.neighbors.')
 
         if 'X_umap' in adata.obsm:
             self._init_umap(adata)

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -322,7 +322,8 @@ class Ingest:
         else:
             raise ValueError(
                 f'There is no neighbors data in `adata.uns["{neighbors_key}"]`.\n'
-                'Please run pp.neighbors.')
+                'Please run pp.neighbors.'
+            )
 
         if 'X_umap' in adata.obsm:
             self._init_umap(adata)

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -75,8 +75,8 @@ def ingest(
         for neighbors settings and adata_ref.obsp['distances'] for
         distances (default storage places for pp.neighbors).
         If specified, ingest looks adata_ref.uns[neighbors_key] for
-        neighbors settings and adata_ref.obsp[neighbors_key+'_distances']
-        for distances.
+        neighbors settings and
+        adata_ref.obsp[adata_ref.uns[neighbors_key]['distances_key']] for distances.
     inplace
         Only works if `return_joint=False`.
         Add labels and embeddings to the passed `adata` (if `True`)

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -30,6 +30,7 @@ def leiden(
     use_weights: bool = True,
     n_iterations: int = -1,
     partition_type: Optional[Type[MutableVertexPartition]] = None,
+    neighbors_key: Optional[str] = None,
     copy: bool = False,
     **partition_kwargs,
 ) -> Optional[AnnData]:
@@ -103,12 +104,15 @@ def leiden(
     adata = adata.copy() if copy else adata
     # are we clustering a user-provided graph or the default AnnData one?
     if adjacency is None:
-        if 'neighbors' not in adata.uns:
+        if neighbors_key is None:
+            neighbors_key = 'neighbors'
+        if neighbors_key not in adata.uns:
             raise ValueError(
                 'You need to run `pp.neighbors` first '
                 'to compute a neighborhood graph.'
             )
-        adjacency = adata.uns['neighbors']['connectivities']
+        neighbors = _utils.NeighborsView(adata, neighbors_key)
+        adjacency = neighbors['connectivities']
     if restrict_to is not None:
         restrict_key, restrict_categories = restrict_to
         adjacency, restrict_indices = restrict_adjacency(

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -31,7 +31,7 @@ def leiden(
     n_iterations: int = -1,
     partition_type: Optional[Type[MutableVertexPartition]] = None,
     neighbors_key: Optional[str] = None,
-    obsp_key: Optional[str] = None,
+    obsp: Optional[str] = None,
     copy: bool = False,
     **partition_kwargs,
 ) -> Optional[AnnData]:
@@ -83,9 +83,9 @@ def leiden(
         (default storage place for pp.neighbors).
         If specified, leiden looks
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
-    obsp_key
-        Use .obsp[obsp_key] as adjacency. You can't specify both
-        obsp_key and neighbors_key at the same time.
+    obsp
+        Use .obsp[obsp] as adjacency. You can't specify both
+        `obsp` and `neighbors_key` at the same time.
     copy
         Whether to copy `adata` or modify it inplace.
     **partition_kwargs
@@ -113,7 +113,7 @@ def leiden(
     adata = adata.copy() if copy else adata
     # are we clustering a user-provided graph or the default AnnData one?
     if adjacency is None:
-        adjacency = _utils._choose_graph(adata, obsp_key, neighbors_key)
+        adjacency = _utils._choose_graph(adata, obsp, neighbors_key)
     if restrict_to is not None:
         restrict_key, restrict_categories = restrict_to
         adjacency, restrict_indices = restrict_adjacency(

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -77,6 +77,11 @@ def leiden(
         Defaults to :class:`~leidenalg.RBConfigurationVertexPartition`.
         For the available options, consult the documentation for
         :func:`~leidenalg.find_partition`.
+    neighbors_key
+        If not specified, leiden looks .obsp['connectivities'] for connectivities
+        (default storage place for pp.neighbors).
+        If specified, leiden looks
+        .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
     copy
         Whether to copy `adata` or modify it inplace.
     **partition_kwargs

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -77,6 +77,11 @@ def louvain(
     partition_kwargs
         Key word arguments to pass to partitioning,
         if ``vtraag`` method is being used.
+    neighbors_key
+        If not specified, louvain looks .obsp['connectivities'] for connectivities
+        (default storage place for pp.neighbors).
+        If specified, louvain looks
+        .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
     copy
         Copy adata or modify it inplace.
 

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -10,7 +10,7 @@ from scipy.sparse import spmatrix
 from ._utils_clustering import rename_groups, restrict_adjacency
 from .. import _utils, logging as logg
 from .._compat import Literal
-from .._utils import NeighborsView
+from .._utils import _choose_graph
 
 try:
     from louvain.VertexPartition import MutableVertexPartition
@@ -32,6 +32,7 @@ def louvain(
     partition_type: Optional[Type[MutableVertexPartition]] = None,
     partition_kwargs: Mapping[str, Any] = MappingProxyType({}),
     neighbors_key: Optional[str] = None,
+    obsp_key: Optional[str] = None,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -62,8 +63,7 @@ def louvain(
     key_added
         Key under which to add the cluster labels. (default: ``'louvain'``)
     adjacency
-        Sparse adjacency matrix of the graph, defaults to
-        ``adata.uns['neighbors']['connectivities']``.
+        Sparse adjacency matrix of the graph, defaults to neighbors connectivities.
     flavor
         Choose between to packages for computing the clustering.
         ``'vtraag'`` is much more powerful, and the default.
@@ -78,10 +78,14 @@ def louvain(
         Key word arguments to pass to partitioning,
         if ``vtraag`` method is being used.
     neighbors_key
+        Use neighbors connectivities as adjacency.
         If not specified, louvain looks .obsp['connectivities'] for connectivities
         (default storage place for pp.neighbors).
         If specified, louvain looks
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
+    obsp_key
+        Use .obsp[obsp_key] as adjacency. You can't specify both
+        obsp_key and neighbors_key at the same time.
     copy
         Copy adata or modify it inplace.
 
@@ -105,16 +109,8 @@ def louvain(
             'when `flavour` is "vtraag"'
         )
     adata = adata.copy() if copy else adata
-    if neighbors_key is None:
-        neighbors_key = 'neighbors'
-    if adjacency is None and neighbors_key not in adata.uns:
-        raise ValueError(
-            'You need to run `pp.neighbors` first '
-            'to compute a neighborhood graph.'
-        )
     if adjacency is None:
-        neighbors = NeighborsView(adata, neighbors_key)
-        adjacency = neighbors['connectivities']
+        adjacency = _choose_graph(adata, obsp_key, neighbors_key)
     if restrict_to is not None:
         restrict_key, restrict_categories = restrict_to
         adjacency, restrict_indices = restrict_adjacency(

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -32,7 +32,7 @@ def louvain(
     partition_type: Optional[Type[MutableVertexPartition]] = None,
     partition_kwargs: Mapping[str, Any] = MappingProxyType({}),
     neighbors_key: Optional[str] = None,
-    obsp_key: Optional[str] = None,
+    obsp: Optional[str] = None,
     copy: bool = False,
 ) -> Optional[AnnData]:
     """\
@@ -83,9 +83,9 @@ def louvain(
         (default storage place for pp.neighbors).
         If specified, louvain looks
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
-    obsp_key
-        Use .obsp[obsp_key] as adjacency. You can't specify both
-        obsp_key and neighbors_key at the same time.
+    obsp
+        Use .obsp[obsp] as adjacency. You can't specify both
+        `obsp` and `neighbors_key` at the same time.
     copy
         Copy adata or modify it inplace.
 
@@ -110,7 +110,7 @@ def louvain(
         )
     adata = adata.copy() if copy else adata
     if adjacency is None:
-        adjacency = _choose_graph(adata, obsp_key, neighbors_key)
+        adjacency = _choose_graph(adata, obsp, neighbors_key)
     if restrict_to is not None:
         restrict_key, restrict_categories = restrict_to
         adjacency, restrict_indices = restrict_adjacency(

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -8,7 +8,7 @@ from ._utils import get_init_pos_from_paga, _choose_representation
 from .. import logging as logg
 from .._settings import settings
 from .._compat import Literal
-from .._utils import AnyRandom
+from .._utils import AnyRandom, NeighborsView
 
 
 _InitPos = Literal['paga', 'spectral', 'random']
@@ -28,7 +28,8 @@ def umap(
     a: Optional[float] = None,
     b: Optional[float] = None,
     copy: bool = False,
-    method: Literal['umap', 'rapids'] = 'umap'
+    method: Literal['umap', 'rapids'] = 'umap',
+    neighbors_key: Optional[str] = None,
 ) -> Optional[AnnData]:
     """\
     Embed the neighborhood graph using UMAP [McInnes18]_.
@@ -108,13 +109,20 @@ def umap(
         UMAP coordinates of data.
     """
     adata = adata.copy() if copy else adata
-    if 'neighbors' not in adata.uns:
+
+    if neighbors_key is None:
+        neighbors_key = 'neighbors'
+
+    if neighbors_key not in adata.uns:
         raise ValueError(
-            'Did not find \'neighbors/connectivities\'. Run `sc.pp.neighbors` first.')
+            f'Did not find .uns["{neighbors_key}"]. Run `sc.pp.neighbors` first.')
     start = logg.info('computing UMAP')
-    if ('params' not in adata.uns['neighbors']
-        or adata.uns['neighbors']['params']['method'] != 'umap'):
-        logg.warning('neighbors/connectivities have not been computed using umap')
+
+    neighbors = NeighborsView(adata, neighbors_key)
+
+    if ('params' not in neighbors
+        or neighbors['params']['method'] != 'umap'):
+        logg.warning(f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap')
     from umap.umap_ import find_ab_params, simplicial_set_embedding
     if a is None or b is None:
         a, b = find_ab_params(spread, min_dist)
@@ -125,7 +133,7 @@ def umap(
     if isinstance(init_pos, str) and init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]
     elif isinstance(init_pos, str) and init_pos == 'paga':
-        init_coords = get_init_pos_from_paga(adata, random_state=random_state)
+        init_coords = get_init_pos_from_paga(adata, random_state=random_state, neighbors_key=neighbors_key)
     else:
         init_coords = init_pos  # Let umap handle it
     if hasattr(init_coords, "dtype"):
@@ -135,7 +143,7 @@ def umap(
         adata.uns['umap']['params']['random_state'] = random_state
     random_state = check_random_state(random_state)
 
-    neigh_params = adata.uns['neighbors']['params']
+    neigh_params = neighbors['params']
     X = _choose_representation(
         adata, neigh_params.get('use_rep', None), neigh_params.get('n_pcs', None), silent=True)
     if method == 'umap':
@@ -144,7 +152,7 @@ def umap(
         n_epochs = 0 if maxiter is None else maxiter
         X_umap = simplicial_set_embedding(
             X,
-            adata.uns['neighbors']['connectivities'].tocoo(),
+            neighbors['connectivities'].tocoo(),
             n_components,
             alpha,
             a,
@@ -166,7 +174,7 @@ def umap(
                 "but umap `method` 'rapids' only supports the 'euclidean' metric."
             )
         from cuml import UMAP
-        n_neighbors = adata.uns['neighbors']['params']['n_neighbors']
+        n_neighbors = neighbors['params']['n_neighbors']
         n_epochs = 500 if maxiter is None else maxiter # 0 is not a valid value for rapids, unlike original umap
         X_contiguous = np.ascontiguousarray(X, dtype=np.float32)
         umap = UMAP(

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -100,7 +100,13 @@ def umap(
         Return a copy instead of writing to adata.
     method
         Use the original 'umap' implementation, or 'rapids' (experimental, GPU only)
-
+    neighbors_key
+        If not specified, umap looks .uns['neighbors'] for neighbors settings
+        and .obsp['connectivities'] for connectivities
+        (default storage places for pp.neighbors).
+        If specified, umap looks .uns[neighbors_key] for neighbors settings and
+        .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
+    
     Returns
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -106,7 +106,7 @@ def umap(
         (default storage places for pp.neighbors).
         If specified, umap looks .uns[neighbors_key] for neighbors settings and
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
-    
+
     Returns
     -------
     Depending on `copy`, returns or updates `adata` with the following fields.

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -5,7 +5,7 @@ from .. import logging as logg
 from ._pca import pca
 from ..preprocessing._simple import N_PCS
 from .. import settings
-from .._utils import NeighborsView
+from .._utils import _choose_graph
 
 doc_use_rep = """\
 use_rep
@@ -91,11 +91,10 @@ def preprocess_with_pca(adata, n_pcs: Optional[int] = None, random_state=0):
             return adata.X
 
 
-def get_init_pos_from_paga(adata, adjacency=None, random_state=0, neighbors_key=None):
+def get_init_pos_from_paga(adata, adjacency=None, random_state=0, neighbors_key=None, obsp=None):
     np.random.seed(random_state)
     if adjacency is None:
-        neighbors = NeighborsView(adata, neighbors_key)
-        adjacency = neighbors['connectivities']
+        adjacency = _choose_graph(adata, obsp, neighbors_key)
     if 'paga' in adata.uns and 'pos' in adata.uns['paga']:
         groups = adata.obs[adata.uns['paga']['groups']]
         pos = adata.uns['paga']['pos']

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -5,6 +5,7 @@ from .. import logging as logg
 from ._pca import pca
 from ..preprocessing._simple import N_PCS
 from .. import settings
+from .._utils import NeighborsView
 
 doc_use_rep = """\
 use_rep
@@ -90,10 +91,11 @@ def preprocess_with_pca(adata, n_pcs: Optional[int] = None, random_state=0):
             return adata.X
 
 
-def get_init_pos_from_paga(adata, adjacency=None, random_state=0):
+def get_init_pos_from_paga(adata, adjacency=None, random_state=0, neighbors_key=None):
     np.random.seed(random_state)
     if adjacency is None:
-        adjacency = adata.uns['neighbors']['connectivities']
+        neighbors = NeighborsView(adata, neighbors_key)
+        adjacency = neighbors['connectivities']
     if 'paga' in adata.uns and 'pos' in adata.uns['paga']:
         groups = adata.obs[adata.uns['paga']['groups']]
         pos = adata.uns['paga']['pos']


### PR DESCRIPTION
It is now possible to have several neighbors graphs in adata.

For example,

```py
sc.pp.neighbors(adata)
sc.pp.neighbors(adata, use_rep='some', key_added='test')
sc.pp.neighbors(adata, use_rep='some1', key_added='test1')
sc.pp.neighbors(adata, key_added='test2')

sc.tl.umap(adata, neighbors_key='test')
sc.tl.diffmap(adata, neighbors_key='test1')
```

and so on.