### PR TITLE
Hide some FutureWarnings

### DIFF
--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from typing import Optional
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -235,7 +236,9 @@ def pbmc68k_reduced() -> AnnData:
     """
 
     filename = HERE / '10x_pbmc68k_reduced.h5ad'
-    return read(filename)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="anndata")
+        return read(filename)
 
 
 def pbmc3k() -> AnnData:
@@ -289,11 +292,12 @@ def pbmc3k_processed() -> AnnData:
     -------
     Annotated data matrix.
     """
-    adata = read(
-        settings.datasetdir / 'pbmc3k_processed.h5ad',
-        backup_url='https://raw.githubusercontent.com/chanzuckerberg/cellxgene/master/example-dataset/pbmc3k.h5ad',
-    )
-    return adata
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="anndata")
+        return read(
+            settings.datasetdir / 'pbmc3k_processed.h5ad',
+            backup_url='https://raw.githubusercontent.com/chanzuckerberg/cellxgene/master/example-dataset/pbmc3k.h5ad',
+        )
 
 
 def _download_visium_dataset(sample_id: str, base_dir: Optional[Path] = None):

--- a/scanpy/tests/test_datasets.py
+++ b/scanpy/tests/test_datasets.py
@@ -44,6 +44,16 @@ def test_pbmc3k(tmp_dataset_dir):
 
 
 @pytest.mark.internet
+def test_pbmc3k_processed(tmp_dataset_dir):
+    with pytest.warns(None) as records:
+        adata = sc.datasets.pbmc3k_processed()
+    assert adata.shape == (2638, 1838)
+    assert adata.raw.shape == (2638, 13714)
+
+    assert len(records) == 0
+
+
+@pytest.mark.internet
 def test_ebi_expression_atlas(tmp_dataset_dir):
     adata = sc.datasets.ebi_expression_atlas("E-MTAB-4888")
     assert adata.shape == (2315, 23852)
@@ -70,7 +80,9 @@ def test_toggleswitch():
 
 
 def test_pbmc68k_reduced():
-    sc.datasets.pbmc68k_reduced()
+    with pytest.warns(None) as records:
+        sc.datasets.pbmc68k_reduced()
+    assert len(records) == 0  # Test that loading a dataset does not warn
 
 
 @pytest.mark.internet

--- a/scanpy/tests/test_neighbors.py
+++ b/scanpy/tests/test_neighbors.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 import pytest
 from anndata import AnnData
@@ -159,6 +161,9 @@ def test_restore_n_neighbors(neigh, conv):
     neigh.compute_neighbors(method='gauss', n_neighbors=n_neighbors)
 
     ad = AnnData(np.array(X))
-    ad.uns['neighbors'] = dict(connectivities=conv(neigh.connectivities))
+    # Allow deprecated usage for now
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning, module="anndata")
+        ad.uns['neighbors'] = dict(connectivities=conv(neigh.connectivities))
     neigh_restored = Neighbors(ad)
     assert neigh_restored.n_neighbors == 1


### PR DESCRIPTION
This hides some FutureWarnings that are generated from moving neighbor graphs to obsp.