### PR TITLE
add robust installation instructions again

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,13 +6,12 @@ Anaconda
 If you do not have a working installation of Python 3.6 (or later), consider
 installing Miniconda_ (see `Installing Miniconda`_). Then run::
 
-    conda install -c bioconda scanpy
+    conda install seaborn scikit-learn statsmodels numba pytables
+    conda install -c conda-forge python-igraph leiden	
 
-Install the Leiden clustering package [Traag18]_ (improved Louvain clustering) via::
+Pull Scanpy from `PyPI <https://pypi.org/project/scanpy>`__ (consider using ``pip3`` to access Python 3)::
 
-    conda install -c conda-forge leidenalg
-
-Alternatively, you might want to pull Scanpy `from PyPI`_.
+    pip install scanpy
 
 .. _from PyPI: https://pypi.org/project/scanpy
 


### PR DESCRIPTION
These were removed in https://github.com/theislab/scanpy/commit/fddb710258b816629f8c8feb9c01f2b75b8a6ebf#diff-548eb9ce4cac8e13a1238ad703272931.