### PR TITLE
Bugfix for one gene being passed to score_genes

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -32,7 +32,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pip install git+https://github.com/theislab/anndata
+      pip install -v git+https://github.com/theislab/anndata
     displayName: 'Install development anndata'
     condition: eq(variables['ANNDATA_DEV'], 'yes')
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -11,6 +11,7 @@ On master
 * Fixed `marker_gene_overlap` default value for `top_n_markers` :pr:`1464` :smaller:`MD Luecken`
 * Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`
 * Fixed anndata version requirement for `sc.concat` :pr:`1491` :smaller:`I Virshup`
+* Fixed bug where `score_genes` would error if one gene was passed :pr:`1398` :smaller:`I Virshup`
 
 .. rubric:: Performance
 

--- a/scanpy/tests/test_score_genes.py
+++ b/scanpy/tests/test_score_genes.py
@@ -175,3 +175,18 @@ def test_npnanmean_vs_sparsemean(monkeypatch):
     dense_scores = adata.obs['Test'].values
 
     np.testing.assert_allclose(sparse_scores, dense_scores)
+
+
+def test_missing_genes():
+    adata = _create_adata(100, 1000, p_zero=0, p_nan=0)
+    # These genes have a different length of name
+    non_extant_genes = _create_random_gene_names(n_genes=3, name_length=7)
+
+    with pytest.raises(ValueError):
+        sc.tl.score_genes(adata, non_extant_genes)
+
+
+def test_one_gene():
+    # https://github.com/theislab/scanpy/issues/1395
+    adata = _create_adata(100, 1000, p_zero=0, p_nan=0)
+    sc.tl.score_genes(adata, [adata.var_names[0]])

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -110,9 +110,7 @@ def score_genes(
     gene_list = set(gene_list_in_var[:])
 
     if len(gene_list) == 0:
-        logg.warning('provided gene list has length 0, scores as 0')
-        adata.obs[score_name] = 0
-        return adata if copy else None
+        raise ValueError("No valid genes were passed for scoring.")
 
     if gene_pool is None:
         gene_pool = list(var_names)
@@ -164,21 +162,7 @@ def score_genes(
     else:
         X_control = np.nanmean(X_control, axis=1)
 
-    if len(gene_list) == 0:
-        # We shouldn't even get here, but just in case
-        logg.hint(
-            f'could not add \n'
-            f'    {score_name!r}, score of gene set (adata.obs)'
-        )
-        return adata if copy else None
-    elif len(gene_list) == 1:
-        if _adata[:, gene_list].X.ndim == 2:
-            vector = _adata[:, gene_list].X.toarray()[:, 0] # new anndata
-        else:
-            vector = _adata[:, gene_list].X  # old anndata
-        score = vector - X_control
-    else:
-        score = X_list - X_control
+    score = X_list - X_control
 
     adata.obs[score_name] = pd.Series(np.array(score).ravel(), index=adata.obs_names)
 


### PR DESCRIPTION
Fixes #1395

It looks like this code was originally added for dealing with the automatic flattening of `X` when indices had length 1. I also made it an error if there were no genes to score. Arguably it should be an error if any of the passed genes are missing.