### PR TITLE
Bump anndata required version for `anndata.concat`

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -9,6 +9,7 @@ On master
 * Fixed `log1p` inplace on integer dense arrays :pr:`1400` :smaller:`I Virshup`
 * Fixed `marker_gene_overlap` default value for `top_n_markers` :pr:`1464` :smaller:`MD Luecken`
 * Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`
+* Fixed anndata version requirement for `sc.concat` :pr:`1491` :smaller:`I Virshup`
 
 1.6.0 :small:`2020-08-15`
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-anndata>=0.7
+anndata>=0.7.4
 # numpy needs a version due to #1320
 numpy>=1.17.0
 # Matplotlib 3.1 causes an error in 3d scatter plots (https://github.com/matplotlib/matplotlib/issues/14298)


### PR DESCRIPTION
Fixes #1439