### PR TITLE
fixes type bug, now tagging exactly n_top_genes

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -256,7 +256,7 @@ def _highly_variable_genes_single_batch(
             ) / disp_mad_bin[df['mean_bin'].values].values
     else:
         raise ValueError('`flavor` needs to be "seurat" or "cell_ranger"')
-    dispersion_norm = df['dispersions_norm'].values.astype('float32')
+    dispersion_norm = df['dispersions_norm'].values
     if n_top_genes is not None:
         dispersion_norm = dispersion_norm[~np.isnan(dispersion_norm)]
         dispersion_norm[


### PR DESCRIPTION
Due to type conversion, often 1999 genes gets tagged as 'highly_variable' even though n_top_genes is set to 2000. 
Now, this minor change guarantees that exactly (!) n_top_genes get tagged.