### PR TITLE
Bump scipy requirement to >1.4

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -11,7 +11,7 @@
 /* Custom classes */
 
 .small { font-size:40% }
-.smaller, .pr { font-size:70% }
+.smaller, .pr, .issue { font-size:70% }
 
 
 /* Custom classes with bootstrap buttons */

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+On master
+~~~~~~~~~~~~
+
+.. rubric:: Bug fixes
+
+- Bumped version requirement of `scipy` to `scipy>1.4` to support `rmatmat` argument of `LinearOperator` :issue:`1246`
+
 1.5.1 :small:`2020-05-21`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ anndata>=0.7
 # But matplotlib 3.0 causes one in heatmaps
 matplotlib>=3.1.2
 pandas>=0.21
-scipy>=1.3
+scipy>=1.4
 seaborn
 h5py>=2.10.0
 tables


### PR DESCRIPTION
Fix for https://github.com/theislab/scanpy/issues/1246. It looks like the `rmatmat` argument for `LinearOperator` was only added in scipy 1.4: https://github.com/scipy/scipy/pull/10849