### PR TITLE
Implement sc.get.summarized_expression_df

### DIFF
--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -379,6 +379,7 @@ def identify_groups(ref_labels, pred_labels, return_overlaps=False):
 
 # backwards compat... remove this in the future
 def sanitize_anndata(adata):
+    """Transform string annotations to categoricals."""
     adata._sanitize()
 
 

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -1,12 +1,7 @@
 """This module contains helper functions for accessing data."""
 from typing import Optional, Iterable, Tuple, Mapping, Union, Sequence
 
-try:
-    from typing import Literal
-except ImportError:
-    try:
-        from typing_extensions import Literal
-    except ImportError:
+from ._compat import Literal
 
 import numpy as np
 import pandas as pd

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -1,5 +1,12 @@
 """This module contains helper functions for accessing data."""
-from typing import Optional, Iterable, Tuple, Mapping, Union, Sequence, Literal
+from typing import Optional, Iterable, Tuple, Mapping, Union, Sequence
+
+try:
+    from typing import Literal
+except ImportError:
+    try:
+        from typing_extensions import Literal
+    except ImportError:
 
 import numpy as np
 import pandas as pd

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -1,11 +1,15 @@
 """This module contains helper functions for accessing data."""
-from typing import Optional, Iterable, Tuple
+from typing import Optional, Iterable, Tuple, Mapping, Union, Sequence
 
 import numpy as np
 import pandas as pd
-from scipy.sparse import spmatrix, issparse
+from pandas.api.types import is_categorical_dtype
+from scipy.sparse import spmatrix
 
 from anndata import AnnData
+from ._utils import sanitize_anndata
+
+_VarNames = Union[str, Sequence[str]]
 
 # --------------------------------------------------------------------------------
 # Plotting data helpers
@@ -346,3 +350,149 @@ def _set_obs_rep(adata, val, *, use_raw=False, layer=None, obsm=None, obsp=None)
             "That was unexpected. Please report this bug at:\n\n\t"
             " https://github.com/theislab/scanpy/issues"
         )
+
+
+def _prepare_dataframe(
+    adata: AnnData,
+    var_names: Optional[Union[_VarNames, Mapping[str, _VarNames]]] = None,
+    groupby: Optional[Union[str, Sequence[str]]] = None,
+    use_raw: Optional[bool] = None,
+    log: bool = False,
+    num_categories: int = 7,
+    layer: Optional[str] = None,
+    gene_symbols: Optional[str] = None,
+    concat_indices: bool = True,
+):
+    """
+    Given the anndata object, prepares a data frame in which the row index are the categories
+    defined by group by and the columns correspond to var_names.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix.
+    var_names
+        `var_names` should be a valid subset of `adata.var_names`. All genes are used if no
+        given.
+    groupby
+        The key of the observation grouping to consider. It is expected that
+        groupby is a categorical. If groupby is not a categorical observation,
+        it would be subdivided into `num_categories`.
+    use_raw
+        Use `raw` attribute of `adata` if present.
+    log
+        Use the log of the values
+    num_categories
+        Only used if groupby observation is not categorical. This value
+        determines the number of groups into which the groupby observation
+        should be subdivided.
+    gene_symbols
+        Key for field in .var that stores gene symbols.
+    concat_indices
+        Concatenates categorical indices into a single categorical index, if 
+        groupby is a sequence. True by default.
+
+    Returns
+    -------
+    Tuple of `pandas.DataFrame` and list of categories.
+    """
+    from scipy.sparse import issparse
+
+    sanitize_anndata(adata)
+    if use_raw is None and adata.raw is not None:
+        use_raw = True
+    if isinstance(var_names, str):
+        var_names = [var_names]
+    if var_names is None:
+        if use_raw:
+            var_names = adata.raw.var_names.values
+        else:
+            var_names = adata.var_names.values
+
+    if groupby is not None:
+        if isinstance(groupby, str):
+            # if not a list, turn into a list
+            groupby = [groupby]
+        for group in groupby:
+            if group not in adata.obs_keys():
+                raise ValueError(
+                    'groupby has to be a valid observation. '
+                    f'Given {group}, is not in observations: {adata.obs_keys()}'
+                )
+
+    if gene_symbols is not None and gene_symbols in adata.var.columns:
+        # translate gene_symbols to var_names
+        # slow method but gives a meaningful error if no gene symbol is found:
+        translated_var_names = []
+        # if we're using raw to plot, we should also do gene symbol translations
+        # using raw
+        if use_raw:
+            adata_or_raw = adata.raw
+        else:
+            adata_or_raw = adata
+        for symbol in var_names:
+            if symbol not in adata_or_raw.var[gene_symbols].values:
+                logg.error(
+                    f"Gene symbol {symbol!r} not found in given "
+                    f"gene_symbols column: {gene_symbols!r}"
+                )
+                return
+            translated_var_names.append(
+                adata_or_raw.var[adata_or_raw.var[gene_symbols] == symbol].index[0]
+            )
+        symbols = var_names
+        var_names = translated_var_names
+    if layer is not None:
+        if layer not in adata.layers.keys():
+            raise KeyError(
+                f'Selected layer: {layer} is not in the layers list. '
+                f'The list of valid layers is: {adata.layers.keys()}'
+            )
+        matrix = adata[:, var_names].layers[layer]
+    elif use_raw:
+        matrix = adata.raw[:, var_names].X
+    else:
+        matrix = adata[:, var_names].X
+
+    if issparse(matrix):
+        matrix = matrix.toarray()
+    if log:
+        matrix = np.log1p(matrix)
+
+    obs_tidy = pd.DataFrame(matrix, columns=var_names)
+    if groupby is None:
+        groupby = ''
+        obs_tidy_idx = pd.Series(np.repeat('', len(obs_tidy))).astype('category')
+    else:
+        if len(groupby) == 1 and not is_categorical_dtype(adata.obs[groupby[0]]):
+            # if the groupby column is not categorical, turn it into one
+            # by subdividing into  `num_categories` categories
+            obs_tidy_idx = pd.cut(adata.obs[groupby[0]], num_categories)
+            idx_categories = obs_tidy_idx.cat.categories
+        else:
+            assert all(is_categorical_dtype(adata.obs[group]) for group in groupby)
+            if concat_indices:
+                obs_tidy_idx = adata.obs[groupby[0]]
+                if len(groupby) > 1:
+                    for group in groupby[1:]:
+                        # create new category by merging the given groupby categories
+                        obs_tidy_idx = (
+                            obs_tidy_idx.astype(str) + "_" + adata.obs[group].astype(str)
+                        ).astype('category')
+                obs_tidy_idx.name = "_".join(groupby)
+                idx_categories = obs_tidy_idx.cat.categories
+            else:
+                obs_tidy_idx = [adata.obs[group] for group in groupby] # keep as multiindex
+                idx_categories = [x.cat.categories for x in obs_tidy_idx]
+
+    obs_tidy.set_index(obs_tidy_idx, inplace=True)
+    if gene_symbols is not None:
+        # translate the column names to the symbol names
+        obs_tidy.rename(
+            columns={var_names[x]: symbols[x] for x in range(len(var_names))},
+            inplace=True,
+        )
+
+    return idx_categories, obs_tidy
+
+

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -328,7 +328,7 @@ def summarized_expression_df(
         specified threshold (`mean_expressed` and `var_expressed`) and fraction of cells expressing
         given genes above threshold (`fraction`)  by default.
     long_format
-        Whether to keep group names in columns (False) or in rows (True). True by default.
+        Whether to keep the gene names in columns (False) or in rows (True). True by default.
     var_names
         `var_names` should be a valid subset of `adata.var_names`. All genes are used if no
         given.

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -324,9 +324,10 @@ def summarized_expression_df(
         The key of the observation grouping to consider. It is expected that
         groupby is a categorical.
     ops
-        Operations to execute on the grouped dataframe. mean and variance of expression above the 
-        specified threshold (`mean_expressed` and `var_expressed`) and fraction of cells expressing
-        given genes above threshold (`fraction`)  by default.
+        Operations to execute on the grouped dataframe. By default mean and variance of
+        expression above the specified threshold (`mean_expressed` and `var_expressed`)
+        and fraction of cells expressing given genes above threshold (`fraction`) are
+        returned.
     long_format
         Whether to keep the gene names in columns (False) or in rows (True). True by default.
     var_names
@@ -340,10 +341,6 @@ def summarized_expression_df(
         Layer to use instead of adata.X.
     threshold
         Expression threshold for mean_expressed and var_expressed ops.
-    num_categories
-        Only used if groupby observation is not categorical. This value
-        determines the number of groups into which the groupby observation
-        should be subdivided.
     gene_symbols
         Key for field in .var that stores gene symbols.
 
@@ -563,6 +560,7 @@ def _indexed_expression_df(
     if groupby is None:
         groupby = ''
         obs_tidy_idx = pd.Series(np.repeat('', len(obs_tidy))).astype('category')
+        idx_categories = obs_tidy_idx.cat.categories
     else:
         if len(groupby) == 1 and not is_categorical_dtype(adata.obs[groupby[0]]):
             # if the groupby column is not categorical, turn it into one

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -308,7 +308,7 @@ def var_df(
 def grouped_expression_df(
     adata: AnnData,
     groupby: Optional[Union[str, Sequence[str]]] = None,
-    ops: Optional[Literal['mean_expressed', 'var_expressed', 'fraction']] = ('mean_expressed', 'var_expressed', 'fraction'),
+    ops: Optional[Literal['mean_expressed', 'var_expressed', 'fraction']] = None,
     long_format: bool = True,
     var_names: Optional[Union[_VarNames, Mapping[str, _VarNames]]] = None,
     use_raw: Optional[bool] = None,

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -346,9 +346,17 @@ def summarized_expression_df(
         should be subdivided.
     gene_symbols
         Key for field in .var that stores gene symbols.
+
     Returns
     -------
     `pandas.DataFrame`
+
+    Example
+    -------
+    >>> import scanpy as sc
+    >>> adata = sc.datasets.paul15()
+    >>> adata.obs['somecat'] = pd.Categorical(['A' if x == '3Ery' else 'B' for x in adata.obs.paul15_clusters])
+    >>> df = sc.get.summarized_expression_df(adata, groupby=['paul15_clusters', 'somecat'])
     """
     if isinstance(groupby, str):
         groupby = [groupby]
@@ -366,6 +374,8 @@ def summarized_expression_df(
 
     if ops is None:
         ops = ['mean_expressed', 'var_expressed', 'fraction']
+    if isinstance(ops, str):
+        ops = [ops]
     assert all(np.isin(ops, ['mean_expressed', 'var_expressed', 'fraction'])), 'Undefined op'
     assert len(ops) > 0, 'No ops given'
 

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -300,9 +300,9 @@ def var_df(
     return df
 
 
-def grouped_expression_df(
+def summarized_expression_df(
     adata: AnnData,
-    groupby: Optional[Union[str, Sequence[str]]] = None,
+    groupby: Union[str, Sequence[str]],
     ops: Optional[Literal['mean_expressed', 'var_expressed', 'fraction']] = None,
     long_format: bool = True,
     var_names: Optional[Union[_VarNames, Mapping[str, _VarNames]]] = None,
@@ -350,6 +350,8 @@ def grouped_expression_df(
     -------
     `pandas.DataFrame`
     """
+    if isinstance(groupby, str):
+        groupby = [groupby]
     assert all(is_categorical_dtype(adata.obs[group]) for group in groupby)
     _, df = _indexed_expression_df(
         adata,
@@ -378,10 +380,10 @@ def grouped_expression_df(
     if 'fraction' in ops:
         res['fraction'] = (df>threshold).groupby(level=df.index.names, observed=True).mean()
 
-    res = pd.concat(res.values(), axis=1, keys=res.keys(), names=[None, 'Genes'])
+    res = pd.concat(res.values(), axis=1, keys=res.keys(), names=[None, 'gene'])
 
     if long_format:
-        res = res.stack(level=1)
+        res = res.stack(level=1).reset_index('gene')
 
     return res
 

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -367,6 +367,8 @@ def grouped_expression_df(
         concat_indices=False,
     )
 
+    if ops is None:
+        ops = ['mean_expressed', 'var_expressed', 'fraction']
     assert all(np.isin(ops, ['mean_expressed', 'var_expressed', 'fraction'])), 'Undefined op'
     assert len(ops) > 0, 'No ops given'
 

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1734,7 +1734,6 @@ def correlation_matrix(
         return axs
 
 
-
 def _plot_gene_groups_brackets(
     gene_groups_ax: Axes,
     group_positions: Iterable[Tuple[int, int]],

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1855,7 +1855,7 @@ def _prepare_dataframe(
                             obs_tidy_idx.astype(str) + "_" + adata.obs[group].astype(str)
                         ).astype('category')
                 obs_tidy_idx.name = "_".join(groupby)
-                idx_categories = obs_tidy_idx.categories
+                idx_categories = obs_tidy_idx.cat.categories
             else:
                 obs_tidy_idx = [adata.obs[group] for group in groupby] # keep as multiindex
                 idx_categories = [x.categories for x in obs_tidy.index.levels]

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -967,7 +967,7 @@ def heatmap(
         var_names, var_group_labels, var_group_positions
     )
 
-    categories, obs_tidy = _prepare_dataframe(
+    categories, obs_tidy = get._prepare_dataframe(
         adata,
         var_names,
         groupby,
@@ -1329,7 +1329,7 @@ def tracksplot(
         var_names, var_group_labels, var_group_positions
     )
 
-    categories, obs_tidy = _prepare_dataframe(
+    categories, obs_tidy = get._prepare_dataframe(
         adata,
         var_names,
         groupby,
@@ -1733,142 +1733,6 @@ def correlation_matrix(
     if ax is None and not show:
         return axs
 
-
-def _prepare_dataframe(
-    adata: AnnData,
-    var_names: Union[_VarNames, Mapping[str, _VarNames]],
-    groupby: Optional[Union[str, Sequence[str]]] = None,
-    use_raw: Optional[bool] = None,
-    log: bool = False,
-    num_categories: int = 7,
-    layer: Optional[str] = None,
-    gene_symbols: Optional[str] = None,
-    concat_indices: bool = True,
-):
-    """
-    Given the anndata object, prepares a data frame in which the row index are the categories
-    defined by group by and the columns correspond to var_names.
-
-    Parameters
-    ----------
-    adata
-        Annotated data matrix.
-    var_names
-        `var_names` should be a valid subset of  `adata.var_names`.
-    groupby
-        The key of the observation grouping to consider. It is expected that
-        groupby is a categorical. If groupby is not a categorical observation,
-        it would be subdivided into `num_categories`.
-    use_raw
-        Use `raw` attribute of `adata` if present.
-    log
-        Use the log of the values
-    num_categories
-        Only used if groupby observation is not categorical. This value
-        determines the number of groups into which the groupby observation
-        should be subdivided.
-    gene_symbols
-        Key for field in .var that stores gene symbols.
-    concat_indices
-        Concatenates categorical indices into a single categorical index, if 
-        groupby is a sequence. True by default.
-
-    Returns
-    -------
-    Tuple of `pandas.DataFrame` and list of categories.
-    """
-    from scipy.sparse import issparse
-
-    sanitize_anndata(adata)
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
-    if isinstance(var_names, str):
-        var_names = [var_names]
-
-    if groupby is not None:
-        if isinstance(groupby, str):
-            # if not a list, turn into a list
-            groupby = [groupby]
-        for group in groupby:
-            if group not in adata.obs_keys():
-                raise ValueError(
-                    'groupby has to be a valid observation. '
-                    f'Given {group}, is not in observations: {adata.obs_keys()}'
-                )
-
-    if gene_symbols is not None and gene_symbols in adata.var.columns:
-        # translate gene_symbols to var_names
-        # slow method but gives a meaningful error if no gene symbol is found:
-        translated_var_names = []
-        # if we're using raw to plot, we should also do gene symbol translations
-        # using raw
-        if use_raw:
-            adata_or_raw = adata.raw
-        else:
-            adata_or_raw = adata
-        for symbol in var_names:
-            if symbol not in adata_or_raw.var[gene_symbols].values:
-                logg.error(
-                    f"Gene symbol {symbol!r} not found in given "
-                    f"gene_symbols column: {gene_symbols!r}"
-                )
-                return
-            translated_var_names.append(
-                adata_or_raw.var[adata_or_raw.var[gene_symbols] == symbol].index[0]
-            )
-        symbols = var_names
-        var_names = translated_var_names
-    if layer is not None:
-        if layer not in adata.layers.keys():
-            raise KeyError(
-                f'Selected layer: {layer} is not in the layers list. '
-                f'The list of valid layers is: {adata.layers.keys()}'
-            )
-        matrix = adata[:, var_names].layers[layer]
-    elif use_raw:
-        matrix = adata.raw[:, var_names].X
-    else:
-        matrix = adata[:, var_names].X
-
-    if issparse(matrix):
-        matrix = matrix.toarray()
-    if log:
-        matrix = np.log1p(matrix)
-
-    obs_tidy = pd.DataFrame(matrix, columns=var_names)
-    if groupby is None:
-        groupby = ''
-        obs_tidy_index = pd.Series(np.repeat('', len(obs_tidy))).astype('category')
-    else:
-        if len(groupby) == 1 and not is_categorical_dtype(adata.obs[groupby[0]]):
-            # if the groupby column is not categorical, turn it into one
-            # by subdividing into  `num_categories` categories
-            obs_tidy_index = pd.cut(adata.obs[groupby[0]], num_categories)
-        else:
-            assert all(is_categorical_dtype(adata.obs[group]) for group in groupby)
-            if concat_indices:
-                obs_tidy_idx = adata.obs[groupby[0]]
-                if len(groupby) > 1:
-                    for group in groupby[1:]:
-                        # create new category by merging the given groupby categories
-                        obs_tidy_idx = (
-                            obs_tidy_idx.astype(str) + "_" + adata.obs[group].astype(str)
-                        ).astype('category')
-                obs_tidy_idx.name = "_".join(groupby)
-                idx_categories = obs_tidy_idx.cat.categories
-            else:
-                obs_tidy_idx = [adata.obs[group] for group in groupby] # keep as multiindex
-                idx_categories = [x.cat.categories for x in obs_tidy_idx]
-
-    obs_tidy.set_index(obs_tidy_idx, inplace=True)
-    if gene_symbols is not None:
-        # translate the column names to the symbol names
-        obs_tidy.rename(
-            columns={var_names[x]: symbols[x] for x in range(len(var_names))},
-            inplace=True,
-        )
-
-    return idx_categories, obs_tidy
 
 
 def _plot_gene_groups_brackets(

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1847,7 +1847,7 @@ def _prepare_dataframe(
         else:
             assert all(is_categorical_dtype(adata.obs[group]) for group in groupby)
             if concat_indices:
-                obs_tidy_index = adata.obs[groupby[0]]
+                obs_tidy_idx = adata.obs[groupby[0]]
                 if len(groupby) > 1:
                     for group in groupby[1:]:
                         # create new category by merging the given groupby categories

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1855,7 +1855,7 @@ def _prepare_dataframe(
                             obs_tidy_idx.astype(str) + "_" + adata.obs[group].astype(str)
                         ).astype('category')
                 obs_tidy_idx.name = "_".join(groupby)
-                idx_categories = obs_tidy.index.categories
+                idx_categories = obs_tidy_idx.categories
             else:
                 obs_tidy_idx = [adata.obs[group] for group in groupby] # keep as multiindex
                 idx_categories = [x.categories for x in obs_tidy.index.levels]

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -967,7 +967,7 @@ def heatmap(
         var_names, var_group_labels, var_group_positions
     )
 
-    categories, obs_tidy = get._prepare_dataframe(
+    categories, obs_tidy = get._indexed_expression_df(
         adata,
         var_names,
         groupby,
@@ -1329,7 +1329,7 @@ def tracksplot(
         var_names, var_group_labels, var_group_positions
     )
 
-    categories, obs_tidy = get._prepare_dataframe(
+    categories, obs_tidy = get._indexed_expression_df(
         adata,
         var_names,
         groupby,

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1858,7 +1858,7 @@ def _prepare_dataframe(
                 idx_categories = obs_tidy_idx.cat.categories
             else:
                 obs_tidy_idx = [adata.obs[group] for group in groupby] # keep as multiindex
-                idx_categories = [x.categories for x in obs_tidy.index.levels]
+                idx_categories = [x.cat.categories for x in obs_tidy_idx]
 
     obs_tidy.set_index(obs_tidy_idx, inplace=True)
     if gene_symbols is not None:

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -1851,8 +1851,8 @@ def _prepare_dataframe(
                 if len(groupby) > 1:
                     for group in groupby[1:]:
                         # create new category by merging the given groupby categories
-                        obs_tidy_index = (
-                            obs_tidy_index.astype(str) + "_" + adata.obs[group].astype(str)
+                        obs_tidy_idx = (
+                            obs_tidy_idx.astype(str) + "_" + adata.obs[group].astype(str)
                         ).astype('category')
                 obs_tidy_idx.name = "_".join(groupby)
                 idx_categories = obs_tidy.index.categories

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -12,10 +12,11 @@ from matplotlib import pyplot as pl
 from matplotlib import gridspec
 
 from .. import logging as logg
+from .. import get
 from .._compat import Literal
 from ._utils import make_grid_spec
 from ._utils import ColorLike, _AxesSubplot
-from ._anndata import _plot_dendrogram, _get_dendrogram_key, _prepare_dataframe
+from ._anndata import _plot_dendrogram, _get_dendrogram_key
 
 _VarNames = Union[str, Sequence[str]]
 
@@ -102,7 +103,7 @@ class BasePlot(object):
 
         self._update_var_groups()
 
-        self.categories, self.obs_tidy = _prepare_dataframe(
+        self.categories, self.obs_tidy = get._prepare_dataframe(
             adata,
             self.var_names,
             groupby,

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -103,7 +103,7 @@ class BasePlot(object):
 
         self._update_var_groups()
 
-        self.categories, self.obs_tidy = get._prepare_dataframe(
+        self.categories, self.obs_tidy = get._indexed_expression_df(
             adata,
             self.var_names,
             groupby,

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -231,7 +231,6 @@ def test_summarized_expression_df():
     adata = sc.datasets.paul15()
     adata.obs['somecat'] = pd.Categorical(adata.obs.paul15_clusters == '3Ery')
     df = sc.get.summarized_expression_df(adata, groupby=['paul15_clusters', 'somecat'])
-
     assert len(df.index.levels) == 2
     assert df.fraction.max() <= 1.
     assert df.fraction.min() >= 0.
@@ -243,3 +242,10 @@ def test_summarized_expression_df():
     assert all(df.columns.levels[1].isin(adata.var_names))
     assert all(df.columns.levels[0].isin(['mean_expressed', 'var_expressed', 'fraction']))
     assert len(df.columns.levels) == 2
+
+    df = sc.get.summarized_expression_df(adata, groupby='paul15_clusters', ops='fraction')
+    assert pd.api.types.is_categorical_dtype(df.index)
+    assert df.fraction.max() <= 1.
+    assert df.fraction.min() >= 0.
+    assert df.columns[-1] == 'fraction'
+    assert len(df.columns) == 2

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -225,3 +225,21 @@ def test_rank_genes_groups_df():
         sc.get.rank_genes_groups_df(adata, "a")
     dedf2 = sc.get.rank_genes_groups_df(adata, "a", key="different_key")
     pd.testing.assert_frame_equal(dedf, dedf2)
+
+
+def test_summarized_expression_df():
+    adata = sc.datasets.paul15()
+    adata.obs['somecat'] = pd.Categorical(adata.obs.paul15_clusters == '3Ery')
+    df = sc.get.summarized_expression_df(adata, groupby=['paul15_clusters', 'somecat'])
+
+    assert len(df.index.levels) == 2
+    assert df.fraction.max() <= 1.
+    assert df.fraction.min() >= 0.
+    assert all(np.isin(df.index.levels[0].categories, (adata.obs['paul15_clusters']).cat.categories))
+    assert all(df.gene.isin(adata.var_names))
+    assert all(df.columns.isin(['gene', 'mean_expressed', 'var_expressed', 'fraction']))
+
+    df = sc.get.summarized_expression_df(adata, groupby=['paul15_clusters', 'somecat'], long_format=False)
+    assert all(df.columns.levels[1].isin(adata.var_names))
+    assert all(df.columns.levels[0].isin(['mean_expressed', 'var_expressed', 'fraction']))
+    assert len(df.columns.levels) == 2

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -9,6 +9,7 @@ from anndata import AnnData
 from pandas.api.types import is_categorical_dtype
 
 from .. import logging as logg
+from .. import get
 from .._utils import _doc_params
 from ..tools._utils import _choose_representation, doc_use_rep, doc_n_pcs
 
@@ -127,9 +128,7 @@ def dendrogram(
         if use_raw is None and adata.raw is not None:
             use_raw = True
         gene_names = adata.raw.var_names if use_raw else adata.var_names
-        from ..plotting._anndata import _prepare_dataframe
-
-        categories, rep_df = _prepare_dataframe(adata, gene_names, groupby, use_raw)
+        categories, rep_df = get._prepare_dataframe(adata, gene_names, groupby, use_raw)
 
     # aggregate values within categories using 'mean'
     mean_df = rep_df.groupby(level=0).mean()

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -129,7 +129,7 @@ def dendrogram(
             use_raw = True
         gene_names = adata.raw.var_names if use_raw else adata.var_names
         categories, rep_df = get._indexed_expression_df(
-                adata, gene_names, groupby, use_raw
+            adata, gene_names, groupby, use_raw
         )
 
     # aggregate values within categories using 'mean'

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -128,7 +128,9 @@ def dendrogram(
         if use_raw is None and adata.raw is not None:
             use_raw = True
         gene_names = adata.raw.var_names if use_raw else adata.var_names
-        categories, rep_df = get._indexed_expression_df(adata, gene_names, groupby, use_raw)
+        categories, rep_df = get._indexed_expression_df(
+                adata, gene_names, groupby, use_raw
+        )
 
     # aggregate values within categories using 'mean'
     mean_df = rep_df.groupby(level=0).mean()

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -128,7 +128,7 @@ def dendrogram(
         if use_raw is None and adata.raw is not None:
             use_raw = True
         gene_names = adata.raw.var_names if use_raw else adata.var_names
-        categories, rep_df = get._prepare_dataframe(adata, gene_names, groupby, use_raw)
+        categories, rep_df = get._indexed_expression_df(adata, gene_names, groupby, use_raw)
 
     # aggregate values within categories using 'mean'
     mean_df = rep_df.groupby(level=0).mean()

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -9,6 +9,7 @@ from anndata import AnnData
 from scipy.sparse import issparse, vstack
 
 from .. import _utils
+from .. import get
 from .. import logging as logg
 from ..preprocessing._simple import _get_mean_var
 from .._compat import Literal


### PR DESCRIPTION
This pr moves the (in)famous `_prepare_dataframe` function from scanpy.plotting._anndata to sc.get as `_indexed_expression_df` (bcs why would it be in plotting anyway) and implements a simple public interface called `sc.get.summarized_expresion_df` which simply provides nonzero mean/var and fraction using `_indexed_expression_df` function. 

As discussed here (https://github.com/theislab/scanpy/pull/1388#issuecomment-678739734) we can use this in rank_genes_groups_df.