### PR TITLE
added support for individual cmaps for continous variables

### DIFF
--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -80,6 +80,9 @@ color_map
     or `mpl.cm.cividis`), see :func:`~matplotlib.cm.get_cmap`.
     If `None`, the value of `mpl.rcParams["image.cmap"]` is used.
     The default `color_map` can be set using :func:`~scanpy.set_figure_params`.
+    The color map can also be set individually for each value in adata.obs and
+    adata.var, by setting `adata.uns["{var}_cmap"]`. The individual values overwrite
+    `color_map`.
 palette
     Colors to use for plotting categorical annotation groups.
     The palette can be a valid :class:`~matplotlib.colors.ListedColormap` name

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -395,9 +395,9 @@ def embedding(
                 **kwargs,
             )
 
-            # in case continous cmap was individual, change back to global cmap
-            if not categorical and cmap != kwargs['cmap']:
-                kwargs['cmap'] = cmap
+        # in case continous cmap was individual, change back to global cmap
+        if not categorical and cmap != kwargs['cmap']:
+            kwargs['cmap'] = cmap
 
         # remove y and x ticks
         ax.set_yticks([])

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -258,6 +258,12 @@ def embedding(
             na_color=na_color,
         )
 
+        # change the cmap if individually defined in adata.uns
+        if not categorical and f"{value_to_plot}_cmap" in adata.uns:
+            cmap_ind = copy(get_cmap(adata.uns[f"{value_to_plot}_cmap"]))
+            cmap_ind.set_bad(na_color)
+            kwargs["cmap"] = cmap_ind
+
         ### Order points
         order = slice(None)
         if sort_order is True and value_to_plot is not None and categorical is False:
@@ -388,6 +394,10 @@ def embedding(
                 rasterized=settings._vector_friendly,
                 **kwargs,
             )
+
+            # in case continous cmap was individual, change back to global cmap
+            if not categorical and cmap != kwargs['cmap']:
+                kwargs['cmap'] = cmap
 
         # remove y and x ticks
         ax.set_yticks([])


### PR DESCRIPTION
As explained in plotting docs
> The color map can also be set individually for each value in adata.obs and adata.var, by setting `adata.uns["{var}_cmap"]`. The individual values overwrite `color_map`.

I think it's very useful when plotting multiple .obs or .var variables using "color", as the cmaps can then be defined for each embedding individually.