### PR TITLE
Require a minimum groupsize for marker detection to prevent division by zero errors

### DIFF
--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -518,7 +518,6 @@ def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize 
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
         groups_counts = adata.obs[key].value_counts()
-        valid_groups  = groups_counts.index[groups_counts >= min_groupsize]
         valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
         groups_order_subset = groups_order[ valid_groups ]
         groups_masks = groups_masks[ valid_groups ]

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -475,7 +475,7 @@ def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
         return True
 
 
-def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize = 1):
+def select_groups(adata, groups_order_subset='all', key='groups'):
     """Get subset of groups in adata.obs[key].
     """
     groups_order = adata.obs[key].cat.categories
@@ -507,21 +507,18 @@ def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize 
                     np.array(groups_order_subset),
                 )
             )[0]
-        if len(groups_ids) < min_groupsize:
+        if len(groups_ids) == 0:
             logg.debug(
                 f'{np.array(groups_order_subset)} invalid! specify valid '
                 f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
+
             exit(0)
         groups_masks = groups_masks[groups_ids]
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
-        groups_counts = adata.obs[key].value_counts()
-        valid_groups  = groups_counts.index[groups_counts >= min_groupsize]
-        valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
-        groups_order_subset = groups_order[ valid_groups ]
-        groups_masks = groups_masks[ valid_groups ]
+        groups_order_subset = groups_order.values
     return groups_order_subset, groups_masks
 
 

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -385,8 +385,7 @@ def sanitize_anndata(adata):
 def view_to_actual(adata):
     if adata.is_view:
         warnings.warn(
-            "Revieved a view of an AnnData. Making a copy.",
-            stacklevel=2,
+            "Revieved a view of an AnnData. Making a copy.", stacklevel=2,
         )
         adata._init_as_actual(adata.copy())
 
@@ -417,9 +416,7 @@ def moving_average(a: np.ndarray, n: int):
 
 
 def update_params(
-    old_params: Mapping[str, Any],
-    new_params: Mapping[str, Any],
-    check=False,
+    old_params: Mapping[str, Any], new_params: Mapping[str, Any], check=False,
 ) -> Dict[str, Any]:
     """\
     Update old_params with new_params.
@@ -461,7 +458,8 @@ def update_params(
 
 
 def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
-    """Checks values of X to ensure it is count data"""
+    """Checks values of X to ensure it is count data
+    """
     from numbers import Integral
 
     data = X if isinstance(X, np.ndarray) else X.data
@@ -477,8 +475,9 @@ def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
         return True
 
 
-def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize=1):
-    """Get subset of groups in adata.obs[key]."""
+def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize = 1):
+    """Get subset of groups in adata.obs[key].
+    """
     groups_order = adata.obs[key].cat.categories
     if key + '_masks' in adata.uns:
         groups_masks = adata.uns[key + '_masks']
@@ -514,18 +513,14 @@ def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize=
                 f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
-
             exit(0)
         groups_masks = groups_masks[groups_ids]
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
         groups_counts = adata.obs[key].value_counts()
-        valid_groups = [
-            item in groups_counts.index[groups_counts >= min_groupsize]
-            for item in groups_order
-        ]
-        groups_order_subset = groups_order[valid_groups]
-        groups_masks = groups_masks[valid_groups]
+        valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
+        groups_order_subset = groups_order[ valid_groups ]
+        groups_masks = groups_masks[ valid_groups ]
     return groups_order_subset, groups_masks
 
 
@@ -546,9 +541,7 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
 
 
 def subsample(
-    X: np.ndarray,
-    subsample: int = 1,
-    seed: int = 0,
+    X: np.ndarray, subsample: int = 1, seed: int = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """\
     Subsample a fraction of 1/subsample samples from the rows of X.

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -475,7 +475,7 @@ def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
         return True
 
 
-def select_groups(adata, groups_order_subset='all', key='groups'):
+def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize = 1):
     """Get subset of groups in adata.obs[key].
     """
     groups_order = adata.obs[key].cat.categories
@@ -507,18 +507,21 @@ def select_groups(adata, groups_order_subset='all', key='groups'):
                     np.array(groups_order_subset),
                 )
             )[0]
-        if len(groups_ids) == 0:
+        if len(groups_ids) < min_groupsize:
             logg.debug(
                 f'{np.array(groups_order_subset)} invalid! specify valid '
                 f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
-
             exit(0)
         groups_masks = groups_masks[groups_ids]
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
-        groups_order_subset = groups_order.values
+        groups_counts = adata.obs[key].value_counts()
+        valid_groups  = groups_counts.index[groups_counts >= min_groupsize]
+        valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
+        groups_order_subset = groups_order[ valid_groups ]
+        groups_masks = groups_masks[ valid_groups ]
     return groups_order_subset, groups_masks
 
 

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -518,6 +518,7 @@ def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize 
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
         groups_counts = adata.obs[key].value_counts()
+        valid_groups  = groups_counts.index[groups_counts >= min_groupsize]
         valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
         groups_order_subset = groups_order[ valid_groups ]
         groups_masks = groups_masks[ valid_groups ]

--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -385,7 +385,8 @@ def sanitize_anndata(adata):
 def view_to_actual(adata):
     if adata.is_view:
         warnings.warn(
-            "Revieved a view of an AnnData. Making a copy.", stacklevel=2,
+            "Revieved a view of an AnnData. Making a copy.",
+            stacklevel=2,
         )
         adata._init_as_actual(adata.copy())
 
@@ -416,7 +417,9 @@ def moving_average(a: np.ndarray, n: int):
 
 
 def update_params(
-    old_params: Mapping[str, Any], new_params: Mapping[str, Any], check=False,
+    old_params: Mapping[str, Any],
+    new_params: Mapping[str, Any],
+    check=False,
 ) -> Dict[str, Any]:
     """\
     Update old_params with new_params.
@@ -458,8 +461,7 @@ def update_params(
 
 
 def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
-    """Checks values of X to ensure it is count data
-    """
+    """Checks values of X to ensure it is count data"""
     from numbers import Integral
 
     data = X if isinstance(X, np.ndarray) else X.data
@@ -475,9 +477,8 @@ def check_nonnegative_integers(X: Union[np.ndarray, sparse.spmatrix]):
         return True
 
 
-def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize = 1):
-    """Get subset of groups in adata.obs[key].
-    """
+def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize=1):
+    """Get subset of groups in adata.obs[key]."""
     groups_order = adata.obs[key].cat.categories
     if key + '_masks' in adata.uns:
         groups_masks = adata.uns[key + '_masks']
@@ -513,14 +514,18 @@ def select_groups(adata, groups_order_subset='all', key='groups', min_groupsize 
                 f'groups_order (or indices) from {adata.obs[key].cat.categories}',
             )
             from sys import exit
+
             exit(0)
         groups_masks = groups_masks[groups_ids]
         groups_order_subset = adata.obs[key].cat.categories[groups_ids].values
     else:
         groups_counts = adata.obs[key].value_counts()
-        valid_groups = [ item in groups_counts.index[groups_counts >= min_groupsize] for item in groups_order ]
-        groups_order_subset = groups_order[ valid_groups ]
-        groups_masks = groups_masks[ valid_groups ]
+        valid_groups = [
+            item in groups_counts.index[groups_counts >= min_groupsize]
+            for item in groups_order
+        ]
+        groups_order_subset = groups_order[valid_groups]
+        groups_masks = groups_masks[valid_groups]
     return groups_order_subset, groups_masks
 
 
@@ -541,7 +546,9 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
 
 
 def subsample(
-    X: np.ndarray, subsample: int = 1, seed: int = 0,
+    X: np.ndarray,
+    subsample: int = 1,
+    seed: int = 0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """\
     Subsample a fraction of 1/subsample samples from the rows of X.

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -139,13 +139,13 @@ def test_results_layers():
     for name in true_scores_t_test.dtype.names:
         assert not np.allclose(true_scores_t_test[name][:7], adata.uns['rank_genes_groups']['scores'][name][:7])
 
-@pytest.mark.xfail
 def test_singlets():
     pbmc = pbmc68k_reduced()
     pbmc.obs['louvain'] = pbmc.obs['louvain'].cat.add_categories(['11'])
     pbmc.obs['louvain'][0] = '11' 
     
-    rank_genes_groups(pbmc, groupby = 'louvain')
+    with pytest.raises(ValueError, match=rf"Could not calculate statistics.*{'11'}"):
+        rank_genes_groups(pbmc, groupby = 'louvain')
 
 @pytest.mark.xfail
 def test_emptycat():

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -139,6 +139,20 @@ def test_results_layers():
     for name in true_scores_t_test.dtype.names:
         assert not np.allclose(true_scores_t_test[name][:7], adata.uns['rank_genes_groups']['scores'][name][:7])
 
+@pytest.mark.xfail
+def test_singlets():
+    pbmc = pbmc68k_reduced()
+    pbmc.obs['louvain'] = pbmc.obs['louvain'].cat.add_categories(['11'])
+    pbmc.obs['louvain'][0] = '11' 
+    
+    rank_genes_groups(pbmc, groupby = 'louvain')
+
+@pytest.mark.xfail
+def test_emptycat():
+    pbmc = pbmc68k_reduced()
+    pbmc.obs['louvain'] = pbmc.obs['louvain'].cat.add_categories(['11'])
+    
+    rank_genes_groups(pbmc, groupby = 'louvain')
 
 def test_wilcoxon_symmetry():
     pbmc = pbmc68k_reduced()

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -147,12 +147,12 @@ def test_singlets():
     with pytest.raises(ValueError, match=rf"Could not calculate statistics.*{'11'}"):
         rank_genes_groups(pbmc, groupby = 'louvain')
 
-@pytest.mark.xfail
 def test_emptycat():
     pbmc = pbmc68k_reduced()
     pbmc.obs['louvain'] = pbmc.obs['louvain'].cat.add_categories(['11'])
-    
-    rank_genes_groups(pbmc, groupby = 'louvain')
+
+    with pytest.raises(ValueError, match=rf"Could not calculate statistics.*{'11'}"):
+        rank_genes_groups(pbmc, groupby = 'louvain')
 
 def test_wilcoxon_symmetry():
     pbmc = pbmc68k_reduced()

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -98,6 +98,17 @@ class _RankGenes:
             adata, groups, groupby
         )
 
+        # Singlet groups cause division by zero errors
+        invalid_groups_selected = set(self.groups_order) & set(
+            adata.obs[groupby].value_counts().loc[lambda x: x < 2].index
+        )
+
+        if len(invalid_groups_selected) > 0:
+            raise ValueError(
+                "Could not calculate statistics for groups {} since they only "
+                "contain one sample.".format(', '.join(invalid_groups_selected))
+            )
+
         adata_comp = adata
         if layer is not None:
             if use_raw:

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -87,7 +87,6 @@ class _RankGenes:
         use_raw=True,
         layer=None,
         comp_pts=False,
-        min_groupsize=1,
     ):
 
         if 'log1p' in adata.uns_keys() and adata.uns['log1p']['base'] is not None:
@@ -96,7 +95,7 @@ class _RankGenes:
             self.expm1_func = np.expm1
 
         self.groups_order, self.groups_masks = _utils.select_groups(
-            adata, groups, groupby, min_groupsize
+            adata, groups, groupby, min_groupsize = 2
         )
 
         adata_comp = adata
@@ -420,7 +419,6 @@ def rank_genes_groups(
     groupby: str,
     use_raw: bool = True,
     groups: Union[Literal['all'], Iterable[str]] = 'all',
-    min_groupsize: int = 1,
     reference: str = 'rest',
     n_genes: Optional[int] = None,
     rankby_abs: bool = False,
@@ -451,9 +449,6 @@ def rank_genes_groups(
     groups
         Subset of groups, e.g. [`'g1'`, `'g2'`, `'g3'`], to which comparison
         shall be restricted, or `'all'` (default), for all groups.
-    min_groupsize
-        Where groups = 'all', filter the list of groups such that any with less
-        than this number of members are not considered. 
     reference
         If `'rest'`, compare each group to the union of the rest of the group.
         If a group identifier, compare with respect to this group.
@@ -575,9 +570,7 @@ def rank_genes_groups(
         corr_method=corr_method,
     )
 
-    test_obj = _RankGenes(
-        adata, groups_order, groupby, reference, use_raw, layer, pts, min_groupsize
-    )
+    test_obj = _RankGenes(adata, groups_order, groupby, reference, use_raw, layer, pts)
 
     # for clarity, rename variable
     n_genes_user = n_genes

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -87,6 +87,7 @@ class _RankGenes:
         use_raw=True,
         layer=None,
         comp_pts=False,
+        min_groupsize=1,
     ):
 
         if 'log1p' in adata.uns_keys() and adata.uns['log1p']['base'] is not None:
@@ -95,7 +96,7 @@ class _RankGenes:
             self.expm1_func = np.expm1
 
         self.groups_order, self.groups_masks = _utils.select_groups(
-            adata, groups, groupby, min_groupsize = 2
+            adata, groups, groupby, min_groupsize
         )
 
         adata_comp = adata
@@ -419,6 +420,7 @@ def rank_genes_groups(
     groupby: str,
     use_raw: bool = True,
     groups: Union[Literal['all'], Iterable[str]] = 'all',
+    min_groupsize: int = 1,
     reference: str = 'rest',
     n_genes: Optional[int] = None,
     rankby_abs: bool = False,
@@ -449,6 +451,9 @@ def rank_genes_groups(
     groups
         Subset of groups, e.g. [`'g1'`, `'g2'`, `'g3'`], to which comparison
         shall be restricted, or `'all'` (default), for all groups.
+    min_groupsize
+        Where groups = 'all', filter the list of groups such that any with less
+        than this number of members are not considered. 
     reference
         If `'rest'`, compare each group to the union of the rest of the group.
         If a group identifier, compare with respect to this group.
@@ -570,7 +575,9 @@ def rank_genes_groups(
         corr_method=corr_method,
     )
 
-    test_obj = _RankGenes(adata, groups_order, groupby, reference, use_raw, layer, pts)
+    test_obj = _RankGenes(
+        adata, groups_order, groupby, reference, use_raw, layer, pts, min_groupsize
+    )
 
     # for clarity, rename variable
     n_genes_user = n_genes

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -95,7 +95,7 @@ class _RankGenes:
             self.expm1_func = np.expm1
 
         self.groups_order, self.groups_masks = _utils.select_groups(
-            adata, groups, groupby, min_groupsize = 2
+            adata, groups, groupby
         )
 
         adata_comp = adata

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -95,7 +95,7 @@ class _RankGenes:
             self.expm1_func = np.expm1
 
         self.groups_order, self.groups_masks = _utils.select_groups(
-            adata, groups, groupby
+            adata, groups, groupby, min_groupsize = 2
         )
 
         adata_comp = adata


### PR DESCRIPTION

Currently, if a set of cell groups has any groups with only one cell, attempting to run rank_genes_groups() gets you an error like:

```
>>> sc.tl.rank_genes_groups(ad, 'louvain_resolution_3.0')
WARNING: Default of the method has been changed to 't-test' from 't-test_overestim_var'
ranking genes
    consider 'louvain_resolution_3.0' groups:
    with sizes: [28 13 13 11 10  9  9  8  8  8  8  7  6  6  6  4  3  3  1  1  1]
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/path/to/scanpy/tools/_rank_genes_groups.py", line 584, in rank_genes_groups
    method, corr_method, n_genes_user, rankby_abs, tie_correct, **kwds
  File "/path/to/scanpy/tools/_rank_genes_groups.py", line 365, in compute_statistics
    for group_index, scores, pvals in generate_test_results:
  File "/path/to/scanpy/tools/_rank_genes_groups.py", line 187, in t_test
    self._basic_stats()
  File "/path/to/scanpy/tools/_rank_genes_groups.py", line 172, in _basic_stats
    self.means[imask], self.vars[imask] = _get_mean_var(X_mask)
  File "/path/to/scanpy/preprocessing/_utils.py", line 14, in _get_mean_var
    var *= X.shape[axis] / (X.shape[axis] - 1)
ZeroDivisionError: division by zero
```

The fix I've come up with is to filter groups by size when calling select_groups(), happy to help on alternate approaches if required. 