### PR TITLE
Getters and setters for X

### DIFF
--- a/docs/extensions/param_police.py
+++ b/docs/extensions/param_police.py
@@ -36,8 +36,9 @@ def show_param_warnings(app, exception):
             file_name,
             line,
         )
-    if param_warnings:
-        raise RuntimeError('Encountered text parameter type. Use annotations.')
+    # TODO: Figure out with @flying-sheep what to do about these
+    # if param_warnings:
+    #     raise RuntimeError('Encountered text parameter type. Use annotations.')
 
 
 def setup(app: Sphinx):

--- a/docs/extensions/param_police.py
+++ b/docs/extensions/param_police.py
@@ -36,9 +36,8 @@ def show_param_warnings(app, exception):
             file_name,
             line,
         )
-    # TODO: Figure out with @flying-sheep what to do about these
-    # if param_warnings:
-    #     raise RuntimeError('Encountered text parameter type. Use annotations.')
+    if param_warnings:
+        raise RuntimeError('Encountered text parameter type. Use annotations.')
 
 
 def setup(app: Sphinx):

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -169,6 +169,19 @@ def _doc_params(**kwds):
     return dec
 
 
+def _check_array_function_arguments(**kwargs):
+    """Checks for invalid arguments when an array is passed.
+
+    Helper for functions that work on either AnnData objects or array-likes.
+    """
+    # TODO: Figure out a better solution for documenting dispatched functions
+    invalid_args = [k for k, v in kwargs.items() if v is not None]
+    if len(invalid_args) > 0:
+        raise TypeError(
+            f"Arguments {invalid_args} are only valid if an AnnData object is passed."
+        )
+
+
 # --------------------------------------------------------------------------------
 # Graph stuff
 # --------------------------------------------------------------------------------

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -17,7 +17,7 @@ from anndata import AnnData
 
 from .. import logging as logg
 from .._settings import settings as sett
-from .._utils import sanitize_anndata, deprecated_arg_names, view_to_actual, AnyRandom
+from .._utils import sanitize_anndata, deprecated_arg_names, view_to_actual, AnyRandom, _check_array_function_arguments
 from .._compat import Literal
 from ..get import _get_obs_rep, _set_obs_rep
 from ._distributed import materialize_as_ndarray
@@ -256,6 +256,10 @@ def log1p(
     *,
     base: Optional[Number] = None,
     copy: bool = False,
+    chunked: bool = None,
+    chunk_size: Optional[int] = None,
+    layer: Optional[str] = None,
+    obsm: Optional[str] = None,
 ):
     """\
     Logarithmize the data matrix.
@@ -273,20 +277,23 @@ def log1p(
     copy
         If an :class:`~anndata.AnnData` is passed, determines whether a copy
         is returned.
-    chunked : `bool` (default: `False`)
+    chunked
         Process the data matrix in chunks, which will save memory.
         Applies only to :class:`~anndata.AnnData`.
-    chunk_size : `Optional[int]`
+    chunk_size
         `n_obs` of the chunks to process the data in.
-    layer : `Optional[str]`
+    layer
         Entry of layers to tranform.
-    obsm : `Optional[str]`
+    obsm
         Entry of obsm to transform.
 
     Returns
     -------
     Returns or updates `data`, depending on `copy`.
     """
+    _check_array_function_arguments(
+        chunked=chunked, chunk_size=chunk_size, layer=layer, obsm=obsm
+    )
     return log1p_array(X, copy=copy, base=base)
 
 
@@ -711,6 +718,8 @@ def scale(
     zero_center: bool = True,
     max_value: Optional[float] = None,
     copy: bool = False,
+    layer: Optional[str] = None,
+    obsm: Optional[str] = None,
 ):
     """\
     Scale data to unit variance and zero mean.
@@ -733,9 +742,9 @@ def scale(
     copy
         Whether this function should be performed inplace. If an AnnData object
         is passed, this also determines if a copy is returned.
-    layer : Optional[str]
+    layer
         If provided, which element of layers to scale.
-    obsm : Optional[str]
+    obsm
         If provided, which element of obsm to scale.
 
     Returns
@@ -743,7 +752,8 @@ def scale(
     Depending on `copy` returns or updates `adata` with a scaled `adata.X`,
     annotated with `'mean'` and `'std'` in `adata.var`.
     """
-    return scale_array(X, zero_center=zero_center, max_value=max_value, copy=copy)
+    _check_array_function_arguments(layer=layer, obsm=obsm)
+    return scale_array(data, zero_center=zero_center, max_value=max_value, copy=copy)
 
 
 @scale.register(np.ndarray)

--- a/scanpy/tests/helpers.py
+++ b/scanpy/tests/helpers.py
@@ -1,0 +1,69 @@
+"""
+This file contains helper functions for the scanpy test suite.
+"""
+
+import scanpy as sc
+import numpy as np
+
+from anndata.tests.helpers import asarray, assert_equal
+
+###########################
+# Representation choice
+###########################
+# These functions can be used to check that functions are correctly using arugments like `layers`, `obsm`, etc.
+
+
+def check_rep_mutation(func, X, **kwargs):
+    """Check that only the array meant to be modified is modified."""
+    adata = sc.AnnData(
+        X=X.copy(),
+        layers={"layer": X.copy()},
+        obsm={"obsm": X.copy()},
+        dtype=np.float64,
+    )
+    adata_X = func(adata, copy=True, **kwargs)
+    adata_layer = func(adata, layer="layer", copy=True, **kwargs)
+    adata_obsm = func(adata, obsm="obsm", copy=True, **kwargs)
+
+    assert np.array_equal(asarray(adata_X.X), asarray(adata_layer.layers["layer"]))
+    assert np.array_equal(asarray(adata_X.X), asarray(adata_obsm.obsm["obsm"]))
+
+    assert np.array_equal(asarray(adata_layer.X), asarray(adata_layer.obsm["obsm"]))
+    assert np.array_equal(asarray(adata_obsm.X), asarray(adata_obsm.layers["layer"]))
+    assert np.array_equal(
+        asarray(adata_X.layers["layer"]), asarray(adata_X.obsm["obsm"])
+    )
+
+
+def check_rep_results(func, X, **kwargs):
+    """Checks that the results of a computation add values/ mutate the anndata object in a consistent way."""
+    # Gen data
+    adata_X = sc.AnnData(
+        X=X.copy(),
+        layers={"layer": np.zeros(shape=X.shape, dtype=X.dtype)},
+        obsm={"obsm": np.zeros(shape=X.shape, dtype=X.dtype)},
+    )
+    adata_layer = sc.AnnData(
+        X=np.zeros(shape=X.shape, dtype=X.dtype),
+        layers={"layer": X.copy()},
+        obsm={"obsm": np.zeros(shape=X.shape, dtype=X.dtype)},
+    )
+    adata_obsm = sc.AnnData(
+        X=np.zeros(shape=X.shape, dtype=X.dtype),
+        layers={"layer": np.zeros(shape=X.shape, dtype=X.dtype)},
+        obsm={"obsm": X.copy()},
+    )
+
+    # Apply function
+    func(adata_X, **kwargs)
+    func(adata_layer, layer="layer", **kwargs)
+    func(adata_obsm, obsm="obsm", **kwargs)
+
+    # Reset X
+    adata_X.X = np.zeros(shape=X.shape, dtype=X.dtype)
+    adata_layer.layers["layer"] = np.zeros(shape=X.shape, dtype=X.dtype)
+    adata_obsm.obsm["obsm"] = np.zeros(shape=X.shape, dtype=X.dtype)
+
+    # Check equality
+    assert_equal(adata_X, adata_layer)
+    assert_equal(adata_X, adata_obsm)

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -9,6 +9,8 @@ import pytest
 from anndata import AnnData
 from anndata.tests.helpers import assert_equal, asarray
 
+from scanpy.tests.helpers import check_rep_mutation, check_rep_results
+
 
 def test_log1p(tmp_path):
     A = np.random.rand(200, 10)
@@ -28,6 +30,17 @@ def test_log1p(tmp_path):
     ad4 = AnnData(A)
     sc.pp.log1p(ad4, base=2)
     assert np.allclose(ad4.X, A_l/np.log(2))
+
+
+@pytest.fixture(params=[None, 2])
+def base(request):
+    return request.param
+
+
+def test_log1p_rep(count_matrix_format, base):
+    X = count_matrix_format(sp.random(100, 200, density=0.3).toarray())
+    check_rep_mutation(sc.pp.log1p, X, base=base)
+    check_rep_results(sc.pp.log1p, X, base=base)
 
 
 def test_mean_var_sparse():
@@ -123,27 +136,13 @@ def zero_center(request):
     return request.param
 
 
-def test_scale_loc(count_matrix_format, zero_center):
+def test_scale_rep(count_matrix_format, zero_center):
     """
     Test that it doesn't matter where the array being scaled is in the anndata object.
     """
     X = count_matrix_format(sp.random(100, 200, density=0.3).toarray())
-    adata = sc.AnnData(X=X.copy(), layers={"layer": X.copy()}, obsm={"obsm": X.copy()}, dtype=np.float64)
-    adata_X = sc.pp.scale(adata, zero_center=zero_center, copy=True)
-    adata_layer = sc.pp.scale(adata, zero_center=zero_center, layer="layer", copy=True)
-    adata_obsm = sc.pp.scale(adata, zero_center=zero_center, obsm="obsm", copy=True)
-
-    assert np.array_equal(asarray(adata_X.X), asarray(adata_layer.layers["layer"]))
-    assert np.array_equal(asarray(adata_X.X), asarray(adata_obsm.obsm["obsm"]))
-
-    assert np.array_equal(asarray(adata_layer.X), asarray(adata_layer.obsm["obsm"]))
-    assert np.array_equal(asarray(adata_obsm.X), asarray(adata_obsm.layers["layer"]))
-    assert np.array_equal(asarray(adata_X.layers["layer"]), asarray(adata_X.obsm["obsm"]))
-
-    assert np.array_equal(adata_X.var["mean"], adata_layer.var["mean"])
-    assert np.array_equal(adata_X.var["mean"], adata_obsm.var["mean"])
-    assert np.array_equal(adata_X.var["std"], adata_layer.var["std"])
-    assert np.array_equal(adata_X.var["std"], adata_obsm.var["std"])
+    check_rep_mutation(sc.pp.scale, X, zero_center=zero_center)
+    check_rep_results(sc.pp.scale, X, zero_center=zero_center)
 
 
 def test_scale_array(count_matrix_format, zero_center):

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
         l.strip() for l in Path('requirements.txt').read_text('utf-8').splitlines()
     ],
     extras_require=dict(
-        louvain=['python-igraph', 'louvain>=0.6'],
+        louvain=['python-igraph', 'louvain>=0.6,!=0.6.2'],
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
         rapids=['cudf>=0.9', 'cuml>=0.9', 'cugraph>=0.9'],


### PR DESCRIPTION
This PR adds some utilities for choosing which values to use for `X` inside scanpy functions. These utilities include a getter and setter for representations of the observations and some checks for testing these functions.

This approach has been applied to `sc.pp.scale` and `sc.pp.log1p` as demonstrations, and because that code was in need of a refactor. I think it results in cleaner code with more standardized behaviors.

The implementation of `sc.pp.scale` is just a hammered out version of what I commented here: https://github.com/theislab/scanpy/pull/1135#issuecomment-608200735

Still todo:

- [x] Figure out how documentation should work. In particular automatic documentation with type variables
- [x] Figure out tab completion for arguments not in the default/ fallback definition

This PR would:

* Close #1089
* Supercede #1135