### PR TITLE
Support of a 'prefix' for load_10x_mtx

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -421,6 +421,8 @@ def read_10x_mtx(
     cache: bool = False,
     cache_compression: Union[Literal['gzip', 'lzf'], None, Empty] = _empty,
     gex_only: bool = True,
+    *,
+    prefix: str = None,
 ) -> AnnData:
     """\
     Read 10x-Genomics-formatted mtx directory.
@@ -443,13 +445,19 @@ def read_10x_mtx(
     gex_only
         Only keep 'Gene Expression' data and ignore other feature types,
         e.g. 'Antibody Capture', 'CRISPR Guide Capture', or 'Custom'
+    prefix
+        Any prefix before `matrix.mtx`, `genes.tsv` and `barcodes.tsv`. For instance,
+        if the files are named `patientA_matrix.mtx`, `patientA_genes.tsv` and
+        `patientA_barcodes.tsv` the prefix is `patientA_`.
+        (Default: no prefix)
 
     Returns
     -------
     An :class:`~anndata.AnnData` object
     """
     path = Path(path)
-    genefile_exists = (path / 'genes.tsv').is_file()
+    prefix = "" if prefix is None else prefix
+    genefile_exists = (path / f'{prefix}genes.tsv').is_file()
     read = _read_legacy_10x_mtx if genefile_exists else _read_v3_10x_mtx
     adata = read(
         str(path),
@@ -457,6 +465,7 @@ def read_10x_mtx(
         make_unique=make_unique,
         cache=cache,
         cache_compression=cache_compression,
+        prefix=prefix,
     )
     if genefile_exists or not gex_only:
         return adata
@@ -473,15 +482,17 @@ def _read_legacy_10x_mtx(
     make_unique=True,
     cache=False,
     cache_compression=_empty,
+    *,
+    prefix="",
 ):
     """
     Read mex from output from Cell Ranger v2 or earlier versions
     """
     path = Path(path)
     adata = read(
-        path / 'matrix.mtx', cache=cache, cache_compression=cache_compression,
+        path / f'{prefix}matrix.mtx', cache=cache, cache_compression=cache_compression,
     ).T  # transpose the data
-    genes = pd.read_csv(path / 'genes.tsv', header=None, sep='\t')
+    genes = pd.read_csv(path / f'{prefix}genes.tsv', header=None, sep='\t')
     if var_names == 'gene_symbols':
         var_names = genes[1].values
         if make_unique:
@@ -493,7 +504,7 @@ def _read_legacy_10x_mtx(
         adata.var['gene_symbols'] = genes[1].values
     else:
         raise ValueError("`var_names` needs to be 'gene_symbols' or 'gene_ids'")
-    adata.obs_names = pd.read_csv(path / 'barcodes.tsv', header=None)[0].values
+    adata.obs_names = pd.read_csv(path / f'{prefix}barcodes.tsv', header=None)[0].values
     return adata
 
 
@@ -503,15 +514,19 @@ def _read_v3_10x_mtx(
     make_unique=True,
     cache=False,
     cache_compression=_empty,
+    *,
+    prefix="",
 ):
     """
-    Read mex from output from Cell Ranger v3 or later versions
+    Read mtx from output from Cell Ranger v3 or later versions
     """
     path = Path(path)
     adata = read(
-        path / 'matrix.mtx.gz', cache=cache, cache_compression=cache_compression
+        path / f'{prefix}matrix.mtx.gz',
+        cache=cache,
+        cache_compression=cache_compression,
     ).T  # transpose the data
-    genes = pd.read_csv(path / 'features.tsv.gz', header=None, sep='\t')
+    genes = pd.read_csv(path / f'{prefix}features.tsv.gz', header=None, sep='\t')
     if var_names == 'gene_symbols':
         var_names = genes[1].values
         if make_unique:
@@ -524,7 +539,9 @@ def _read_v3_10x_mtx(
     else:
         raise ValueError("`var_names` needs to be 'gene_symbols' or 'gene_ids'")
     adata.var['feature_types'] = genes[2].values
-    adata.obs_names = pd.read_csv(path / 'barcodes.tsv.gz', header=None)[0].values
+    adata.obs_names = pd.read_csv(path / f'{prefix}barcodes.tsv.gz', header=None)[
+        0
+    ].values
     return adata
 
 

--- a/scanpy/tests/test_read_10x.py
+++ b/scanpy/tests/test_read_10x.py
@@ -4,6 +4,7 @@ import h5py
 import numpy as np
 import pytest
 import scanpy as sc
+import shutil
 
 
 ROOT = Path(__file__).parent
@@ -30,8 +31,18 @@ def assert_anndata_equal(a1, a2):
         ),
     ],
 )
-def test_read_10x(tmp_path, mtx_path, h5_path):
-    mtx = sc.read_10x_mtx(mtx_path, var_names="gene_symbols")
+@pytest.mark.parametrize('prefix', [None, "prefix_"])
+def test_read_10x(tmp_path, mtx_path, h5_path, prefix):
+    if prefix is not None:
+        # Build files named "prefix_XXX.xxx" in a temporary directory.
+        mtx_path_orig = mtx_path
+        mtx_path = tmp_path / "filtered_gene_bc_matrices_prefix"
+        mtx_path.mkdir()
+        for item in mtx_path_orig.iterdir():
+            if item.is_file():
+                shutil.copyfile(item, mtx_path / f"{prefix}{item.name}")
+
+    mtx = sc.read_10x_mtx(mtx_path, var_names="gene_symbols", prefix=prefix)
     h5 = sc.read_10x_h5(h5_path)
 
     # Drop genome column for comparing v3


### PR DESCRIPTION
Sometimes, it can happen when downloading 10x files from e.g. GEO that they are not organized in
folders but instead, they have a sample-specific prefix. E.g. 

```console
sturm@zeus [SSH] processed % ll
total 156M
-rw-r--r-- 1 dbadmin dbadmin  29K May 21  2018 GSM3148575_BC09_TUMOR1_barcodes.tsv.gz
-rw-r--r-- 1 dbadmin dbadmin 259K May 21  2018 GSM3148575_BC09_TUMOR1_genes.tsv.gz
-rw-r--r-- 1 dbadmin dbadmin  34M May 21  2018 GSM3148575_BC09_TUMOR1_matrix.mtx.gz
-rw-r--r-- 1 dbadmin dbadmin  28K May 21  2018 GSM3148576_BC09_TUMOR2_barcodes.tsv.gz
-rw-r--r-- 1 dbadmin dbadmin 259K May 21  2018 GSM3148576_BC09_TUMOR2_genes.tsv.gz
-rw-r--r-- 1 dbadmin dbadmin  33M May 21  2018 GSM3148576_BC09_TUMOR2_matrix.mtx.gz
```

This PR adds a keyword argument `prefix` to `read_10x_mtx` which enables to load these files 
without manual renaming and moving, e.g. 
```python
adata = sc.read_10x_mtx("path/to/files", prefix="GSM3148575_BC09_TUMOR1_")
```