### PR TITLE
Speedup sc.get.obs_df

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -12,6 +12,10 @@ On master
 * Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`
 * Fixed anndata version requirement for `sc.concat` :pr:`1491` :smaller:`I Virshup`
 
+.. rubric:: Performance
+
+* Sped up `sc.get.obs_df` signifigantly :pr:`1499` :smaller:`F Ramirez`
+
 1.6.0 :small:`2020-08-15`
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -176,6 +176,9 @@ def obs_df(
     if len(var_names) > 0:
         X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
         matrix = X[:, adata.var_names.get_indexer(var_names)]
+        from scipy.sparse import issparse
+        if issparse(matrix):
+            matrix = matrix.toarray()
         df = df.join(pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index))
 
     # add obs values
@@ -251,6 +254,10 @@ def var_df(
     if len(obs_names) > 0:
         X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
         matrix = X[adata.obs_names.get_indexer(obs_names), :]
+        from scipy.sparse import issparse
+        if issparse(matrix):
+            matrix = matrix.toarray()
+
         df = df.join(pd.DataFrame(matrix.T, columns=obs_names, index=adata.var.index))
 
     # add obs values

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -170,20 +170,17 @@ def obs_df(
         )
 
     # Make df
-    df_var = df_obs = None
+    df = pd.DataFrame(index=adata.obs.index)
 
-    # prepare var values
+    # add var values
     if len(var_names) > 0:
         X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
         matrix = X[:, adata.var_names.get_indexer(var_names)]
-        df_var = pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index)
+        df = df.join(pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index))
 
-    # prepare obs values
+    # add obs values
     if len(obs_names) > 0:
-        df_obs = adata.obs[obs_names]
-
-    # concatenate and reorder after given `keys`
-    df = pd.concat([df_obs, df_var], axis=1)[keys]
+        df.join(adata.obs[obs_names])
 
     for k, idx in obsm_keys:
         added_k = f"{k}-{idx}"

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -174,23 +174,8 @@ def obs_df(
 
     # prepare var values
     if len(var_names) > 0:
-        if layer is not None:
-            if layer not in adata.layers.keys():
-                raise KeyError(
-                    f'Selected layer: {layer} is not in the layers list. '
-                    f'The list of valid layers is: {adata.layers.keys()}'
-                )
-            matrix = adata[:, var_names].layers[layer]
-        elif use_raw:
-            matrix = adata.raw[:, var_names].X
-        else:
-            matrix = adata[:, var_names].X
-
-        from scipy.sparse import issparse
-
-        if issparse(matrix):
-            matrix = matrix.toarray()
-
+        X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
+        matrix = X[:, adata.var_names.get_indexer(var_names)]
         df_var = pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index)
 
     # prepare obs values

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -175,7 +175,12 @@ def obs_df(
     # add var values
     if len(var_names) > 0:
         X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
-        matrix = X[:, adata.var_names.get_indexer(var_names)]
+        if use_raw:
+            var_idx = adata.raw.var_names.get_indexer(var_names)
+            print(var_names, var_symbol)
+        else:
+            var_idx = adata.var_names.get_indexer(var_names)
+        matrix = X[:, var_idx]
         from scipy.sparse import issparse
         if issparse(matrix):
             matrix = matrix.toarray()

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -170,28 +170,32 @@ def obs_df(
         )
 
     # Make df
+    df_var = df_obs = None
+
     # prepare var values
-    if layer is not None:
-        if layer not in adata.layers.keys():
-            raise KeyError(
-                f'Selected layer: {layer} is not in the layers list. '
-                f'The list of valid layers is: {adata.layers.keys()}'
-            )
-        matrix = adata[:, var_names].layers[layer]
-    elif use_raw:
-        matrix = adata.raw[:, var_names].X
-    else:
-        matrix = adata[:, var_names].X
+    if len(var_names) > 0:
+        if layer is not None:
+            if layer not in adata.layers.keys():
+                raise KeyError(
+                    f'Selected layer: {layer} is not in the layers list. '
+                    f'The list of valid layers is: {adata.layers.keys()}'
+                )
+            matrix = adata[:, var_names].layers[layer]
+        elif use_raw:
+            matrix = adata.raw[:, var_names].X
+        else:
+            matrix = adata[:, var_names].X
 
-    from scipy.sparse import issparse
+        from scipy.sparse import issparse
 
-    if issparse(matrix):
-        matrix = matrix.toarray()
+        if issparse(matrix):
+            matrix = matrix.toarray()
 
-    df_var = pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index)
+        df_var = pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index)
 
     # prepare obs values
-    df_obs = adata.obs[obs_names]
+    if len(obs_names) > 0:
+        df_obs = adata.obs[obs_names]
 
     # concatenate and reorder after given `keys`
     df = pd.concat([df_obs, df_var], axis=1)[keys]

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -210,7 +210,6 @@ def var_df(
     varm_keys: Iterable[Tuple[str, int]] = (),
     *,
     layer: str = None,
-    use_raw: bool = False,
 ) -> pd.DataFrame:
     """\
     Return values for observations in adata.
@@ -225,8 +224,6 @@ def var_df(
         Tuple of `(key from varm, column index of varm[key])`.
     layer
         Layer of `adata` to use as expression values.
-    use_raw
-        Whether to get expression values from `adata.raw`.
 
     Returns
     -------
@@ -240,8 +237,6 @@ def var_df(
     for key in keys:
         if key in adata.obs_names:
             obs_names.append(key)
-        elif use_raw and key in adata.raw.var.columns:
-            var_names.append(key)
         elif key in adata.var.columns:
             var_names.append(key)
         else:
@@ -257,7 +252,7 @@ def var_df(
 
     # add obs values
     if len(obs_names) > 0:
-        X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
+        X = _get_obs_rep(adata, layer=layer)
         matrix = X[adata.obs_names.get_indexer(obs_names), :]
         from scipy.sparse import issparse
         if issparse(matrix):
@@ -267,10 +262,7 @@ def var_df(
 
     # add obs values
     if len(var_names) > 0:
-        if use_raw:
-            df = df.join(adata.raw.var[var_names])
-        else:
-            df = df.join(adata.var[var_names])
+        df = df.join(adata.var[var_names])
 
     # reorder columns to given order
     df = df[keys]

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -176,11 +176,11 @@ def obs_df(
     if len(var_names) > 0:
         X = _get_obs_rep(adata, layer=layer, use_raw=use_raw)
         if use_raw:
-            var_idx = adata.raw.var_names.get_indexer(var_names)
+            var_bool = adata.raw.var.index.isin(var_names)
             print(var_names, var_symbol)
         else:
-            var_idx = adata.var_names.get_indexer(var_names)
-        matrix = X[:, var_idx]
+            var_bool = adata.var.index.isin(var_names)
+        matrix = X[:, var_bool]
         from scipy.sparse import issparse
         if issparse(matrix):
             matrix = matrix.toarray()
@@ -253,7 +253,7 @@ def var_df(
     # add obs values
     if len(obs_names) > 0:
         X = _get_obs_rep(adata, layer=layer)
-        matrix = X[adata.obs_names.get_indexer(obs_names), :]
+        matrix = X[adata.obs.index.isin(obs_names), :]
         from scipy.sparse import issparse
         if issparse(matrix):
             matrix = matrix.toarray()

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -183,6 +183,7 @@ def obs_df(
         # for backed AnnData is important that the indices are ordered
         var_order = np.argsort(var_idx)
         matrix = X[:, var_idx[var_order]]
+
         from scipy.sparse import issparse
 
         if issparse(matrix):

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -3,7 +3,7 @@ from typing import Optional, Iterable, Tuple
 
 import numpy as np
 import pandas as pd
-from scipy.sparse import spmatrix
+from scipy.sparse import spmatrix, issparse
 
 from anndata import AnnData
 
@@ -181,18 +181,17 @@ def obs_df(
             var_idx = adata.var_names.get_indexer(var_names)
 
         # for backed AnnData is important that the indices are ordered
-        var_order = np.argsort(var_idx)
-        matrix = X[:, var_idx[var_order]]
+        if adata.isbacked:
+            var_order = np.argsort(var_idx)
+            matrix = X[:, var_idx[var_order]][:, np.argsort(var_order)]
+        else:
+            matrix = X[:, var_idx]
 
         from scipy.sparse import issparse
 
         if issparse(matrix):
             matrix = matrix.toarray()
-        df = df.join(
-            pd.DataFrame(
-                matrix, columns=np.array(var_symbol)[var_order], index=adata.obs.index
-            )
-        )
+        df = df.join(pd.DataFrame(matrix, columns=var_symbol, index=adata.obs.index))
 
     # add obs values
     if len(obs_names) > 0:
@@ -264,18 +263,17 @@ def var_df(
         obs_idx = adata.obs_names.get_indexer(obs_names)
 
         # for backed AnnData is important that the indices are ordered
-        obs_order = np.argsort(obs_idx)
-        matrix = X[obs_idx[obs_order], :]
+        if adata.isbacked:
+            obs_order = np.argsort(obs_idx)
+            matrix = X[obs_idx[obs_order], :][np.argsort(obs_order)]
+        else:
+            matrix = X[obs_idx, :]
         from scipy.sparse import issparse
 
         if issparse(matrix):
             matrix = matrix.toarray()
 
-        df = df.join(
-            pd.DataFrame(
-                matrix.T, columns=np.array(obs_names)[obs_order], index=adata.var.index
-            )
-        )
+        df = df.join(pd.DataFrame(matrix.T, columns=obs_names, index=adata.var.index))
 
     # add obs values
     if len(var_names) > 0:

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -32,9 +32,13 @@ def test_obs_df(adata):
     adata.obsm["eye"] = np.eye(2, dtype=int)
     adata.obsm["sparse"] = sparse.csr_matrix(np.eye(2), dtype='float64')
 
+    # make raw with different genes than adata
     adata.raw = AnnData(
-        X=np.zeros((2, 2)),
-        var=pd.DataFrame({"gene_symbols": ["raw1", "raw2"]}, index=["gene1", "gene2"]),
+        X=np.array([[1, 2, 3], [2, 4, 6]]),
+        var=pd.DataFrame(
+            {"gene_symbols": ["raw1", "raw2", 'raw3']},
+            index=["gene2", "gene3", "gene4"],
+        ),
         dtype='float64',
     )
     pd.testing.assert_frame_equal(
@@ -70,9 +74,15 @@ def test_obs_df(adata):
 
     pd.testing.assert_frame_equal(
         sc.get.obs_df(
-            adata, keys=["raw2", "obs1"], gene_symbols="gene_symbols", use_raw=True
+            adata,
+            keys=["raw2", "raw3", "obs1"],
+            gene_symbols="gene_symbols",
+            use_raw=True,
         ),
-        pd.DataFrame({"raw2": [0.0, 0.0], "obs1": [0, 1]}, index=adata.obs_names),
+        pd.DataFrame(
+            {"raw2": [2.0, 4.0], "raw3": [3.0, 6.0], "obs1": [0, 1]},
+            index=adata.obs_names,
+        ),
     )
     # test only obs
     pd.testing.assert_frame_equal(

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -19,77 +19,66 @@ def adata():
         var=pd.DataFrame(
             {"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]
         ),
-        layers={"double": np.ones((2, 2)) * 2},
+        layers={"double": np.ones((2, 2), dtype=int) * 2},
+        dtype=int,
     )
 
 
 def test_obs_df(adata):
-    adata.obsm["eye"] = np.eye(2)
-    adata.obsm["sparse"] = sparse.csr_matrix(np.eye(2))
+    adata.obsm["eye"] = np.eye(2, dtype=int)
+    adata.obsm["sparse"] = sparse.csr_matrix(np.eye(2), dtype='float64')
 
     adata.raw = AnnData(
         X=np.zeros((2, 2)),
         var=pd.DataFrame({"gene_symbols": ["raw1", "raw2"]}, index=["gene1", "gene2"]),
+        dtype='float64',
     )
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(
-                adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)]
-            ),
-            pd.DataFrame(
-                {"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]},
-                index=adata.obs_names,
-            ),
-        )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(
+            adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)]
+        ),
+        pd.DataFrame(
+            {"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0.0, 1.0]},
+            index=adata.obs_names,
+        ),
     )
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(
-                adata,
-                keys=["genesymbol2", "obs1"],
-                obsm_keys=[("eye", 0), ("sparse", 1)],
-                gene_symbols="gene_symbols",
-            ),
-            pd.DataFrame(
-                {
-                    "genesymbol2": [1, 1],
-                    "obs1": [0, 1],
-                    "eye-0": [1, 0],
-                    "sparse-1": [0, 1],
-                },
-                index=adata.obs_names,
-            ),
-        )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(
+            adata,
+            keys=["genesymbol2", "obs1"],
+            obsm_keys=[("eye", 0), ("sparse", 1)],
+            gene_symbols="gene_symbols",
+        ),
+        pd.DataFrame(
+            {
+                "genesymbol2": [1, 1],
+                "obs1": [0, 1],
+                "eye-0": [1, 0],
+                "sparse-1": [0.0, 1.0],
+            },
+            index=adata.obs_names,
+        ),
     )
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(adata, keys=["gene2", "obs1"], layer="double"),
-            pd.DataFrame({"gene2": [2, 2], "obs1": [0, 1]}, index=adata.obs_names),
-        )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(adata, keys=["gene2", "obs1"], layer="double"),
+        pd.DataFrame({"gene2": [2, 2], "obs1": [0, 1]}, index=adata.obs_names),
     )
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(
-                adata, keys=["raw2", "obs1"], gene_symbols="gene_symbols", use_raw=True
-            ),
-            pd.DataFrame({"raw2": [0, 0], "obs1": [0, 1]}, index=adata.obs_names),
-        )
+
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(
+            adata, keys=["raw2", "obs1"], gene_symbols="gene_symbols", use_raw=True
+        ),
+        pd.DataFrame({"raw2": [0.0, 0.0], "obs1": [0, 1]}, index=adata.obs_names),
     )
     # test only obs
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(adata, keys=["obs1", "obs2"]),
-            pd.DataFrame(
-                {"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]
-            ),
-        )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(adata, keys=["obs1", "obs2"]),
+        pd.DataFrame({"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]),
     )
     # test only var
-    assert np.all(
-        np.equal(
-            sc.get.obs_df(adata, keys=["gene1", "gene2"]),
-            pd.DataFrame({"gene1": [1, 1], "gene2": [1, 1]}, index=adata.obs_names),
-        )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(adata, keys=["gene1", "gene2"]),
+        pd.DataFrame({"gene1": [1, 1], "gene2": [1, 1]}, index=adata.obs_names),
     )
     badkeys = ["badkey1", "badkey2"]
     with pytest.raises(KeyError) as badkey_err:

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -88,6 +88,24 @@ def test_obs_df(adata):
     assert all(badkey_err.match(k) for k in badkeys)
 
 
+def test_obs_df_backed_vs_memory():
+    "compares backed vs. memory"
+    from pathlib import Path
+
+    # get location test h5ad file in datasets
+    HERE = Path(sc.__file__).parent
+    adata_file = HERE / "datasets/10x_pbmc68k_reduced.h5ad"
+    adata_backed = sc.read(adata_file, backed='r')
+    adata = sc.read_h5ad(adata_file,)
+
+    genes = list(adata.var_names[:10])
+    obs_names = ['bulk_labels', 'n_genes']
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(adata, keys=genes + obs_names),
+        sc.get.obs_df(adata_backed, keys=genes + obs_names),
+    )
+
+
 def test_var_df(adata):
     adata.varm["eye"] = np.eye(2, dtype=int)
     adata.varm["sparse"] = sparse.csr_matrix(np.eye(2), dtype='float64')

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -13,8 +13,12 @@ import scanpy as sc
 def adata():
     return AnnData(
         X=np.ones((2, 2)),
-        obs=pd.DataFrame({"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]),
-        var=pd.DataFrame({"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]),
+        obs=pd.DataFrame(
+            {"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]
+        ),
+        var=pd.DataFrame(
+            {"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]
+        ),
         layers={"double": np.ones((2, 2)) * 2},
     )
 
@@ -27,22 +31,66 @@ def test_obs_df(adata):
         X=np.zeros((2, 2)),
         var=pd.DataFrame({"gene_symbols": ["raw1", "raw2"]}, index=["gene1", "gene2"]),
     )
-    assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)]),
-        pd.DataFrame({"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names),
-    ))
-    assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["genesymbol2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)], gene_symbols="gene_symbols"),
-        pd.DataFrame({"genesymbol2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names),
-    ))
-    assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["gene2", "obs1"], layer="double"),
-        pd.DataFrame({"gene2": [2, 2], "obs1": [0, 1]}, index=adata.obs_names),
-    ))
-    assert np.all(np.equal(
-        sc.get.obs_df(adata, keys=["raw2", "obs1"], gene_symbols="gene_symbols", use_raw=True),
-        pd.DataFrame({"raw2": [0, 0], "obs1": [0, 1]}, index=adata.obs_names),
-    ))
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(
+                adata, keys=["gene2", "obs1"], obsm_keys=[("eye", 0), ("sparse", 1)]
+            ),
+            pd.DataFrame(
+                {"gene2": [1, 1], "obs1": [0, 1], "eye-0": [1, 0], "sparse-1": [0, 1]},
+                index=adata.obs_names,
+            ),
+        )
+    )
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(
+                adata,
+                keys=["genesymbol2", "obs1"],
+                obsm_keys=[("eye", 0), ("sparse", 1)],
+                gene_symbols="gene_symbols",
+            ),
+            pd.DataFrame(
+                {
+                    "genesymbol2": [1, 1],
+                    "obs1": [0, 1],
+                    "eye-0": [1, 0],
+                    "sparse-1": [0, 1],
+                },
+                index=adata.obs_names,
+            ),
+        )
+    )
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(adata, keys=["gene2", "obs1"], layer="double"),
+            pd.DataFrame({"gene2": [2, 2], "obs1": [0, 1]}, index=adata.obs_names),
+        )
+    )
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(
+                adata, keys=["raw2", "obs1"], gene_symbols="gene_symbols", use_raw=True
+            ),
+            pd.DataFrame({"raw2": [0, 0], "obs1": [0, 1]}, index=adata.obs_names),
+        )
+    )
+    # test only obs
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(adata, keys=["obs1", "obs2"]),
+            pd.DataFrame(
+                {"obs1": [0, 1], "obs2": ["a", "b"]}, index=["cell1", "cell2"]
+            ),
+        )
+    )
+    # test only var
+    assert np.all(
+        np.equal(
+            sc.get.obs_df(adata, keys=["gene1", "gene2"]),
+            pd.DataFrame({"gene1": [1, 1], "gene2": [1, 1]}, index=adata.obs_names),
+        )
+    )
     badkeys = ["badkey1", "badkey2"]
     with pytest.raises(KeyError) as badkey_err:
         sc.get.obs_df(adata, keys=badkeys)
@@ -55,14 +103,33 @@ def test_var_df(adata):
     adata.varm["eye"] = np.eye(2)
     adata.varm["sparse"] = sparse.csr_matrix(np.eye(2))
 
-    assert np.all(np.equal(
-        sc.get.var_df(adata, keys=["cell2", "gene_symbols"], varm_keys=[("eye", 0), ("sparse", 1)]),
-        pd.DataFrame({"cell2": [1, 1], "gene_symbols": ["genesymbol1", "genesymbol2"], "eye-0": [1, 0], "sparse-1": [0, 1]}, index=adata.obs_names),
-    ))
-    assert np.all(np.equal(
-        sc.get.var_df(adata, keys=["cell1", "gene_symbols"], layer="double"),
-        pd.DataFrame({"cell1": [2, 2], "gene_symbols": ["genesymbol1", "genesymbol2"]}, index=adata.obs_names),
-    ))
+    assert np.all(
+        np.equal(
+            sc.get.var_df(
+                adata,
+                keys=["cell2", "gene_symbols"],
+                varm_keys=[("eye", 0), ("sparse", 1)],
+            ),
+            pd.DataFrame(
+                {
+                    "cell2": [1, 1],
+                    "gene_symbols": ["genesymbol1", "genesymbol2"],
+                    "eye-0": [1, 0],
+                    "sparse-1": [0, 1],
+                },
+                index=adata.obs_names,
+            ),
+        )
+    )
+    assert np.all(
+        np.equal(
+            sc.get.var_df(adata, keys=["cell1", "gene_symbols"], layer="double"),
+            pd.DataFrame(
+                {"cell1": [2, 2], "gene_symbols": ["genesymbol1", "genesymbol2"]},
+                index=adata.obs_names,
+            ),
+        )
+    )
     badkeys = ["badkey1", "badkey2"]
     with pytest.raises(KeyError) as badkey_err:
         sc.get.var_df(adata, keys=badkeys)
@@ -82,10 +149,10 @@ def test_rank_genes_groups_df():
     )
     sc.tl.rank_genes_groups(adata, groupby="celltype", method="wilcoxon")
     dedf = sc.get.rank_genes_groups_df(adata, "a")
-    assert dedf["pvals"].value_counts()[1.] == 2
-    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_max=.1).shape[0] == 2
-    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_min=.1).shape[0] == 1
-    assert sc.get.rank_genes_groups_df(adata, "a", pval_cutoff=.9).shape[0] == 1
+    assert dedf["pvals"].value_counts()[1.0] == 2
+    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_max=0.1).shape[0] == 2
+    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_min=0.1).shape[0] == 1
+    assert sc.get.rank_genes_groups_df(adata, "a", pval_cutoff=0.9).shape[0] == 1
     del adata.uns["rank_genes_groups"]
     sc.tl.rank_genes_groups(
         adata, groupby="celltype", method="wilcoxon", key_added="different_key"

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -129,12 +129,6 @@ def test_var_df(adata):
     adata.varm["eye"] = np.eye(2, dtype=int)
     adata.varm["sparse"] = sparse.csr_matrix(np.eye(2), dtype='float64')
 
-    adata.raw = AnnData(
-        X=np.zeros((2, 2)),
-        var=pd.DataFrame({"gene_symbols": ["raw1", "raw2"]}, index=["gene1", "gene2"]),
-        dtype='float64',
-    )
-
     pd.testing.assert_frame_equal(
         sc.get.var_df(
             adata,
@@ -155,14 +149,6 @@ def test_var_df(adata):
         sc.get.var_df(adata, keys=["cell1", "gene_symbols"], layer="double"),
         pd.DataFrame(
             {"cell1": [2, 2], "gene_symbols": ["genesymbol1", "genesymbol2"]},
-            index=adata.var_names,
-        ),
-    )
-    # test use_raw=True
-    pd.testing.assert_frame_equal(
-        sc.get.var_df(adata, keys=["cell1", "gene_symbols"], use_raw=True),
-        pd.DataFrame(
-            {"cell1": [0.0, 0.0], "gene_symbols": ["raw1", "raw2"]},
             index=adata.var_names,
         ),
     )

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -92,6 +92,12 @@ def test_var_df(adata):
     adata.varm["eye"] = np.eye(2, dtype=int)
     adata.varm["sparse"] = sparse.csr_matrix(np.eye(2), dtype='float64')
 
+    adata.raw = AnnData(
+        X=np.zeros((2, 2)),
+        var=pd.DataFrame({"gene_symbols": ["raw1", "raw2"]}, index=["gene1", "gene2"]),
+        dtype='float64',
+    )
+
     pd.testing.assert_frame_equal(
         sc.get.var_df(
             adata,
@@ -112,6 +118,14 @@ def test_var_df(adata):
         sc.get.var_df(adata, keys=["cell1", "gene_symbols"], layer="double"),
         pd.DataFrame(
             {"cell1": [2, 2], "gene_symbols": ["genesymbol1", "genesymbol2"]},
+            index=adata.var_names,
+        ),
+    )
+    # test use_raw=True
+    pd.testing.assert_frame_equal(
+        sc.get.var_df(adata, keys=["cell1", "gene_symbols"], use_raw=True),
+        pd.DataFrame(
+            {"cell1": [0.0, 0.0], "gene_symbols": ["raw1", "raw2"]},
             index=adata.var_names,
         ),
     )

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -11,6 +11,10 @@ import scanpy as sc
 
 @pytest.fixture
 def adata():
+    """
+    adata.X is np.ones((2, 2))
+    adata.layers['double'] is sparse np.ones((2,2)) * 2 to also test sparse matrices
+    """
     return AnnData(
         X=np.ones((2, 2)),
         obs=pd.DataFrame(
@@ -19,7 +23,7 @@ def adata():
         var=pd.DataFrame(
             {"gene_symbols": ["genesymbol1", "genesymbol2"]}, index=["gene1", "gene2"]
         ),
-        layers={"double": np.ones((2, 2), dtype=int) * 2},
+        layers={"double": sparse.csr_matrix(np.ones((2, 2)), dtype=int) * 2},
         dtype=int,
     )
 
@@ -80,6 +84,11 @@ def test_obs_df(adata):
         sc.get.obs_df(adata, keys=["gene1", "gene2"]),
         pd.DataFrame({"gene1": [1, 1], "gene2": [1, 1]}, index=adata.obs_names),
     )
+    pd.testing.assert_frame_equal(
+        sc.get.obs_df(adata, keys=["gene1", "gene2"]),
+        pd.DataFrame({"gene1": [1, 1], "gene2": [1, 1]}, index=adata.obs_names),
+    )
+
     badkeys = ["badkey1", "badkey2"]
     with pytest.raises(KeyError) as badkey_err:
         sc.get.obs_df(adata, keys=badkeys)

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -129,8 +129,30 @@ def test_backed_vs_memory():
     cell_indices = list(adata.obs_names[30::-2])
     pd.testing.assert_frame_equal(
         sc.get.var_df(adata, keys=cell_indices + ["highly_variable"]),
-        sc.get.var_df(adata_backed, keys=cell_indices + ["highly_variable"])
+        sc.get.var_df(adata_backed, keys=cell_indices + ["highly_variable"]),
     )
+
+
+def test_column_content():
+    "uses a larger dataset to test column order and content"
+    adata = sc.datasets.pbmc68k_reduced()
+
+    # test that columns content is correct for obs_df
+    query = ['CST3', 'NKG7', 'GNLY', 'louvain', 'n_counts', 'n_genes']
+    df = sc.get.obs_df(adata, query)
+    for col in query:
+        assert col in df
+        np.testing.assert_array_equal(query, df.columns)
+        np.testing.assert_array_equal(df[col].values, adata.obs_vector(col))
+
+    # test that columns content is correct for var_df
+    cell_ids = list(adata.obs.sample(5).index)
+    query = cell_ids + ['highly_variable', 'dispersions_norm', 'dispersions']
+    df = sc.get.var_df(adata, query)
+    for col in query:
+        assert col in df
+        np.testing.assert_array_equal(query, df.columns)
+        np.testing.assert_array_equal(df[col].values, adata.var_vector(col))
 
 
 def test_var_df(adata):

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -107,7 +107,7 @@ def test_obs_df(adata):
     assert all(badkey_err.match(k) for k in badkeys)
 
 
-def test_obs_df_backed_vs_memory():
+def test_backed_vs_memory():
     "compares backed vs. memory"
     from pathlib import Path
 
@@ -117,11 +117,19 @@ def test_obs_df_backed_vs_memory():
     adata_backed = sc.read(adata_file, backed='r')
     adata = sc.read_h5ad(adata_file,)
 
-    genes = list(adata.var_names[:10])
+    # use non-sequential list of genes
+    genes = list(adata.var_names[20::-2])
     obs_names = ['bulk_labels', 'n_genes']
     pd.testing.assert_frame_equal(
         sc.get.obs_df(adata, keys=genes + obs_names),
         sc.get.obs_df(adata_backed, keys=genes + obs_names),
+    )
+
+    # use non-sequential list of cell indices
+    cell_indices = list(adata.obs_names[30::-2])
+    pd.testing.assert_frame_equal(
+        sc.get.var_df(adata, keys=cell_indices + ["highly_variable"]),
+        sc.get.var_df(adata_backed, keys=cell_indices + ["highly_variable"])
     )
 
 

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -149,9 +149,8 @@ def test_column_content():
     cell_ids = list(adata.obs.sample(5).index)
     query = cell_ids + ['highly_variable', 'dispersions_norm', 'dispersions']
     df = sc.get.var_df(adata, query)
+    np.testing.assert_array_equal(query, df.columns)
     for col in query:
-        assert col in df
-        np.testing.assert_array_equal(query, df.columns)
         np.testing.assert_array_equal(df[col].values, adata.var_vector(col))
 
 


### PR DESCRIPTION
By using array slicing, this codes improves ~10 fold the speed of `sc.get.obs_df()`.

```PYTHON
%timeit sc.get.obs_df(adata, list(adata.var_names[:100]) + ['louvain'])
````
before:
`40.6 ms ± 2.38 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)`

after:
`4.45 ms ± 228 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)`