### PR TITLE
[WIP] Remove usage of AnnData constructor dtype argument

### DIFF
--- a/scanpy/tests/helpers.py
+++ b/scanpy/tests/helpers.py
@@ -19,7 +19,6 @@ def check_rep_mutation(func, X, **kwargs):
         X=X.copy(),
         layers={"layer": X.copy()},
         obsm={"obsm": X.copy()},
-        dtype=X.dtype,
     )
     adata_X = func(adata, copy=True, **kwargs)
     adata_layer = func(adata, layer="layer", copy=True, **kwargs)

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -13,7 +13,7 @@ X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
 @pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)
 @pytest.mark.parametrize('dtype', ['float32', 'int64'])
 def test_normalize_total(typ, dtype):
-    adata = AnnData(typ(X_total), dtype=dtype)
+    adata = AnnData(typ(X_total, dtype=dtype))
     sc.pp.normalize_total(adata, key_added='n_counts')
     assert np.allclose(np.ravel(adata.X.sum(axis=1)), [3.0, 3.0, 3.0])
     sc.pp.normalize_total(adata, target_sum=1, key_added='n_counts2')
@@ -27,7 +27,7 @@ def test_normalize_total(typ, dtype):
 @pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)
 @pytest.mark.parametrize('dtype', ['float32', 'int64'])
 def test_normalize_total_layers(typ, dtype):
-    adata = AnnData(typ(X_total), dtype=dtype)
+    adata = AnnData(typ(X_total, dtype=dtype))
     adata.layers["layer"] = adata.X.copy()
     sc.pp.normalize_total(adata, layers=["layer"])
     assert np.allclose(adata.layers["layer"].sum(axis=1), [3.0, 3.0, 3.0])
@@ -36,7 +36,7 @@ def test_normalize_total_layers(typ, dtype):
 @pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)
 @pytest.mark.parametrize('dtype', ['float32', 'int64'])
 def test_normalize_total_view(typ, dtype):
-    adata = AnnData(typ(X_total), dtype=dtype)
+    adata = AnnData(typ(X_total, dtype=dtype))
     v = adata[:, :]
 
     sc.pp.normalize_total(v)

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -152,7 +152,7 @@ def test_scale_array(count_matrix_format, zero_center):
     Test that running sc.pp.scale on an anndata object and an array returns the same results.
     """
     X = count_matrix_format(sp.random(100, 200, density=0.3).toarray())
-    adata = sc.AnnData(X=X.copy(), dtype=np.float64)
+    adata = sc.AnnData(X=X.copy())
 
     sc.pp.scale(adata, zero_center=zero_center)
     scaled_X = sc.pp.scale(X, zero_center=zero_center, copy=True)
@@ -257,7 +257,7 @@ def test_downsample_counts_per_cell(count_matrix_format, replace, dtype):
         * np.random.binomial(1, 0.3, (1000, 100))
     )
     X = X.astype(dtype)
-    adata = AnnData(X=count_matrix_format(X), dtype=dtype)
+    adata = AnnData(X=count_matrix_format(X).astype(dtype))
     with pytest.raises(ValueError):
         sc.pp.downsample_counts(
             adata, counts_per_cell=TARGET, total_counts=TARGET, replace=replace
@@ -293,7 +293,7 @@ def test_downsample_counts_per_cell_multiple_targets(
         * np.random.binomial(1, 0.3, (1000, 100))
     )
     X = X.astype(dtype)
-    adata = AnnData(X=count_matrix_format(X), dtype=dtype)
+    adata = AnnData(X=count_matrix_format(X).astype(dtype))
     initial_totals = np.ravel(adata.X.sum(axis=1))
     with pytest.raises(ValueError):
         sc.pp.downsample_counts(
@@ -324,7 +324,7 @@ def test_downsample_total_counts(count_matrix_format, replace, dtype):
         * np.random.binomial(1, 0.3, (1000, 100))
     )
     X = X.astype(dtype)
-    adata_orig = AnnData(X=count_matrix_format(X), dtype=dtype)
+    adata_orig = AnnData(X=count_matrix_format(X).astype(dtype))
     total = X.sum()
     target = np.floor_divide(total, 10)
     initial_totals = np.ravel(adata_orig.X.sum(axis=1))

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -103,8 +103,7 @@ def test_normalize_per_cell():
         sp.csr_matrix([[1, 0], [3, 0], [5, 6]]))
     sc.pp.normalize_per_cell(adata)
     sc.pp.normalize_per_cell(adata_sparse)
-    assert adata.X.sum(axis=1).tolist() == adata_sparse.X.sum(
-        axis=1).A1.tolist()
+    assert np.allclose(adata.X.sum(axis=1), adata_sparse.X.sum(axis=1))
 
 
 def test_subsample():

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -16,9 +16,9 @@ from scanpy.tests.helpers import check_rep_mutation, check_rep_results
 def test_log1p(tmp_path):
     A = np.random.rand(200, 10)
     A_l = np.log1p(A)
-    ad = AnnData(A)
-    ad2 = AnnData(A)
-    ad3 = AnnData(A)
+    ad = AnnData(A.copy())
+    ad2 = AnnData(A.copy())
+    ad3 = AnnData(A.copy())
     ad3.filename = tmp_path / 'test.h5ad'
     sc.pp.log1p(ad)
     assert np.allclose(ad.X, A_l)
@@ -28,7 +28,7 @@ def test_log1p(tmp_path):
     assert np.allclose(ad3.X, ad.X)
 
     # Test base
-    ad4 = AnnData(A)
+    ad4 = AnnData(A.copy())
     sc.pp.log1p(ad4, base=2)
     assert np.allclose(ad4.X, A_l/np.log(2))
 

--- a/scanpy/tests/test_scaling.py
+++ b/scanpy/tests/test_scaling.py
@@ -28,15 +28,15 @@ X_centered = [
 def test_scale(typ, dtype):
     ## test AnnData arguments
     # test scaling with default zero_center == True
-    adata0 = AnnData(typ(X), dtype=dtype)
+    adata0 = AnnData(typ(X, dtype=dtype))
     sc.pp.scale(adata0)
     assert np.allclose(csr_matrix(adata0.X).toarray(), X_centered)
     # test scaling with explicit zero_center == True
-    adata1 = AnnData(typ(X), dtype=dtype)
+    adata1 = AnnData(typ(X, dtype=dtype))
     sc.pp.scale(adata1, zero_center=True)
     assert np.allclose(csr_matrix(adata1.X).toarray(), X_centered)
     # test scaling with explicit zero_center == False
-    adata2 = AnnData(typ(X), dtype=dtype)
+    adata2 = AnnData(typ(X, dtype=dtype))
     sc.pp.scale(adata2, zero_center=False)
     assert np.allclose(csr_matrix(adata2.X).toarray(), X_scaled)
     ## test bare count arguments, for simplicity only with explicit copy=True


### PR DESCRIPTION
Companion PR to https://github.com/theislab/anndata/pull/434

Basically, I would like to deprecate the `dtype` argument of `AnnData._init_as_actual`, since it mostly just makes unexpected copies of `X`. Since other elements of an AnnData object are passed by reference, it makes sense for this to happen with `X` as well.

Right now, this PR will fail CI. What I've done so far is remove all uses of that argument from the scanpy code base, while keeping the tests passing. I'm trying to figure out how to best preserve compatibility with older versions of `anndata`, without throwing too many warnings.

I think the thing to do will be make code work with both (`AnnData(X.astype(dtype), dtype=dtype))` should only make one copy) and catch warnings. This can be removed once scanpy depends on `anndata 0.8`.