### PR TITLE
Make harmonypy test optional

### DIFF
--- a/scanpy/tests/external/test_harmony_integrate.py
+++ b/scanpy/tests/external/test_harmony_integrate.py
@@ -1,5 +1,9 @@
+import pytest
+
 import scanpy as sc
 import scanpy.external as sce
+
+pytest.importorskip("harmonypy")
 
 
 def test_harmony_integrate():


### PR DESCRIPTION
This skips the test `test_harmony_integrate` if harmonypy is not installed.