### PR TITLE
Get rid of top and bottom spaces in dot plots

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -2011,15 +2011,12 @@ def dotplot(
     dot_ax.set_xticklabels([mean_obs.columns[idx] for idx in x_ticks], rotation=90)
     dot_ax.tick_params(axis='both', labelsize='small')
     dot_ax.grid(False)
-    dot_ax.set_xlim(-0.5, len(var_names) + 0.5)
     dot_ax.set_ylabel(groupby)
 
     # to be consistent with the heatmap plot, is better to
     # invert the order of the y-axis, such that the first group is on
     # top
-    ymin, ymax = dot_ax.get_ylim()
-    dot_ax.set_ylim(ymax + 0.5, ymin - 0.5)
-
+    dot_ax.set_ylim(df.shape[0], -0.5)
     dot_ax.set_xlim(-1, len(var_names))
 
     # plot group legends on top of dot_ax (if given)

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -2016,7 +2016,7 @@ def dotplot(
     # to be consistent with the heatmap plot, is better to
     # invert the order of the y-axis, such that the first group is on
     # top
-    dot_ax.set_ylim(df.shape[0], -0.5)
+    dot_ax.set_ylim(df.shape[0], -1)
     dot_ax.set_xlim(-1, len(var_names))
 
     # plot group legends on top of dot_ax (if given)


### PR DESCRIPTION
@fidelram, I'm not sure whether I'm breaking things you intended differently. But for us, this removes the strange scaling of the white space above and below the dots, and makes it behave like the x-axis.

Just a suggestion, no need to follow up. 