### PR TITLE
Make sure dependencies are up to date in travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,9 @@ matrix:
     - name: "anndata dev"
       python: "3.7"
       install:
-        - pip install -U docutils sphinx pip
-        - pip install -U -e .[test,louvain,leiden,magic,scvi]
-        - pip install -U git+https://github.com/theislab/anndata
+        - pip install docutils sphinx
+        - pip install -e .[test,louvain,leiden,magic,scvi]
+        - pip install git+https://github.com/theislab/anndata
 python:
   - '3.6'
   - '3.7'
@@ -22,8 +22,8 @@ cache:
   - pip
   - directories: data
 install:
-  - pip install -U docutils sphinx pip
-  - pip install -U -e .[test,louvain,leiden,magic,scvi]
+  - pip install docutils sphinx
+  - pip install -e .[test,louvain,leiden,magic,scvi]
 env:
   - MPLBACKEND=Agg
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     - name: "anndata dev"
       python: "3.7"
       install:
-        - pip install docutils sphinx
+        - pip install -U docutils sphinx pip
         - pip install -U -e .[test,louvain,leiden,magic,scvi]
         - pip install -U git+https://github.com/theislab/anndata
 python:
@@ -22,7 +22,7 @@ cache:
   - pip
   - directories: data
 install:
-  - pip install docutils sphinx
+  - pip install -U docutils sphinx pip
   - pip install -U -e .[test,louvain,leiden,magic,scvi]
 env:
   - MPLBACKEND=Agg

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,8 @@ matrix:
       python: "3.7"
       install:
         - pip install docutils sphinx
-        - pip install -e .[test,louvain,leiden,magic,scvi]
-        # also test new umap. remove once umap 0.4+ is used by other runs as well
-        - pip install umap-learn>=0.4 git+https://github.com/theislab/anndata
+        - pip install -U -e .[test,louvain,leiden,magic,scvi]
+        - pip install -U git+https://github.com/theislab/anndata
 python:
   - '3.6'
   - '3.7'
@@ -24,7 +23,7 @@ cache:
   - directories: data
 install:
   - pip install docutils sphinx
-  - pip install -e .[test,louvain,leiden,magic,scvi]
+  - pip install -U -e .[test,louvain,leiden,magic,scvi]
 env:
   - MPLBACKEND=Agg
 script:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 anndata>=0.7
+# numpy needs a version due to #1320
+numpy>=1.17.0
 # Matplotlib 3.1 causes an error in 3d scatter plots (https://github.com/matplotlib/matplotlib/issues/14298)
 # But matplotlib 3.0 causes one in heatmaps
 matplotlib>=3.1.2


### PR DESCRIPTION
Travis builds are currently breaking due to incompatible versions of numpy being present, so no compatible version gets installed. This should fix that.