### PR TITLE
Consistent foldchange, fractions calculation for filter_rank_genes_groups

### DIFF
--- a/scanpy/tests/test_filter_rank_genes_groups.py
+++ b/scanpy/tests/test_filter_rank_genes_groups.py
@@ -9,7 +9,18 @@ names_no_reference = np.array(
         ['CD3E', 'CD3D', 'nan', 'NKG7', 'CD3D', 'AIF1', 'CD79B', 'nan', 'GNLY', 'CST3'],
         ['IL32', 'RPL39', 'nan', 'CST7', 'nan', 'nan', 'nan', 'SNHG7', 'CD7', 'nan'],
         ['nan', 'SRSF7', 'IL32', 'GZMA', 'nan', 'LST1', 'IGJ', 'nan', 'CTSW', 'nan'],
-        ['nan', 'nan', 'CD2', 'CTSW', 'CD8B', 'TYROBP', 'ISG20', 'SNHG8', 'GZMB', 'nan'],
+        [
+            'nan',
+            'nan',
+            'CD2',
+            'CTSW',
+            'CD8B',
+            'TYROBP',
+            'ISG20',
+            'SNHG8',
+            'GZMB',
+            'nan',
+        ],
     ]
 )
 
@@ -23,6 +34,7 @@ names_reference = np.array(
     ]
 )
 
+
 def test_filter_rank_genes_groups():
     adata = pbmc68k_reduced()
 
@@ -32,7 +44,7 @@ def test_filter_rank_genes_groups():
         'key_added': 'rank_genes_groups_filtered',
         'min_in_group_fraction': 0.25,
         'min_fold_change': 1,
-        'max_out_group_fraction': 0.5
+        'max_out_group_fraction': 0.5,
     }
 
     rank_genes_groups(

--- a/scanpy/tests/test_filter_rank_genes_groups.py
+++ b/scanpy/tests/test_filter_rank_genes_groups.py
@@ -1,0 +1,53 @@
+import numpy as np
+from scanpy.tools import rank_genes_groups, filter_rank_genes_groups
+from scanpy.datasets import pbmc68k_reduced
+
+
+names_no_reference = np.array(
+    [
+        ['CD3D', 'ITM2A', 'CD3D', 'CCL5', 'CD7', 'nan', 'CD79A', 'nan', 'NKG7', 'LYZ'],
+        ['CD3E', 'CD3D', 'nan', 'NKG7', 'CD3D', 'AIF1', 'CD79B', 'nan', 'GNLY', 'CST3'],
+        ['IL32', 'RPL39', 'nan', 'CST7', 'nan', 'nan', 'nan', 'SNHG7', 'CD7', 'nan'],
+        ['nan', 'SRSF7', 'IL32', 'GZMA', 'nan', 'LST1', 'IGJ', 'nan', 'CTSW', 'nan'],
+        ['nan', 'nan', 'CD2', 'CTSW', 'CD8B', 'TYROBP', 'ISG20', 'SNHG8', 'GZMB', 'nan'],
+    ]
+)
+
+names_reference = np.array(
+    [
+        ['CD3D', 'ITM2A', 'CD3D', 'nan', 'CD3D', 'nan', 'CD79A', 'nan', 'CD7'],
+        ['nan', 'nan', 'nan', 'CD3D', 'nan', 'AIF1', 'nan', 'nan', 'NKG7'],
+        ['nan', 'nan', 'nan', 'NKG7', 'nan', 'FCGR3A', 'ISG20', 'SNHG7', 'CTSW'],
+        ['nan', 'CD3D', 'nan', 'CCL5', 'CD7', 'nan', 'CD79B', 'nan', 'GNLY'],
+        ['CD3E', 'IL32', 'nan', 'IL32', 'CD27', 'FCER1G', 'nan', 'nan', 'nan'],
+    ]
+)
+
+def test_filter_rank_genes_groups():
+    adata = pbmc68k_reduced()
+
+    rank_genes_groups(
+        adata, 'bulk_labels', reference='Dendritic', method='wilcoxon', n_genes=5
+    )
+    filter_rank_genes_groups(adata)
+
+    assert np.array_equal(
+        names_reference,
+        np.array(adata.uns['rank_genes_groups_filtered']['names'].tolist()),
+    )
+
+    rank_genes_groups(adata, 'bulk_labels', method='wilcoxon', n_genes=5)
+    filter_rank_genes_groups(adata)
+
+    assert np.array_equal(
+        names_no_reference,
+        np.array(adata.uns['rank_genes_groups_filtered']['names'].tolist()),
+    )
+
+    rank_genes_groups(adata, 'bulk_labels', method='wilcoxon', pts=True, n_genes=5)
+    filter_rank_genes_groups(adata)
+
+    assert np.array_equal(
+        names_no_reference,
+        np.array(adata.uns['rank_genes_groups_filtered']['names'].tolist()),
+    )

--- a/scanpy/tests/test_filter_rank_genes_groups.py
+++ b/scanpy/tests/test_filter_rank_genes_groups.py
@@ -26,10 +26,19 @@ names_reference = np.array(
 def test_filter_rank_genes_groups():
     adata = pbmc68k_reduced()
 
+    # fix filter defaults
+    args = {
+        'adata': adata,
+        'key_added': 'rank_genes_groups_filtered',
+        'min_in_group_fraction': 0.25,
+        'min_fold_change': 1,
+        'max_out_group_fraction': 0.5
+    }
+
     rank_genes_groups(
         adata, 'bulk_labels', reference='Dendritic', method='wilcoxon', n_genes=5
     )
-    filter_rank_genes_groups(adata)
+    filter_rank_genes_groups(**args)
 
     assert np.array_equal(
         names_reference,
@@ -37,7 +46,7 @@ def test_filter_rank_genes_groups():
     )
 
     rank_genes_groups(adata, 'bulk_labels', method='wilcoxon', n_genes=5)
-    filter_rank_genes_groups(adata)
+    filter_rank_genes_groups(**args)
 
     assert np.array_equal(
         names_no_reference,
@@ -45,7 +54,7 @@ def test_filter_rank_genes_groups():
     )
 
     rank_genes_groups(adata, 'bulk_labels', method='wilcoxon', pts=True, n_genes=5)
-    filter_rank_genes_groups(adata)
+    filter_rank_genes_groups(**args)
 
     assert np.array_equal(
         names_no_reference,

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -630,7 +630,7 @@ def rank_genes_groups(
     return adata if copy else None
 
 
-def _calc_frac_present(X):
+def _calc_frac(X):
     if issparse(X):
         n_nonzero = X.getnnz(axis=0)
     else:
@@ -754,8 +754,8 @@ def filter_rank_genes_groups(
                 adata.uns[key]['pts_rest'][cluster].loc[var_names].values
             )
         else:
-            fraction_in_cluster_matrix.loc[:, cluster] = _calc_frac_present(X_in)
-            fraction_out_cluster_matrix.loc[:, cluster] = _calc_frac_present(X_out)
+            fraction_in_cluster_matrix.loc[:, cluster] = _calc_frac(X_in)
+            fraction_out_cluster_matrix.loc[:, cluster] = _calc_frac(X_out)
 
         if not use_logfolds:
             # compute mean value

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -736,15 +736,12 @@ def filter_rank_genes_groups(
         f"max_out_group_fraction: {max_out_group_fraction}"
     )
 
-    from ..plotting._anndata import _prepare_dataframe
-
     for cluster in gene_names.columns:
         # iterate per column
         var_names = gene_names[cluster].values
 
         if not use_logfolds or not use_fraction:
-            sub_adata = adata[:, var_names]
-            sub_X = _get_obs_rep(sub_adata, use_raw=use_raw).copy()
+            sub_X = adata.raw[:, var_names].X if use_raw else adata[:, var_names].X
             in_group = adata.obs[groupby] == cluster
             X_in = sub_X[in_group]
             X_out = sub_X[~in_group]

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -709,10 +709,14 @@ def filter_rank_genes_groups(
     gene_names = pd.DataFrame(adata.uns[key]['names'])
 
     fraction_in_cluster_matrix = pd.DataFrame(
-        np.zeros(gene_names.shape), columns=gene_names.columns, index=gene_names.index,
+        np.zeros(gene_names.shape),
+        columns=gene_names.columns,
+        index=gene_names.index,
     )
     fraction_out_cluster_matrix = pd.DataFrame(
-        np.zeros(gene_names.shape), columns=gene_names.columns, index=gene_names.index,
+        np.zeros(gene_names.shape),
+        columns=gene_names.columns,
+        index=gene_names.index,
     )
 
     if use_logfolds:
@@ -763,7 +767,8 @@ def filter_rank_genes_groups(
             mean_out_cluster = np.ravel(X_out.mean(0))
             # compute fold change
             fold_change_matrix.loc[:, cluster] = np.log2(
-                (expm1_func(mean_in_cluster) + 1e-9) / (expm1_func(mean_out_cluster) + 1e-9)
+                (expm1_func(mean_in_cluster) + 1e-9)
+                / (expm1_func(mean_out_cluster) + 1e-9)
             )
 
     # filter original_matrix


### PR DESCRIPTION
Use logfoldchanges, fractions for filtering if they are in `adata.uns['rank_genes_groups']` already, otherwise calculate using the same formula as in `rank_genes_groups`.