### PR TITLE
Bugfix: Failure due to cugraph api change in v0.16...

### DIFF
--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -170,7 +170,12 @@ def louvain(
         else:
             weights = None
         g = cugraph.Graph()
-        g.add_adj_list(offsets, indices, weights)
+
+        if hasattr(g, 'add_adj_list'):
+            g.add_adj_list(offsets, indices, weights)
+        else:
+            g.from_cudf_adjlist(offsets, indices, weights)
+
         logg.info('    using the "louvain" package of rapids')
         louvain_parts, _ = cugraph.louvain(g)
         groups = louvain_parts.to_pandas().sort_values('vertex')[['partition']].to_numpy().ravel()


### PR DESCRIPTION
Method cugraph.add_adj_list is replaced in RAPIDS v0.16 with from_cudf_adjlist.
This patch will check for existence of 'add_adj_list' in the object before
calling it.