### PR TITLE
Download header

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 python_files = test_*.py
 testpaths = scanpy/tests/
 xfail_strict = true
+markers =
+    internet: tests which rely on internet resources (enable with `--internet-tests`)

--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -10,6 +10,7 @@ from .. import logging as logg, _utils
 from .._compat import Literal
 from .._settings import settings
 from ..readwrite import read, read_visium
+from ._utils import check_datasetdir_exists
 
 HERE = Path(__file__).parent
 
@@ -52,6 +53,7 @@ def blobs(
     return AnnData(X, obs=dict(blobs=y.astype(str)))
 
 
+@check_datasetdir_exists
 def burczynski06() -> AnnData:
     """\
     Bulk data with conditions ulcerative colitis (UC) and Crohn's disease (CD).
@@ -107,6 +109,7 @@ def krumsiek11() -> AnnData:
     return adata
 
 
+@check_datasetdir_exists
 def moignard15() -> AnnData:
     """\
     Hematopoiesis in early mouse embryos [Moignard15]_.
@@ -144,6 +147,7 @@ def moignard15() -> AnnData:
     return adata
 
 
+@check_datasetdir_exists
 def paul15() -> AnnData:
     """\
     Development of Myeloid Progenitors [Paul15]_.
@@ -165,6 +169,7 @@ def paul15() -> AnnData:
     import h5py
 
     filename = settings.datasetdir / 'paul15/paul15.h5'
+    filename.parent.mkdir(exist_ok=True)
     backup_url = 'http://falexwolf.de/data/paul15.h5'
     _utils.check_presence_download(filename, backup_url)
     with h5py.File(filename, 'r') as f:
@@ -240,6 +245,7 @@ def pbmc68k_reduced() -> AnnData:
         return read(filename)
 
 
+@check_datasetdir_exists
 def pbmc3k() -> AnnData:
     """\
     3k PBMCs from 10x Genomics.
@@ -282,6 +288,7 @@ def pbmc3k() -> AnnData:
     return adata
 
 
+@check_datasetdir_exists
 def pbmc3k_processed() -> AnnData:
     """Processed 3k PBMCs from 10x Genomics.
 
@@ -316,7 +323,7 @@ def _download_visium_dataset(sample_id: str, base_dir: Optional[Path] = None):
     url_prefix = f'http://cf.10xgenomics.com/samples/spatial-exp/1.0.0/{sample_id}/'
 
     sample_dir = base_dir / sample_id
-    sample_dir.mkdir(exist_ok=True, parents=True)
+    sample_dir.mkdir(exist_ok=True)
 
     # Download spatial data
     tar_filename = f"{sample_id}_spatial.tar.gz"
@@ -336,6 +343,7 @@ def _download_visium_dataset(sample_id: str, base_dir: Optional[Path] = None):
     )
 
 
+@check_datasetdir_exists
 def visium_sge(
     sample_id: Literal[
         'V1_Breast_Cancer_Block_A_Section_1',

--- a/scanpy/datasets/_ebi_expression_atlas.py
+++ b/scanpy/datasets/_ebi_expression_atlas.py
@@ -11,6 +11,7 @@ from scipy import sparse
 from ..readwrite import _download
 from .._settings import settings
 from .. import logging as logg
+from ._utils import check_datasetdir_exists
 
 
 def _filter_boring(dataframe: pd.DataFrame) -> pd.DataFrame:
@@ -30,6 +31,7 @@ def sniff_url(accession: str):
         raise
 
 
+@check_datasetdir_exists
 def download_experiment(accession: str):
     sniff_url(accession)
 

--- a/scanpy/datasets/_utils.py
+++ b/scanpy/datasets/_utils.py
@@ -1,0 +1,12 @@
+from functools import wraps
+
+from .._settings import settings
+
+
+def check_datasetdir_exists(f):
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        settings.datasetdir.mkdir(exist_ok=True)
+        return f(*args, **kwargs)
+
+    return wrapper

--- a/scanpy/tests/test_datasets.py
+++ b/scanpy/tests/test_datasets.py
@@ -56,7 +56,7 @@ def test_pbmc3k_processed(tmp_dataset_dir):
 @pytest.mark.internet
 def test_ebi_expression_atlas(tmp_dataset_dir):
     adata = sc.datasets.ebi_expression_atlas("E-MTAB-4888")
-    assert adata.shape == (2315, 23852)
+    assert adata.shape == (2315, 24051)  # This changes sometimes
 
 
 def test_krumsiek11(tmp_dataset_dir):


### PR DESCRIPTION
As noted in #1334, visium downloads were broken. Setting a header on downloads seems to fix them.

This supersedes  #1334 since that solution modifies global state around `urllib`, which is asking for trouble. This unfortunately means most of the method had to be reimplemented.
The new implementation is based on `urllib.requests.urlretrieve`, but with a modification to let us pass a header.

I also included a couple minor fixes to existing dataset download stuff:

* We don't get a warning from using `@internet` test marker anymore
* One of the downloaded datasets changed, so the test got updated
* `_download` no longer creates all parent directories. That is handled upstream.

@Mirkazemi @Koncopd
