### PR TITLE
Use tqdm instead of tqdm.auto when downloading datasets

### DIFF
--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -5,7 +5,6 @@ import warnings
 import numpy as np
 import pandas as pd
 from anndata import AnnData
-from tqdm.auto import tqdm
 
 from .. import logging as logg, _utils
 from .._compat import Literal

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -890,7 +890,11 @@ def _get_filename_from_key(key, ext=None) -> Path:
 
 
 def _download(url: str, path: Path):
-    from tqdm import tqdm
+    try:
+        import ipywidgets
+        from tqdm.auto import tqdm
+    except ModuleNotFoundError:
+        from tqdm import tqdm
     from urllib.request import urlretrieve
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -890,7 +890,7 @@ def _get_filename_from_key(key, ext=None) -> Path:
 
 
 def _download(url: str, path: Path):
-    from tqdm.auto import tqdm
+    from tqdm import tqdm
     from urllib.request import urlretrieve
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         ],
         test=[
             'pytest>=4.4',
-            'dask[array]',
+            'dask[array]!=2.17.0',
             'fsspec',
             'zappy',
             'zarr',


### PR DESCRIPTION
Using the progress bar from tqdm.auto causes a `ImportError` when `ipywidgets` is not installed. 
The progressbar from the top level `tqdm` module does not have this dependency. 

Repex: 

```python
import scanpy as sc
sc.datasets.moignard15()
```

Output: 
```
---------------------------------------------------------------------------
NameError                                 Traceback (most recent call last)
~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/tqdm/notebook.py in status_printer(_, total, desc, ncols)
     97             else:  # No total? Show info style bar with no progress tqdm status
---> 98                 pbar = IProgress(min=0, max=1)
     99                 pbar.value = 1

NameError: name 'IProgress' is not defined

During handling of the above exception, another exception occurred:

ImportError                               Traceback (most recent call last)
<ipython-input-5-ec5b1e8cd660> in <module>
----> 1 sc.datasets.moignard15()

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/scanpy/datasets/__init__.py in moignard15()
    108     filename = settings.datasetdir / 'moignard15/nbt.3154-S3.xlsx'
    109     backup_url = 'http://www.nature.com/nbt/journal/v33/n3/extref/nbt.3154-S3.xlsx'
--> 110     adata = sc.read(filename, sheet='dCt_values.txt', backup_url=backup_url)
    111     # filter out 4 genes as in Haghverdi et al. (2016)
    112     gene_subset = ~np.in1d(adata.var_names, ['Eif2b1', 'Mrpl19', 'Polr2a', 'Ubc'])

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/scanpy/readwrite.py in read(filename, backed, sheet, ext, delimiter, first_column_names, backup_url, cache, **kwargs)
     92     filename = Path(filename)  # allow passing strings
     93     if is_valid_filename(filename):
---> 94         return _read(
     95             filename, backed=backed, sheet=sheet, ext=ext,
     96             delimiter=delimiter, first_column_names=first_column_names,

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/scanpy/readwrite.py in _read(filename, backed, sheet, ext, delimiter, first_column_names, backup_url, cache, suppress_cache_warning, **kwargs)
    489     else:
    490         ext = is_valid_filename(filename, return_ext=True)
--> 491     is_present = check_datafile_present_and_download(
    492         filename,
    493         backup_url=backup_url,

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/scanpy/readwrite.py in check_datafile_present_and_download(path, backup_url)
    745         path.parent.mkdir(parents=True)
    746 
--> 747     download(backup_url, path)
    748     return True
    749 

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/scanpy/readwrite.py in download(url, path)
    722 
    723     path.parent.mkdir(parents=True, exist_ok=True)
--> 724     with tqdm(unit='B', unit_scale=True, miniters=1, desc=path.name) as t:
    725         def update_to(b=1, bsize=1, tsize=None):
    726             if tsize is not None:

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/tqdm/notebook.py in __init__(self, *args, **kwargs)
    206         unit_scale = 1 if self.unit_scale is True else self.unit_scale or 1
    207         total = self.total * unit_scale if self.total else self.total
--> 208         self.container = self.status_printer(
    209             self.fp, total, self.desc, self.ncols)
    210         self.sp = self.display

~/anaconda3/envs/test_scanpy/lib/python3.8/site-packages/tqdm/notebook.py in status_printer(_, total, desc, ncols)
    101         except NameError:
    102             # #187 #451 #558
--> 103             raise ImportError(
    104                 "FloatProgress not found. Please update jupyter and ipywidgets."
    105                 " See https://ipywidgets.readthedocs.io/en/stable"

ImportError: FloatProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html
```