### PR TITLE
update ecosystem docs to contain scvi-tools

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -52,7 +52,6 @@ Differential expression
 Data integration
 ----------------
 
-* `scVI <https://github.com/YosefLab/scVI>`__, see `comparison <https://nbviewer.jupyter.org/github/YosefLab/scVI/blob/master/tests/notebooks/scanpy_pbmc3k.ipynb>`__ :small:`Berkeley`
 * `scanaroma <https://github.com/brianhie/scanorama>`__ :small:`MIT`
 
 
@@ -60,3 +59,12 @@ Modeling perturbations
 ----------------------
 
 * `scGen <https://github.com/theislab/scgen>`__ / `trVAE <https://github.com/theislab/trvae>`__ :small:`Helmholtz Munich`
+
+
+scvi-tools
+----------
+
+* `scvi-tools <https://github.com/YosefLab/scvi-tools>`__ :small:`Berkeley`
+
+    | scvi-tools hosts deep generative models (DGM) for end-to-end analysis of single-cell
+      omics data (e.g., scVI, scANVI, totalVI). It also contains several primitives to build novel DGMs.


### PR DESCRIPTION
We recently transitioned from scvi to scvi-tools. Here I update the ecosystem docs to reflect this change.

I decided to make a new section for it as we have a diversity of models in our package that don't fit any of the other categories well.