### PR TITLE
adding User-Agent changer into _download.py

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -931,7 +931,16 @@ def _download(url: str, path: Path):
             t.update(b * bsize - t.n)
 
         try:
-            urlretrieve(url, str(path), reporthook=update_to)
+            try:
+                urlretrieve(url, str(path), reporthook=update_to)
+            except:
+                from urllib.request import build_opener, install_opener
+                urlopener = build_opener()
+                _user_agent = 'scanpy-user'
+                urlopener.addheaders = [('User-agent', _user_agent)]
+                install_opener(urlopener)
+                urlretrieve(url, str(path), reporthook=update_to)
+                logg.info(f'Changing user-agent to {_user_agent}')
         except Exception:
             # Make sure file doesn’t exist half-downloaded
             if path.is_file():


### PR DESCRIPTION
Spatial tutorial gets 'HTTPError: HTTP Error 403: Forbidden' error by running
`adata = sc.datasets.visium_sge(sample_id="V1_Human_Lymph_Node")`. The error raised by calling `urllib.request.urlretrieve` method for downloading data from 10xgenomics. Sergei suggested to change the User-Agent. 

The `_download.py` tries to get the data via `urllib.request.urlretrieve` as before. If it is not possible the User-agent is changed to 'scanpy-user'. 