### PR TITLE
Add tie correction to wilcoxon method in rank_genes_groups

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -46,6 +46,7 @@ In addition, the internals for the differential expression code were overhauled 
 - Add `CellRank <https://github.com/theislab/cellrank/>`_ to scanpy ecosystem :pr:`1304` :smaller:`giovp`
 - Add backup_url option to :func:`~scanpy.read_10x_h5` :pr:`1296` :smaller:`A Gayoso`
 - Allow prefix for :func:`~scanpy.read_10x_mtx` :pr:`1250`  :smaller:`G Sturm`
+- Add optional tie correction for the 'wilcoxon' method in :func:`~scanpy.tl.rank_genes_groups` :pr:`1330`  :smaller:`S Rybakov`
 
 .. rubric:: Bug fixes
 
@@ -57,3 +58,5 @@ In addition, the internals for the differential expression code were overhauled 
 - Fix neighbors in spring_project :issue:`1260`  :smaller:`S Rybakov`
 - Fix default size of dot in spatial plots :pr:`1255` :issue:`1253`  :smaller:`giovp`
 - Bumped version requirement of `scipy` to `scipy>1.4` to support `rmatmat` argument of `LinearOperator` :issue:`1246` :smaller:`I Virshup`
+- Fix asymmetry of scores for the 'wilcoxon' method in :func:`~scanpy.tl.rank_genes_groups` :issue:`754`  :smaller:`S Rybakov`
+- Avoid trimming of gene names in :func:`~scanpy.tl.rank_genes_groups` :issue:`753`  :smaller:`S Rybakov`

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -170,7 +170,6 @@ def test_wilcoxon_tie_correction():
     pbmc = pbmc68k_reduced()
 
     groups = ['CD14+ Monocyte', 'Dendritic']
-    refers = 'Dendritic'
     groupby = 'bulk_labels'
 
     _, groups_masks = select_groups(pbmc, groups, groupby)
@@ -188,7 +187,7 @@ def test_wilcoxon_tie_correction():
         except ValueError:
             pvals[i] = 1
 
-    test_obj = _RankGenes(pbmc, groups, groupby, 'Dendritic')
+    test_obj = _RankGenes(pbmc, groups, groupby, reference=groups[1])
     test_obj.compute_statistics('wilcoxon', tie_correct=True)
 
-    assert np.allclose(test_obj.stats['CD14+ Monocyte']['pvals'], pvals)
+    assert np.allclose(test_obj.stats[groups[0]]['pvals'], pvals)

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -4,12 +4,15 @@ import pickle
 import numpy as np
 import pandas as pd
 from scipy import sparse as sp
+from scipy.stats import mannwhitneyu
 from numpy.random import negative_binomial, binomial, seed
 
 from anndata import AnnData
 from scanpy.tools import rank_genes_groups
+from scanpy.tools._rank_genes_groups import _RankGenes
 from scanpy.get import rank_genes_groups_df
 from scanpy.datasets import pbmc68k_reduced
+from scanpy._utils import select_groups
 
 
 HERE = Path(__file__).parent / Path('_data/')
@@ -161,3 +164,31 @@ def test_wilcoxon_symmetry():
     stats_dend = rank_genes_groups_df(pbmc, group="Dendritic").drop(columns="names").to_numpy()
 
     assert np.allclose(np.abs(stats_mono), np.abs(stats_dend))
+
+
+def test_wilcoxon_tie_correction():
+    pbmc = pbmc68k_reduced()
+
+    groups = ['CD14+ Monocyte', 'Dendritic']
+    refers = 'Dendritic'
+    groupby = 'bulk_labels'
+
+    _, groups_masks = select_groups(pbmc, groups, groupby)
+
+    X = pbmc.raw.X[groups_masks[0]].toarray()
+    Y = pbmc.raw.X[groups_masks[1]].toarray()
+
+    n_genes = X.shape[1]
+
+    pvals = np.zeros(n_genes)
+
+    for i in range(n_genes):
+        try:
+            _, pvals[i] = mannwhitneyu(X[:, i], Y[:, i], False, 'two-sided')
+        except ValueError:
+            pvals[i] = 1
+
+    test_obj = _RankGenes(pbmc, groups, groupby, 'Dendritic')
+    test_obj.compute_statistics('wilcoxon', tie_correct=True)
+
+    assert np.allclose(test_obj.stats['CD14+ Monocyte']['pvals'], pvals)

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -446,6 +446,9 @@ def rank_genes_groups(
     corr_method
         p-value correction method.
         Used only for `'t-test'`, `'t-test_overestim_var'`, and `'wilcoxon'`.
+    tie_correct
+        Use tie correction for `'wilcoxon'` scores.
+        Used only for `'wilcoxon'`.
     rankby_abs
         Rank genes by the absolute value of the score, not by the
         score. The returned scores are never the absolute values.

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -345,6 +345,8 @@ class _RankGenes:
 
         self.stats = None
 
+        n_genes = self.X.shape[1]
+
         for group_index, scores, pvals in generate_test_results:
             group_name = str(self.groups_order[group_index])
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -77,7 +77,16 @@ def _tiecorrect(ranks):
 
 
 class _RankGenes:
-    def __init__(self, adata, groups, groupby, reference, use_raw, layer, comp_pts):
+    def __init__(
+        self,
+        adata,
+        groups,
+        groupby,
+        reference='rest',
+        use_raw=True,
+        layer=None,
+        comp_pts=False,
+    ):
 
         if 'log1p' in adata.uns_keys() and adata.uns['log1p']['base'] is not None:
             self.expm1_func = lambda x: np.expm1(x * np.log(adata.uns['log1p']['base']))
@@ -264,7 +273,7 @@ class _RankGenes:
                 )
 
                 scores = (
-                    scores - (n_active * ((n_active + m_active + 1) / 2.))
+                    scores - (n_active * ((n_active + m_active + 1) / 2.0))
                 ) / std_dev
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores))
@@ -300,7 +309,7 @@ class _RankGenes:
                 )
 
                 scores[group_index, :] = (
-                    scores[group_index, :] - (n_active * (n_cells + 1) / 2.)
+                    scores[group_index, :] - (n_active * (n_cells + 1) / 2.0)
                 ) / std_dev
                 scores[np.isnan(scores)] = 0
                 pvals = 2 * stats.distributions.norm.sf(np.abs(scores[group_index, :]))
@@ -333,7 +342,13 @@ class _RankGenes:
                 break
 
     def compute_statistics(
-        self, method, corr_method, n_genes_user, rankby_abs, tie_correct, **kwds
+        self,
+        method,
+        corr_method='benjamini-hochberg',
+        n_genes_user=None,
+        rankby_abs=False,
+        tie_correct=False,
+        **kwds,
     ):
 
         if method in {'t-test', 't-test_overestim_var'}:


### PR DESCRIPTION
Addresses https://github.com/theislab/scanpy/issues/698

Adds some bug fixes and optional tie correction for wilcoxon rank sum test.

```
# tie_correct=False by default
sc.tl.rank_genes_groups(adata, ..., method='wilcoxon', tie_correct=True)
```

Also the test here compares `rank_genes_groups` method `'wilcoxon'` to `scipy.stats.mannwhitneyu`.

@idavydov , thanks for the `matrix_tiecorrect` code.