### PR TITLE
More flexible umap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ exclude = '''
         _dpt
         |_sim
         |_paga
-        |_umap
         |_utils
         |_leiden
         |_louvain

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -111,6 +111,9 @@ def umap(
         (default storage places for pp.neighbors).
         If specified, umap looks .uns[neighbors_key] for neighbors settings and
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
+    obsp
+        Key in obsp for connectivity graph. Cannot be specified at the same time
+        as neighbors_key.
     key_added
         What key in obsm should the embedding be placed in?
 

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -143,7 +143,7 @@ def umap(
     else:
         a = a
         b = b
-    adata.uns['umap'] = {'params': {'a': a, 'b': b}}
+    umap_params = {'a': a, 'b': b}
 
     if isinstance(init_pos, str) and init_pos in adata.obsm.keys():
         init_coords = adata.obsm[init_pos]
@@ -157,7 +157,7 @@ def umap(
         init_coords = check_array(init_coords, dtype=np.float32, accept_sparse=False)
 
     if isinstance(random_state, Number):
-        adata.uns['umap']['params']['random_state'] = random_state
+        umap_params['random_state'] = random_state
     random_state = check_random_state(random_state)
 
     neigh_params = neighbors['params'] if 'params' in neighbors else {}
@@ -216,6 +216,10 @@ def umap(
         )
         X_umap = umap.fit_transform(X_contiguous)
     adata.obsm[key_added] = X_umap  # annotate samples with UMAP coordinates
+    adata.uns["umap"] = {
+        "params": umap_params,
+        "obsm_key": key_added,
+    }
     logg.info(
         '    finished',
         time=start,


### PR DESCRIPTION
This PR lets user choose the connectivity matrix passed to UMAP for layout.

Two arguments have been added to the umap function for this:

* `obsp` for specifying the connectivity matrix in `obsp`
* `key_added` for choosing the key name in `obsm`

Still need to reorganize the arguments for `sc.tl.umap` so the more used ones are documented first.