### PR TITLE
Fix download path of pbmc3k_processed

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -9,6 +9,7 @@ On master
 * Fixed `log1p` inplace on integer dense arrays :pr:`1400` :smaller:`I Virshup`
 * Fixed `marker_gene_overlap` default value for `top_n_markers` :pr:`1464` :smaller:`MD Luecken`
 * Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`
+
 1.6.0 :small:`2020-08-15`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -8,7 +8,7 @@ On master
 
 * Fixed `log1p` inplace on integer dense arrays :pr:`1400` :smaller:`I Virshup`
 * Fixed `marker_gene_overlap` default value for `top_n_markers` :pr:`1464` :smaller:`MD Luecken`
-  
+* Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`
 1.6.0 :small:`2020-08-15`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -302,7 +302,7 @@ def pbmc3k_processed() -> AnnData:
         warnings.filterwarnings("ignore", category=FutureWarning, module="anndata")
         return read(
             settings.datasetdir / 'pbmc3k_processed.h5ad',
-            backup_url='https://raw.githubusercontent.com/chanzuckerberg/cellxgene/master/example-dataset/pbmc3k.h5ad',
+            backup_url='https://raw.githubusercontent.com/chanzuckerberg/cellxgene/main/example-dataset/pbmc3k.h5ad',
         )
 
 


### PR DESCRIPTION
The name of the `master` branch of the `cellxgene` repo changed to `main`. This results in a 404 error when trying to download the pbmc3k_processed dataset (see https://github.com/theislab/scanpy/issues/1471). This PR fixes that.