### PR TITLE
Support dict for embedding palette argument

### DIFF
--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -83,9 +83,9 @@ color_map
 palette
     Colors to use for plotting categorical annotation groups.
     The palette can be a valid :class:`~matplotlib.colors.ListedColormap` name
-    (`'Set2'`, `'tab20'`, …), a :class:`~cycler.Cycler` object, or a sequence of
-    matplotlib colors like `['red', '#ccdd11', (0.1, 0.2, 1)]`
-    (see :func:`~matplotlib.colors.is_color_like`).
+    (`'Set2'`, `'tab20'`, …), a :class:`~cycler.Cycler` object, a dict mapping
+    categories to colors, or a sequence of colors. Colors must be valid to
+    matplotlib. (see :func:`~matplotlib.colors.is_color_like`).
     If `None`, `mpl.rcParams["axes.prop_cycle"]` is used unless the categorical
     variable already has colors stored in `adata.uns["{var}_colors"]`.
     If provided, values of `adata.uns["{var}_colors"]` will be set.

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -385,7 +385,8 @@ def _set_colors_for_categorical_obs(
         # this creates a palette from a colormap. E.g. 'Accent, Dark2, tab20'
         cmap = pl.get_cmap(palette)
         colors_list = [to_hex(x) for x in cmap(np.linspace(0, 1, len(categories)))]
-
+    elif isinstance(palette, cabc.Mapping):
+        colors_list = [to_hex(palette[k], keep_alpha=True) for k in categories]
     else:
         # check if palette is a list and convert it to a cycler, thus
         # it doesnt matter if the list is shorter than the categories length:

--- a/scanpy/tests/test_embedding_plots.py
+++ b/scanpy/tests/test_embedding_plots.py
@@ -1,9 +1,11 @@
 from pathlib import Path
 
 import matplotlib.pyplot as plt
+from matplotlib.testing.compare import compare_images
 import numpy as np
 import pandas as pd
 import pytest
+import seaborn as sns
 
 import scanpy as sc
 
@@ -169,3 +171,22 @@ def test_missing_values_continuous(
     )
 
     save_and_compare_images(base_name)
+
+
+def test_enumerated_palettes(fixture_request, adata, tmpdir, plotfunc):
+    tmpdir = Path(tmpdir)
+    base_name = fixture_request.node.name
+
+    categories = adata.obs["label"].cat.categories
+    colors_rgb = dict(zip(categories, sns.color_palette(n_colors=12)))
+
+    dict_pth = tmpdir / f"rgbdict_{base_name}.png"
+    list_pth = tmpdir / f"rgblist_{base_name}.png"
+
+    # making a copy so colors aren't saved
+    plotfunc(adata.copy(), color="label", palette=colors_rgb)
+    plt.savefig(dict_pth, dpi=40)
+    plotfunc(adata.copy(), color="label", palette=[colors_rgb[c] for c in categories])
+    plt.savefig(list_pth, dpi=40)
+
+    compare_images(dict_pth, list_pth, 15)


### PR DESCRIPTION
Possible solution for: https://github.com/theislab/anndata/issues/426

Allows you to pass a name to color mapping to `embedding` functions.

Example usage:

```python
sc.pl.umap(
    pbmc,
    color="highlevel",
    palette={
        "B cells": "#01FFD0",
        "T cells": "#509CFF",
        "Monocytes": "#FF7161",
        "NK cells": "#FF476E"
    },
)
```

![ugly_colors](https://user-images.githubusercontent.com/8238804/91275817-031c1600-e7c4-11ea-98c7-3c2cc6d3e849.png)
