### PR TITLE
Allow JUST symlinking anndata installs

### DIFF
--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -15,7 +15,7 @@ from typing import Union, Callable, Optional, Mapping, Any, Dict, Tuple
 import numpy as np
 from numpy import random
 from scipy import sparse
-from anndata import AnnData
+from anndata import AnnData, __version__ as ad_version
 from textwrap import dedent
 from packaging import version
 
@@ -37,7 +37,7 @@ EPS = 1e-15
 
 
 def check_versions():
-    anndata_version = pkg_version("anndata")
+    anndata_version = version.parse(ad_version)
     umap_version = pkg_version("umap-learn")
 
     if anndata_version < version.parse('0.6.10'):


### PR DESCRIPTION
@Koncopd said in https://github.com/theislab/scanpy/pull/1377#issuecomment-675422847 that he has problems with the package metadata being found.

Which is extremely weird as `flit install --symlink` creates both a symlink and package metadata:

```console
$ ls -l ~/.conda/envs/anndata/lib/python3.8/site-packages/ | grep anndata
lrwxrwxrwx    49 phil 2020-08-18 14:30 anndata -> ~/Dev/Python/Single Cell/anndata/anndata
drwxr-sr-x     - phil 2020-08-18 14:30 anndata-0.7.5.dev9_gd32f11b.dist-info
```

@Koncopd does that help? please post your stack trace before and after this PR so I see what’s going on. And also please post if the `.dist-info` directory has been created.

Maybe we need to recommend `--pth-file` for windows users.