### PR TITLE
Reduce error potential from networkx (e.g. #1227)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ importlib_metadata>=0.7; python_version < '3.8'
 scikit-learn>=0.21.2
 statsmodels>=0.10.0rc2
 patsy
-networkx
+networkx>=2.3
 natsort
 joblib
 numba>=0.41.0


### PR DESCRIPTION
nx <2.3 depends on a since-removed matplotlib API