### PR TITLE
Print info about the real number of control genes in scoring function

### DIFF
--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -156,8 +156,8 @@ def score_genes(
         time=start,
         deep=(
             'added\n'
-            f'    {score_name!r}, score of gene set (adata.obs)'
-            f'\n{len(control_genes)} total control genes are used as baseline.'
+            f'    {score_name!r}, score of gene set (adata.obs).\n'
+            f'    {len(control_genes)} total control genes are used.'
         ),
     )
     return adata if copy else None

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -157,6 +157,7 @@ def score_genes(
         deep=(
             'added\n'
             f'    {score_name!r}, score of gene set (adata.obs)'
+            f'\n{len(control_genes)} total control genes are used as baseline.'
         ),
     )
     return adata if copy else None

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -39,7 +39,7 @@ def score_genes(
     gene_list
         The list of gene names used for score calculation.
     ctrl_size
-        Number of reference genes to be sampled. If `len(gene_list)` is not too
+        Number of reference genes to be sampled from each bin. If `len(gene_list)` is not too
         low, you can set `ctrl_size=len(gene_list)`.
     gene_pool
         Genes for sampling the reference set. Default is all genes.


### PR DESCRIPTION
Since we sample ctrl_size many genes from each bin, total number of genes is a function of n_bins and ctrl_size but total number, but hard to calculate since multiple genes can fall into the same bin. This PR just prints total number of control genes to inform the user.