### PR TITLE
Export concat

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -47,6 +47,7 @@ In addition, the internals for the differential expression code were overhauled 
 - Add backup_url option to :func:`~scanpy.read_10x_h5` :pr:`1296` :smaller:`A Gayoso`
 - Allow prefix for :func:`~scanpy.read_10x_mtx` :pr:`1250`  :smaller:`G Sturm`
 - Add optional tie correction for the 'wilcoxon' method in :func:`~scanpy.tl.rank_genes_groups` :pr:`1330`  :smaller:`S Rybakov`
+- :func:`~anndata.concat` is now exported from scanpy. See :doc:`anndata:concatenation` for more info. :pr:`1338` :smaller:`I Virshup`
 
 .. rubric:: Bug fixes
 

--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -38,7 +38,7 @@ from . import preprocessing as pp
 from . import plotting as pl
 from . import datasets, logging, queries, external, get
 
-from anndata import AnnData
+from anndata import AnnData, concat
 from anndata import read_h5ad, read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools
 from .readwrite import read, read_10x_h5, read_10x_mtx, write, read_visium
 from .neighbors import Neighbors


### PR DESCRIPTION
Exports `anndata.concat` so people don't have to add an extra import for a single function.

This follows what we do with several IO functions and the `AnnData` class.

Should `concat` get a page in the scanpy docs, or is it fine that it's in anndata?