### PR TITLE
Add link to Scanpy in R guide

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -70,6 +70,13 @@ See the `Seurat to AnnData`_ notebook for a tutorial on `anndata2ri`.
 
 .. _Seurat to AnnData: https://github.com/LuckyMD/Code_snippets/blob/master/Seurat_to_anndata.ipynb
 
+See the `Scanpy in R`_ guide for a tutorial on interacting with Scanpy from R.
+
+.. _Scanpy in R: https://theislab.github.io/scanpy-in-R/
+
+.. image:: https://github.com/theislab/scanpy-in-R/raw/master/logo.png
+   :width: 350px
+
 Regressing out cell cycle
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Hi

I have written a guide to interacting with Scanpy from R using the **{reticulate}** package which you can view at https://theislab.github.io/scanpy-in-R/.

This PR just adds a link to the guide to the tutorials page in the documentation.