### PR TITLE
Clean up of _ranks and fix for dendrogram for scipy 1.5

### DIFF
--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -129,7 +129,7 @@ def dendrogram(
     z_var = sch.linkage(
         corr_matrix, method=linkage_method, optimal_ordering=optimal_ordering
     )
-    dendro_info = sch.dendrogram(z_var, labels=categories, no_plot=True)
+    dendro_info = sch.dendrogram(z_var, labels=list(categories), no_plot=True)
 
     # order of groupby categories
     categories_idx_ordered = dendro_info['leaves']

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -51,28 +51,15 @@ def _ranks(X, mask=None, mask_rest=None):
         n_cells = X.shape[0]
         get_chunk = lambda X, left, right: adapt(X[:, left:right])
 
-    # Now calculate gene expression ranking in chunkes:
-    chunk = []
     # Calculate chunk frames
-    n_genes_max_chunk = floor(CONST_MAX_SIZE / n_cells)
-    if n_genes_max_chunk < n_genes:
-        chunk_index = n_genes_max_chunk
-        while chunk_index < n_genes:
-            chunk.append(chunk_index)
-            chunk_index = chunk_index + n_genes_max_chunk
-        chunk.append(n_genes)
-    else:
-        chunk.append(n_genes)
+    max_chunk = floor(CONST_MAX_SIZE / n_cells)
 
-    left = 0
-    # Calculate rank sums for each chunk for the current mask
-    for right in chunk:
+    for left in range(0, n_genes, max_chunk):
+        right = min(left + max_chunk, n_genes)
 
         df = pd.DataFrame(data=get_chunk(X, left, right))
         ranks = df.rank()
         yield ranks, left, right
-
-        left = right
 
 
 class _RankGenes:


### PR DESCRIPTION
Simplification of _ranks in rang_genes_groups.

Passing pandas index to scipy dendrogram now causes an error. This fixes the problem.