### PR TITLE
Import concat from absolute path, if import fails

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-anndata>=0.7
+anndata>=0.7.2
 # numpy needs a version due to #1320
 numpy>=1.17.0
 # Matplotlib 3.1 causes an error in 3d scatter plots (https://github.com/matplotlib/matplotlib/issues/14298)

--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -13,7 +13,11 @@ from . import preprocessing as pp
 from . import plotting as pl
 from . import datasets, logging, queries, external, get
 
-from anndata import AnnData, concat
+from anndata import AnnData
+try:
+    from anndata import concat
+except ImportError:
+    from anndata._core.merge import concat
 from anndata import read_h5ad, read_csv, read_excel, read_hdf, read_loom, read_mtx, read_text, read_umi_tools
 from .readwrite import read, read_10x_h5, read_10x_mtx, write, read_visium
 from .neighbors import Neighbors


### PR DESCRIPTION
Anndata's __init__.py is a shortcut, a full path
avoids the issue.

This PR uses the full path as fallback if the
shortcut fails.

Issue: #1439 