### PR TITLE
Restrict sphinx version to < 3.1

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 -r ../requirements.txt
 sphinx_rtd_theme>=0.3.1
-sphinx>=2.0.1
+sphinx<3.1, >3
 sphinx-autodoc-typehints
 scanpydoc>=0.4.5
 typing_extensions; python_version < '3.8'


### PR DESCRIPTION
Should fix doc builds until we figure out what's going on.

The issue could be upstream, possibly this: https://github.com/sphinx-doc/sphinx/issues/7844