### PR TITLE
`groupby` is converted to a list before adding as dendrogram key

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -2112,7 +2112,10 @@ def _get_dendrogram_key(adata, dendrogram_key, groupby):
     # the `dendrogram_key` can be a bool an NoneType or the name of the
     # dendrogram key. By default the name of the dendrogram key is 'dendrogram'
     if not isinstance(dendrogram_key, str):
-        dendrogram_key = f'dendrogram_{groupby}'
+        if isinstance(groupby, str):
+            dendrogram_key = f'dendrogram_{groupby}'
+        elif isinstance(groupby, list):
+            dendrogram_key = f'dendrogram_{"_".join(groupby)}'
 
     if dendrogram_key not in adata.uns:
         from ..tools._dendrogram import dendrogram

--- a/scanpy/tests/test_dendrogram_key_added.py
+++ b/scanpy/tests/test_dendrogram_key_added.py
@@ -1,0 +1,24 @@
+import scanpy as sc
+import numpy as np
+import pytest
+
+n_neighbors = 5
+key = 'test'
+
+
+@pytest.fixture
+def adata():
+    return sc.AnnData(sc.datasets.pbmc68k_reduced())
+
+@pytest.mark.parametrize('groupby', ['bulk_labels', ['bulk_labels', 'phase']])
+@pytest.mark.parametrize('key_added', [None, "custom_key"])
+def test_dendrogram_key_added(adata, groupby, key_added):
+    sc.tl.dendrogram(adata, groupby=groupby, key_added=key_added, use_rep="X_pca")
+    if isinstance(groupby, list):
+        dendrogram_key = f'dendrogram_{"_".join(groupby)}'
+    else:
+        dendrogram_key = f'dendrogram_{groupby}'
+
+    if key_added is None:
+        key_added = dendrogram_key
+    assert key_added in adata.uns

--- a/scanpy/tests/test_dendrogram_key_added.py
+++ b/scanpy/tests/test_dendrogram_key_added.py
@@ -10,6 +10,7 @@ key = 'test'
 def adata():
     return sc.AnnData(sc.datasets.pbmc68k_reduced())
 
+
 @pytest.mark.parametrize('groupby', ['bulk_labels', ['bulk_labels', 'phase']])
 @pytest.mark.parametrize('key_added', [None, "custom_key"])
 def test_dendrogram_key_added(adata, groupby, key_added):

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -156,10 +156,7 @@ def dendrogram(
 
     if inplace:
         if key_added is None:
-            if len(groupby) == 1:
-                key_added = f'dendrogram_{groupby[0]}'
-            else:
-                key_added = f'dendrogram_{"_".join(groupby)}'
+            key_added = f'dendrogram_{"_".join(groupby)}'
         logg.info(f'Storing dendrogram info using `.uns[{key_added!r}]`')
         adata.uns[key_added] = dat
     else:

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -156,7 +156,10 @@ def dendrogram(
 
     if inplace:
         if key_added is None:
-            key_added = f'dendrogram_{groupby}'
+            if len(groupby) == 1:
+                key_added = f'dendrogram_{groupby[0]}'
+            else:
+                key_added = f'{dendropgram_{"_".join(groupby)}'
         logg.info(f'Storing dendrogram info using `.uns[{key_added!r}]`')
         adata.uns[key_added] = dat
     else:

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -159,7 +159,7 @@ def dendrogram(
             if len(groupby) == 1:
                 key_added = f'dendrogram_{groupby[0]}'
             else:
-                key_added = f'{dendropgram_{"_".join(groupby)}'
+                key_added = f'dendropgram_{"_".join(groupby)}'
         logg.info(f'Storing dendrogram info using `.uns[{key_added!r}]`')
         adata.uns[key_added] = dat
     else:

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -159,7 +159,7 @@ def dendrogram(
             if len(groupby) == 1:
                 key_added = f'dendrogram_{groupby[0]}'
             else:
-                key_added = f'dendropgram_{"_".join(groupby)}'
+                key_added = f'dendrogram_{"_".join(groupby)}'
         logg.info(f'Storing dendrogram info using `.uns[{key_added!r}]`')
         adata.uns[key_added] = dat
     else:


### PR DESCRIPTION
Right now, if you specify `groupby` to `sc.tl.dendrogram`, but not `dendrogram_key`, storage (and subsequent retrieval) from `adata.uns` is messed up because `groupby` is converted from `str` --> `list` during computation.

To give a more concrete example, if my `groupby` variable was "cell_subtype", I would expect it to be stored in `adata.uns` as "dendrogram_cell_subtype". However, because of the list conversion it's stored as "dendrogram_['cell_subtype']" (shown below)

![image](https://user-images.githubusercontent.com/4998310/96769236-d5f77880-13ac-11eb-947f-3dbcf7069d82.png)


This PR attempts to address that. I'm not sure if this is the way you want to go about fixing it, but it's one option.

Thanks for the great package!

