### PR TITLE
Fix `n_pcs` usage if `use_rep=='X_pca'`

### DIFF
--- a/scanpy/tests/test_neighbors.py
+++ b/scanpy/tests/test_neighbors.py
@@ -3,6 +3,7 @@ import pytest
 from anndata import AnnData
 from scipy.sparse import csr_matrix
 
+import scanpy as sc
 from scanpy import Neighbors
 
 # the input data
@@ -141,6 +142,16 @@ def test_metrics_argument():
     no_knn_manhattan.compute_neighbors(method="gauss", knn=False,
         n_neighbors=n_neighbors, metric="manhattan")
     assert not np.allclose(no_knn_euclidean.distances, no_knn_manhattan.distances)
+
+
+def test_use_rep_argument():
+    adata = AnnData(np.random.randn(30, 300))
+    sc.pp.pca(adata)
+    neigh_pca = Neighbors(adata)
+    neigh_pca.compute_neighbors(n_pcs=5, use_rep='X_pca')
+    neigh_none = Neighbors(adata)
+    neigh_none.compute_neighbors(n_pcs=5, use_rep=None)
+    assert np.allclose(neigh_pca.distances.toarray(), neigh_none.distances.toarray())
 
 
 @pytest.mark.parametrize('conv', [csr_matrix.toarray, csr_matrix])

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -49,12 +49,15 @@ def _choose_representation(adata, use_rep=None, n_pcs=None, silent=False):
     else:
         if use_rep in adata.obsm.keys():
             X = adata.obsm[use_rep]
+            if use_rep == 'X_pca' and n_pcs is not None:
+                X = adata.obsm[use_rep][:, :n_pcs]            
         elif use_rep == 'X':
             X = adata.X
         else:
             raise ValueError(
                 'Did not find {} in `.obsm.keys()`. '
                 'You need to compute it first.'.format(use_rep))
+        
     settings.verbosity = verbosity  # resetting verbosity
     return X
 

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -50,14 +50,13 @@ def _choose_representation(adata, use_rep=None, n_pcs=None, silent=False):
         if use_rep in adata.obsm.keys():
             X = adata.obsm[use_rep]
             if use_rep == 'X_pca' and n_pcs is not None:
-                X = adata.obsm[use_rep][:, :n_pcs]            
+                X = adata.obsm[use_rep][:, :n_pcs]
         elif use_rep == 'X':
             X = adata.X
         else:
             raise ValueError(
                 'Did not find {} in `.obsm.keys()`. '
                 'You need to compute it first.'.format(use_rep))
-        
     settings.verbosity = verbosity  # resetting verbosity
     return X
 


### PR DESCRIPTION
Currently
```
sc.pp.pca(adata, n_comps=50)
neighbors = sc.Neighbors(adata)
neighbors.compute_neighbors(n_pcs=30, use_rep='X_pca')
```
and 
```
sc.pp.pca(adata, n_comps=50)
neighbors = sc.Neighbors(adata)
neighbors.compute_neighbors(n_pcs=30, use_rep=None)
```
yield different results, because the former uses all 50 PCs while the latter uses the user-defined 30 PCs.

Now, both ways, it accounts for the user-defined 30 PCs.