### PR TITLE
Fix "Fix diffmap"

### DIFF
--- a/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
+++ b/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
@@ -33,6 +33,7 @@ def test_paga_paul15_subsampled(image_comparer, plt):
     sc.pl.draw_graph(adata, color='paul15_clusters', legend_loc='on data')
 
     sc.tl.diffmap(adata)
+    sc.tl.diffmap(adata) # See #1262    
     sc.pp.neighbors(adata, n_neighbors=10, use_rep='X_diffmap')
     sc.tl.draw_graph(adata)
 

--- a/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
+++ b/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
@@ -33,7 +33,7 @@ def test_paga_paul15_subsampled(image_comparer, plt):
     sc.pl.draw_graph(adata, color='paul15_clusters', legend_loc='on data')
 
     sc.tl.diffmap(adata)
-    sc.tl.diffmap(adata) # See #1262    
+    sc.tl.diffmap(adata) # See #1262
     sc.pp.neighbors(adata, n_neighbors=10, use_rep='X_diffmap')
     sc.tl.draw_graph(adata)
 

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -12,7 +12,7 @@ from ..neighbors import Neighbors, OnFlySymMatrix
 
 def _diffmap(adata, n_comps=15, neighbors_key=None):
     start = logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
-    dpt = DPT(adata, neighbors_key)
+    dpt = DPT(adata, neighbors_key=neighbors_key)
     dpt.compute_transitions()
     dpt.compute_eigen(n_comps=n_comps)
     adata.obsm['X_diffmap'] = dpt.eigen_basis


### PR DESCRIPTION
```py
import scanpy as sc
adata = sc.datasets.paul15()
sc.pp.neighbors(adata)
sc.tl.diffmap(adata)
sc.tl.diffmap(adata)
```

gives

```pytb
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-f88b34870534> in <module>
      7 sc.pp.neighbors(adata)
      8 sc.tl.diffmap(adata)
----> 9 sc.tl.diffmap(adata)

~/.anaconda3/lib/python3.7/site-packages/scanpy/tools/_diffmap.py in diffmap(adata, n_comps, neighbors_key, copy)
     64         raise ValueError('Provide any value greater than 2 for `n_comps`. ')
     65     adata = adata.copy() if copy else adata
---> 66     _diffmap(adata, n_comps=n_comps, neighbors_key=neighbors_key)
     67     return adata if copy else None

~/.anaconda3/lib/python3.7/site-packages/scanpy/tools/_dpt.py in _diffmap(adata, n_comps, neighbors_key)
     13 def _diffmap(adata, n_comps=15, neighbors_key=None):
     14     start = logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
---> 15     dpt = DPT(adata, neighbors_key)
     16     dpt.compute_transitions()
     17     dpt.compute_eigen(n_comps=n_comps)

~/.anaconda3/lib/python3.7/site-packages/scanpy/tools/_dpt.py in __init__(self, adata, n_dcs, min_group_size, n_branchings, allow_kendall_tau_shift, neighbors_key)
    184     def __init__(self, adata, n_dcs=None, min_group_size=0.01,
    185                  n_branchings=0, allow_kendall_tau_shift=False, neighbors_key=None):
--> 186         super(DPT, self).__init__(adata, n_dcs=n_dcs, neighbors_key=neighbors_key)
    187         self.flavor = 'haghverdi16'
    188         self.n_branchings = n_branchings

~/.anaconda3/lib/python3.7/site-packages/scanpy/neighbors/__init__.py in __init__(self, adata, n_dcs, neighbors_key)
    564             self._eigen_basis = _backwards_compat_get_full_X_diffmap(adata)
    565             if n_dcs is not None:
--> 566                 if n_dcs > len(self._eigen_values):
    567                     raise ValueError(
    568                         'Cannot instantiate using `n_dcs`={}. '

TypeError: '>' not supported between instances of 'str' and 'int'
```

because n_dcs is incorrectly set to "neighbors".