### PR TITLE
Add instructions for conda dev install

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -33,11 +33,18 @@ To work with the latest version `on GitHub`_: clone the repository and `cd` into
 its root directory. To install using symbolic links (stay up to date with your
 cloned version after you update with `git pull`) call::
 
-    flit install -s  # from an activated venv
+    flit install -s  # from an activated venv or conda env
     # or
     flit install -s --python path/to/venv/bin/python
 
 .. _on GitHub: https://github.com/theislab/scanpy
+
+If you want to let conda_ handle the installations of dependencies, do::
+
+    pip install beni
+    conda env create -f $(beni pyproject.toml)
+    conda activate scanpy
+    flit install -s
 
 Docker
 ~~~~~~
@@ -72,6 +79,8 @@ Download those and install them using `pip install ./path/to/file.whl`
 
 .. _compiling igraph: https://stackoverflow.com/q/29589696/247482
 .. _unofficial binaries: https://www.lfd.uci.edu/~gohlke/pythonlibs/
+
+.. _conda:
 
 Installing Miniconda
 ~~~~~~~~~~~~~~~~~~~~

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,7 +42,7 @@ cloned version after you update with `git pull`) call::
 If you want to let conda_ handle the installations of dependencies, do::
 
     pip install beni
-    conda env create -f $(beni pyproject.toml)
+    conda env create -f <(beni pyproject.toml)
     conda activate scanpy
     flit install -s
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,9 +42,17 @@ cloned version after you update with `git pull`) call::
 If you want to let conda_ handle the installations of dependencies, do::
 
     pip install beni
-    conda env create -f <(beni pyproject.toml)
+    beni pyproject.toml > environment.yml
+    conda env create -f environment.yml
     conda activate scanpy
     flit install -s
+
+On Windows, you might have to use `flit install --pth-file`
+if you are not able to give yourself the `create symbolic links`_ privilege.
+Be aware that a `conda bug`_ might prevent `conda list` from working then.
+
+.. _create symbolic links: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
+.. _conda bug: https://github.com/conda/conda/issues/9074
 
 Docker
 ~~~~~~


### PR DESCRIPTION
I hope that solves all workflow woes! @ivirshup?

- Users still only need `pip` and can do `pip install scanpy[extras]`
- Installation from source happens via `pip install .[extras]` or `flit install --deps`/`--extras`
- Dev mode install is nonstandard and therefore happens by simply `ln -s scanpy path/to/env/site-packages/` or flit:

![grafik](https://user-images.githubusercontent.com/291575/90508913-c8c5cf80-e158-11ea-802a-2e0e47578bd6.png)

PS: we could also mention `--pth-file` for the 3 windows users who refuse to update to win10 and therefore can’t create symlinks.