### PR TITLE
update scvi version to 0.6.5

### DIFF
--- a/scanpy/external/pp/_scvi.py
+++ b/scanpy/external/pp/_scvi.py
@@ -5,7 +5,7 @@ import scipy as sp
 from typing import Optional, Sequence, Union
 from anndata import AnnData
 
-MIN_VERSION = "0.6.3"
+MIN_VERSION = "0.6.5"
 
 
 def scvi(

--- a/scanpy/tests/external/test_scvi.py
+++ b/scanpy/tests/external/test_scvi.py
@@ -9,7 +9,6 @@ from anndata import AnnData
 pytest.importorskip("scvi", minversion=sce.pp._scvi.MIN_VERSION)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 def test_scvi_linear():
     n_samples = 4
     n_genes = 7
@@ -39,7 +38,6 @@ def test_scvi_linear():
     assert set(adata.uns['ldvae_loadings'].index) == set(gene_subset)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 7), reason="requires python3.7 or higher")
 def test_scvi():
     n_samples = 4
     n_genes = 7

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         louvain=['python-igraph', 'louvain>=0.6,!=0.6.2'],
         leiden=['python-igraph', 'leidenalg'],
         bbknn=['bbknn'],
-        scvi=['scvi>=0.6.3'],
+        scvi=['scvi>=0.6.5'],
         rapids=['cudf>=0.9', 'cuml>=0.9', 'cugraph>=0.9'],
         magic=['magic-impute>=2.0'],
         doc=[


### PR DESCRIPTION
Updating scvi version to 0.6.5. It now supports Python 3.6.