### PR TITLE
short version of print_versions and print_header

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,6 @@ assignees: ''
 
 <details>
 
-[Paste the output of scanpy.logging.print_versions(deps=True) leaving a blank line after the details tag]
+[Paste the output of scanpy.logging.print_versions() leaving a blank line after the details tag]
 
 </details>

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -29,6 +29,6 @@ assignees: ''
 
 <details>
 
-[Paste the output of scanpy.logging.print_versions() leaving a blank line after the details tag]
+[Paste the output of scanpy.logging.print_versions(deps=True) leaving a blank line after the details tag]
 
 </details>

--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -301,6 +301,7 @@ Print versions of packages that might influence numerical results.
 .. autosummary::
    :toctree: .
 
+   logging.print_header
    logging.print_versions
 
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -18,7 +18,6 @@ This release includes an overhaul of :func:`~scanpy.pl.dotplot`, :func:`~scanpy.
 - The `groupby` param can take a list of categories, e.g., `groupby=[‘tissue’, ‘cell type’]`.
 - Added padding parameter to `dotplot` and `stacked_violin`. :pr:`1270`
 - Added title for colorbar and positioned as in dotplot for :func:`~scanpy.pl.matrixplot`.
-- Use `sinfo` for :func:`~scanpy.logging.print_versions` and add :func:`~scanpy.logging.print_header` to do what it previously did.
 
 - :func:`~scanpy.pl.dotplot` changes:
 
@@ -42,6 +41,7 @@ This release includes an overhaul of :func:`~scanpy.pl.dotplot`, :func:`~scanpy.
 - Added `backup_url` param to :func:`~scanpy.read_10x_h5` :pr:`1296` :smaller:`A Gayoso`
 - Allow prefix for :func:`~scanpy.read_10x_mtx` :pr:`1250`  :smaller:`G Sturm`
 - Optional tie correction for the `'wilcoxon'` method in :func:`~scanpy.tl.rank_genes_groups` :pr:`1330`  :smaller:`S Rybakov`
+- Use `sinfo` for :func:`~scanpy.logging.print_versions` and add :func:`~scanpy.logging.print_header` to do what it previously did.
 
 .. rubric:: Bug fixes
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -18,6 +18,7 @@ This release includes an overhaul of :func:`~scanpy.pl.dotplot`, :func:`~scanpy.
 - The `groupby` param can take a list of categories, e.g., `groupby=[‘tissue’, ‘cell type’]`.
 - Added padding parameter to `dotplot` and `stacked_violin`. :pr:`1270`
 - Added title for colorbar and positioned as in dotplot for :func:`~scanpy.pl.matrixplot`.
+- Use `sinfo` for :func:`~scanpy.logging.print_versions` and add :func:`~scanpy.logging.print_header` to do what it previously did.
 
 - :func:`~scanpy.pl.dotplot` changes:
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -41,7 +41,7 @@ This release includes an overhaul of :func:`~scanpy.pl.dotplot`, :func:`~scanpy.
 - Added `backup_url` param to :func:`~scanpy.read_10x_h5` :pr:`1296` :smaller:`A Gayoso`
 - Allow prefix for :func:`~scanpy.read_10x_mtx` :pr:`1250`  :smaller:`G Sturm`
 - Optional tie correction for the `'wilcoxon'` method in :func:`~scanpy.tl.rank_genes_groups` :pr:`1330`  :smaller:`S Rybakov`
-- Use `sinfo` for :func:`~scanpy.logging.print_versions` and add :func:`~scanpy.logging.print_header` to do what it previously did.
+- Use `sinfo` for :func:`~scanpy.logging.print_versions` and add :func:`~scanpy.logging.print_header` to do what it previously did. :pr:`1338` :smaller:`I Virshup` :pr:`1373`
 
 .. rubric:: Bug fixes
 

--- a/scanpy/api/__init__.py
+++ b/scanpy/api/__init__.py
@@ -276,6 +276,7 @@ Print versions of packages that might influence numerical results.
 
 .. autosummary::
 
+   logging.print_header
    logging.print_versions
 
 

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -1,5 +1,6 @@
 """Logging and Profiling
 """
+import io
 import logging
 import sys
 from functools import update_wrapper, partial
@@ -112,17 +113,16 @@ print_memory_usage = anndata.logging.print_memory_usage
 get_memory_usage = anndata.logging.get_memory_usage
 
 
-def print_versions(*, file=None):
+def print_versions(*, deps=False, file=None):
     """Print print versions of imported packages"""
-    if file is None:
-        sinfo(dependencies=True)
-    else:
-        stdout = sys.stdout
-        try:
-            sys.stdout = file
-            sinfo(dependencies=True)
-        finally:
-            sys.stdout = stdout
+    stdout = sys.stdout
+    try:
+        buf = sys.stdout = io.StringIO()
+        sinfo(dependencies=deps)
+    finally:
+        sys.stdout = stdout
+    output = buf.getvalue()
+    print(output, file=file)
 
 
 def print_version_and_date(*, file=None):

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -113,12 +113,50 @@ print_memory_usage = anndata.logging.print_memory_usage
 get_memory_usage = anndata.logging.get_memory_usage
 
 
-def print_versions(*, deps=False, file=None):
+_DEPENDENCIES_NUMERICS = [
+    'anndata',  # anndata actually shouldn't, but as long as it's in development
+    'umap',
+    'numpy',
+    'scipy',
+    'pandas',
+    ('sklearn', 'scikit-learn'),
+    'statsmodels',
+    ('igraph', 'python-igraph'),
+    'louvain',
+    'leidenalg',
+]
+
+
+def _versions_dependencies(dependencies):
+    # this is not the same as the requirements!
+    for mod in dependencies:
+        mod_name, dist_name = mod if isinstance(mod, tuple) else (mod, mod)
+        try:
+            imp = __import__(mod_name)
+            yield dist_name, imp.__version__
+        except (ImportError, AttributeError):
+            pass
+
+
+def print_header(*, file=None):
+    """\
+    Versions that might influence the numerical results.
+    Matplotlib and Seaborn are excluded from this.
+    """
+
+    modules = ['scanpy'] + _DEPENDENCIES_NUMERICS
+    print(' '.join(
+        f'{mod}=={ver}'
+        for mod, ver in _versions_dependencies(modules)
+    ), file=file or sys.stdout)
+
+
+def print_versions(*, file=None):
     """Print print versions of imported packages"""
     stdout = sys.stdout
     try:
         buf = sys.stdout = io.StringIO()
-        sinfo(dependencies=deps)
+        sinfo(dependencies=True)
     finally:
         sys.stdout = stdout
     output = buf.getvalue()

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -153,6 +153,8 @@ def print_header(*, file=None):
 
 def print_versions(*, file=None):
     """Print print versions of imported packages"""
+    if file is None:  # Inform people about the behavior change
+        warning('If you miss a compact list, please try `print_header`!')
     stdout = sys.stdout
     try:
         buf = sys.stdout = io.StringIO()


### PR DESCRIPTION
log a short version of the sinfo header:

```
-----
anndata     0.7.4
scanpy      1.5.2.dev106+gd355654f
sinfo       0.3.1
-----
Python 3.8.5 (default, Jul 27 2020, 08:42:51) [GCC 10.1.0]
Linux-5.7.12-arch1-1-x86_64-with-glibc2.2.5
16 logical CPU cores
-----
Session information updated at 2020-08-16 21:09
```