### PR TITLE
Centralize setup information

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-scanpy/_version.py export-subst

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,4 +1,12 @@
+version: 2
 build:
   image: latest
+sphinx:
+  configuration: docs/conf.py
 python:
   version: 3.6
+  install:
+  - method: pip
+    path: .
+    extra_requirements:
+    - doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,31 +2,32 @@ dist: xenial
 language: python
 matrix:
   include:
-    - name: "static analysis"
-      python: "3.7"
-      script:
-        - black . --check --diff
-        - python -m scanpy.tests.blackdiff 10
-      after_success: skip
-    - name: "anndata dev"
-      python: "3.7"
-      install:
-        - pip install docutils sphinx
-        - pip install -e .[test,louvain,leiden,magic,scvi,harmony,skmisc]
-        - pip install git+https://github.com/theislab/anndata
+  - name: "static analysis"
+    python: "3.7"
+    install:
+    - pip install .[dev,doc]
+    script:
+    - black . --check --diff
+    - python -m scanpy.tests.blackdiff 10
+    - python setup.py check --restructuredtext --strict
+    - rst2html.py --halt=2 README.rst >/dev/null
+    after_success: skip
+  - name: "anndata dev"
+    python: "3.7"
+    install:
+    - pip install .[dev,test,louvain,leiden,magic,scvi,harmony,skmisc]
+    - pip install git+https://github.com/theislab/anndata
 python:
-  - '3.6'
-  - '3.7'
-  #- '3.8-dev' # https://github.com/numpy/numpy/issues/13790
+- '3.6'
+- '3.7'
+#- '3.8-dev' # https://github.com/numpy/numpy/issues/13790
 cache:
-  - pip
-  - directories: data
+- pip
+- directories:
+  - data
 install:
-  - pip install docutils sphinx
-  - pip install -e .[test,louvain,leiden,magic,scvi,harmony,skmisc]
+- pip install .[dev,test,louvain,leiden,magic,scvi,harmony,skmisc]
 env:
-  - MPLBACKEND=Agg
+- MPLBACKEND=Agg
 script:
-  - pytest --ignore=scanpy/tests/_images
-  - python setup.py check --restructuredtext --strict
-  - rst2html.py --halt=2 README.rst >/dev/null
+- pytest --ignore=scanpy/tests/_images

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,0 @@
--r ../requirements.txt
-sphinx_rtd_theme>=0.3.1
-sphinx<3.1, >3
-sphinx-autodoc-typehints
-scanpydoc>=0.4.5
-typing_extensions; python_version < '3.8'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,24 @@
 [build-system]
-requires = ['setuptools', 'setuptools_scm', 'wheel']
+requires = ['setuptools', 'setuptools_scm', 'wheel', 'pytoml']
 build-backend = 'setuptools.build_meta'
+
+# we'll move to flit, but for now this only holds package data
+[tool.flit.metadata]
+author = '''
+Alex Wolf, Philipp Angerer, Fidel Ramirez, Isaac Virshup,
+Sergei Rybakov, Gokcen Eraslan, Tom White, Malte Luecken,
+Davide Cittaro, Tobias Callies, Marius Lange, Andrés R. Muñoz-Rojas
+'''
+# We don’t need all emails, the main authors are sufficient.
+author-email = 'f.alex.wolf@gmx.de, philipp.angerer@helmholtz-muenchen.de'
+
+[tool.pytest.ini_options]
+python_files = 'test_*.py'
+testpaths = 'scanpy/tests/'
+xfail_strict = true
+markers = [
+    'internet: tests which rely on internet resources (enable with `--internet-tests`)',
+]
 
 [tool.black]
 line-length = 88

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,8 @@
 requires = ['setuptools', 'setuptools_scm', 'wheel', 'pytoml']
 build-backend = 'setuptools.build_meta'
 
-# we'll move to flit, but for now this only holds package data
-[tool.flit.metadata]
+# uses the format of tool.flit.metadata because we’ll move to it anyway
+[tool.scanpy]
 author = '''
 Alex Wolf, Philipp Angerer, Fidel Ramirez, Isaac Virshup,
 Sergei Rybakov, Gokcen Eraslan, Tom White, Malte Luecken,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,0 @@
-[pytest]
-python_files = test_*.py
-testpaths = scanpy/tests/
-xfail_strict = true
-markers =
-    internet: tests which rely on internet resources (enable with `--internet-tests`)

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,6 +20,5 @@ joblib
 numba>=0.41.0
 umap-learn>=0.3.10
 legacy-api-wrap
-setuptools_scm
 packaging
 sinfo

--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -1,35 +1,10 @@
-# some technical stuff
-import sys
-from ._utils import pkg_version, check_versions, annotate_doc_types
+"""Single-Cell Analysis in Python."""
 
-__author__ = ', '.join([
-    'Alex Wolf',
-    'Philipp Angerer',
-    'Fidel Ramirez',
-    'Isaac Virshup',
-    'Sergei Rybakov',
-    'Gokcen Eraslan',
-    'Tom White',
-    'Malte Luecken',
-    'Davide Cittaro',
-    'Tobias Callies',
-    'Marius Lange',
-    'Andrés R. Muñoz-Rojas',
-])
-__email__ = ', '.join([
-    'f.alex.wolf@gmx.de',
-    'philipp.angerer@helmholtz-muenchen.de',
-    # We don’t need all, the main authors are sufficient.
-])
-try:
-    from setuptools_scm import get_version
-    __version__ = get_version(root='..', relative_to=__file__)
-    del get_version
-except (LookupError, ImportError):
-    __version__ = str(pkg_version(__name__))
+from ._metadata import __version__, __author__, __email__
 
+from ._utils import check_versions
 check_versions()
-del pkg_version, check_versions
+del check_versions
 
 # the actual API
 from ._settings import settings, Verbosity  # start with settings as several tools are using it
@@ -46,5 +21,7 @@ from .neighbors import Neighbors
 set_figure_params = settings.set_figure_params
 
 # has to be done at the end, after everything has been imported
+import sys
+from ._utils import annotate_doc_types
 annotate_doc_types(sys.modules[__name__], 'scanpy')
 del sys, annotate_doc_types

--- a/scanpy/_compat.py
+++ b/scanpy/_compat.py
@@ -1,3 +1,5 @@
+from packaging import version
+
 try:
     from typing import Literal
 except ImportError:
@@ -13,3 +15,19 @@ except ImportError:
 
         class Literal(metaclass=LiteralMeta):
             pass
+
+
+def pkg_metadata(package):
+    try:
+        from importlib.metadata import metadata as m
+    except ImportError:  # < Python 3.8: Use backport module
+        from importlib_metadata import metadata as m
+    return m(package)
+
+
+def pkg_version(package):
+    try:
+        from importlib.metadata import version as v
+    except ImportError:  # < Python 3.8: Use backport module
+        from importlib_metadata import version as v
+    return version.parse(v(package))

--- a/scanpy/_metadata.py
+++ b/scanpy/_metadata.py
@@ -7,7 +7,7 @@ try:
     import pytoml
 
     proj = pytoml.loads((here.parent / 'pyproject.toml').read_text())
-    metadata = proj['tool']['flit']['metadata']
+    metadata = proj['tool']['scanpy']
 
     __version__ = get_version(root='..', relative_to=__file__)
     __author__ = metadata['author']

--- a/scanpy/_metadata.py
+++ b/scanpy/_metadata.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+here = Path(__file__).parent
+
+try:
+    from setuptools_scm import get_version
+    import pytoml
+
+    proj = pytoml.loads((here.parent / 'pyproject.toml').read_text())
+    metadata = proj['tool']['flit']['metadata']
+
+    __version__ = get_version(root='..', relative_to=__file__)
+    __author__ = metadata['author']
+    __email__ = metadata['author-email']
+except (ImportError, LookupError, FileNotFoundError):
+    from ._compat import pkg_metadata
+
+    metadata = pkg_metadata(here.name)
+    __version__ = metadata['Version']
+    __author__ = metadata['Author']
+    __email__ = metadata['Author-email']

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -15,7 +15,7 @@ from typing import Union, Callable, Optional, Mapping, Any, Dict, Tuple
 import numpy as np
 from numpy import random
 from scipy import sparse
-from anndata import AnnData
+from anndata import AnnData, __version__ as anndata_version
 from textwrap import dedent
 from packaging import version
 
@@ -36,19 +36,12 @@ AnyRandom = Union[None, int, random.RandomState]  # maybe in the future random.G
 EPS = 1e-15
 
 
-def pkg_version(package):
-    try:
-        from importlib.metadata import version as v
-    except ImportError:  # < Python 3.8: Use backport module
-        from importlib_metadata import version as v
-    return version.parse(v(package))
-
-
 def check_versions():
-    anndata_version = pkg_version("anndata")
+    from ._compat import pkg_version
+
     umap_version = pkg_version("umap-learn")
 
-    if anndata_version < version.parse('0.6.10'):
+    if version.parse(anndata_version) < version.parse('0.6.10'):
         from . import __version__
 
         raise ImportError(

--- a/scanpy/tests/test_ingest.py
+++ b/scanpy/tests/test_ingest.py
@@ -6,7 +6,7 @@ from umap import UMAP
 
 import scanpy as sc
 from scanpy import settings
-from scanpy._utils import pkg_version
+from scanpy._compat import pkg_version
 
 
 X = np.array(

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -6,7 +6,7 @@ import pytest
 from matplotlib.testing import setup
 from packaging import version
 
-from scanpy._utils import pkg_version
+from scanpy._compat import pkg_version
 
 setup()
 

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -9,9 +9,10 @@ from scipy.sparse import issparse
 from anndata import AnnData
 
 from .. import settings
-from ..neighbors import _rp_forest_generate
 from .. import logging as logg
-from .._utils import pkg_version, NeighborsView
+from ..neighbors import _rp_forest_generate
+from .._utils import NeighborsView
+from .._compat import pkg_version
 
 ANNDATA_MIN_VERSION = version.parse("0.7rc1")
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ except ImportError:
     sys.exit('Please use `pip install .` or install pytoml first.')
 
 proj = pytoml.loads(Path('pyproject.toml').read_text())
-metadata = proj['tool']['flit']['metadata']
+metadata = proj['tool']['scanpy']
 
 setup(
     name='scanpy',

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         magic=['magic-impute>=2.0'],
         skmisc=['scikit-misc>=0.1.3'],
         harmony=['harmonypy'],
-        dev=['setuptools_scm', 'pytoml'],
+        dev=['setuptools_scm', 'pytoml', 'black'],
         doc=[
             'sphinx<3.1, >3',
             'sphinx_rtd_theme>=0.3.1',
@@ -51,7 +51,6 @@ setup(
             'fsspec',
             'zappy',
             'zarr',
-            'black',
             'profimp',
         ],
     ),

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,13 @@ from pathlib import Path
 
 from setuptools import setup, find_packages
 
-
 try:
-    from scanpy import __author__, __email__
-except ImportError:  # Deps not yet installed
-    __author__ = __email__ = ''
+    import pytoml
+except ImportError:
+    sys.exit('Please use `pip install .` or install pytoml first.')
+
+proj = pytoml.loads(Path('pyproject.toml').read_text())
+metadata = proj['tool']['flit']['metadata']
 
 setup(
     name='scanpy',
@@ -19,8 +21,8 @@ setup(
     description='Single-Cell Analysis in Python.',
     long_description=Path('README.rst').read_text('utf-8'),
     url='http://github.com/theislab/scanpy',
-    author=__author__,
-    author_email=__email__,
+    author=metadata['author'],
+    author_email=metadata['author-email'],
     license='BSD',
     python_requires='>=3.6',
     install_requires=[
@@ -33,11 +35,12 @@ setup(
         scvi=['scvi>=0.6.5'],
         rapids=['cudf>=0.9', 'cuml>=0.9', 'cugraph>=0.9'],
         magic=['magic-impute>=2.0'],
-        skmisc=["scikit-misc>=0.1.3"],
+        skmisc=['scikit-misc>=0.1.3'],
         harmony=['harmonypy'],
+        dev=['setuptools_scm', 'pytoml'],
         doc=[
-            'sphinx',
-            'sphinx_rtd_theme',
+            'sphinx<3.1, >3',
+            'sphinx_rtd_theme>=0.3.1',
             'sphinx_autodoc_typehints',
             'scanpydoc>=0.5',
             'typing_extensions; python_version < "3.8"',  # for `Literal`


### PR DESCRIPTION
This prepares the complete centralization of all setup information in pyproject.toml once we switch to flit.

To this end, it moves all setup metadata that also needs to be accessed at runtime (`__version__`, `__author__` and `__email__`) to a new `scanpy._metadata` module which retrieves them

- during development from a checked-out project's git metadata and `pyproject.toml`
- when installed from the `scanpy-$version.dist-info` metadata.