### PR TITLE
Bugfix log1p for non-float dense arrays

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -1,6 +1,13 @@
 .. role:: small
 .. role:: smaller
 
+On master
+~~~~~~~~~
+
+.. rubric:: Bugfixes
+
+* Fixed `log1p` inplace on integer dense arrays :pr:`1400` :smaller:`I Virshup`
+
 1.6.0 :small:`2020-08-15`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -308,13 +308,17 @@ def log1p_sparse(X, *, base: Optional[Number] = None, copy: bool = False):
 
 @log1p.register(np.ndarray)
 def log1p_array(X, *, base: Optional[Number] = None, copy: bool = False):
-    # Can force arrays to be np.ndarrays, but would be useful
+    # Can force arrays to be np.ndarrays, but would be useful to not
     # X = check_array(X, dtype=(np.float64, np.float32), ensure_2d=False, copy=copy)
     if copy:
         if not np.issubdtype(X.dtype, np.floating):
             X = X.astype(np.floating)
         else:
             X = X.copy()
+    elif not (
+        np.issubdtype(X.dtype, np.floating) or np.issubdtype(X.dtype, np.complex)
+    ):
+        X = X.astype(np.floating)
     np.log1p(X, out=X)
     if base is not None:
         np.divide(X, np.log(base), out=X)

--- a/scanpy/tests/helpers.py
+++ b/scanpy/tests/helpers.py
@@ -19,7 +19,7 @@ def check_rep_mutation(func, X, **kwargs):
         X=X.copy(),
         layers={"layer": X.copy()},
         obsm={"obsm": X.copy()},
-        dtype=np.float64,
+        dtype=X.dtype,
     )
     adata_X = func(adata, copy=True, **kwargs)
     adata_layer = func(adata, layer="layer", copy=True, **kwargs)

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -38,8 +38,10 @@ def base(request):
     return request.param
 
 
-def test_log1p_rep(count_matrix_format, base):
-    X = count_matrix_format(sp.random(100, 200, density=0.3).toarray())
+def test_log1p_rep(count_matrix_format, base, dtype):
+    X = count_matrix_format(
+        np.abs(sp.random(100, 200, density=0.3, dtype=dtype)).toarray()
+    )
     check_rep_mutation(sc.pp.log1p, X, base=base)
     check_rep_results(sc.pp.log1p, X, base=base)
 


### PR DESCRIPTION
Fixes #435

Breaking case:

```python
import scanpy as sc, numpy as np
sc.pp.log1p(
    sc.AnnData(np.ones((100, 100)), dtype=int)
)
```

```pytb
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-3-f3ae2b50ac50> in <module>
----> 1 sc.pp.log1p(a)

/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/functools.py in wrapper(*args, **kw)
    873                             '1 positional argument')
    874 
--> 875         return dispatch(args[0].__class__)(*args, **kw)
    876 
    877     funcname = getattr(func, '__name__', 'singledispatch function')

~/github/scanpy/scanpy/preprocessing/_simple.py in log1p_anndata(adata, base, copy, chunked, chunk_size, layer, obsm)
    348     else:
    349         X = _get_obs_rep(adata, layer=layer, obsm=obsm)
--> 350         X = log1p(X, copy=False, base=base)
    351         _set_obs_rep(adata, X, layer=layer, obsm=obsm)
    352 

/usr/local/Cellar/python@3.8/3.8.5/Frameworks/Python.framework/Versions/3.8/lib/python3.8/functools.py in wrapper(*args, **kw)
    873                             '1 positional argument')
    874 
--> 875         return dispatch(args[0].__class__)(*args, **kw)
    876 
    877     funcname = getattr(func, '__name__', 'singledispatch function')

~/github/scanpy/scanpy/preprocessing/_simple.py in log1p_array(X, base, copy)
    316         else:
    317             X = X.copy()
--> 318     np.log1p(X, out=X)
    319     if base is not None:
    320         np.divide(X, np.log(base), out=X)

TypeError: ufunc 'log1p' output (typecode 'd') could not be coerced to provided output parameter (typecode 'l') according to the casting rule ''same_kind''
```