### PR TITLE
Suggestion on clarifying roles in key contributors panel

### DIFF
--- a/docs/_key_contributors.rst
+++ b/docs/_key_contributors.rst
@@ -1,19 +1,20 @@
 .. sidebar:: Key Contributors
    :subtitle: `anndata graph`_ | `scanpy graph`_ | ☀ = maintainer
 
-   * `Isaac Virshup`_: anndata overhaul, diverse contributions ☀
-   * Gökcen Eraslan: diverse contributions ☀
-   * Sergei Rybakov: diverse contributions ☀
-   * `Fidel Ramirez`_: plotting ☀
-   * `Tom White`_: distributed computing
-   * Philipp Angerer: initial anndata conception/development, software quality ☀
-   * `Alex Wolf`_: initial anndata & scanpy conception/development ☀
+   * `Isaac Virshup`_: lead developer since 2019 ☀
+   * Gökcen Eraslan: developer, diverse contributions ☀
+   * Sergei Rybakov: developer, diverse contributions ☀
+   * `Fidel Ramirez`_: developer, plotting ☀
+   * Giovanni Palla: developer, spatial data
+   * Tom White: developer 2018-2019, distributed computing
+   * Philipp Angerer: developer, software quality, initial anndata conception/development ☀
+   * `Alex Wolf`_: lead developer 2016-2019, initial anndata & scanpy conception/development
+   * Malte Luecken: community & forum
    * `Fabian Theis`_ & lab: enabling guidance, support and environment
 
 .. _anndata graph: https://github.com/theislab/anndata/graphs/contributors
 .. _scanpy graph: https://github.com/theislab/scanpy/graphs/contributors
 .. _Isaac Virshup: https://twitter.com/ivirshup
-.. _Tom White: https://twitter.com/tom_e_white
 .. _Alex Wolf: https://twitter.com/falexwolf
 .. _Fabian Theis: https://twitter.com/fabian_theis
 .. _Fidel Ramirez: https://github.com/fidelram

--- a/docs/_key_contributors.rst
+++ b/docs/_key_contributors.rst
@@ -6,10 +6,9 @@
    * Sergei Rybakov: developer, diverse contributions ☀
    * `Fidel Ramirez`_: developer, plotting ☀
    * Giovanni Palla: developer, spatial data
-   * Tom White: developer 2018-2019, distributed computing
-   * Philipp Angerer: developer, software quality, initial anndata conception/development ☀
-   * `Alex Wolf`_: lead developer 2016-2019, initial anndata & scanpy conception/development
-   * Malte Luecken: community & forum
+   * Malte Luecken: developer, community & forum
+   * Philipp Angerer: developer, software quality, initial anndata conception ☀
+   * `Alex Wolf`_: lead developer 2016-2019, initial anndata & scanpy conception
    * `Fabian Theis`_ & lab: enabling guidance, support and environment
 
 .. _anndata graph: https://github.com/theislab/anndata/graphs/contributors

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -1,6 +1,8 @@
 Contributors
 ============
 
+.. include:: _key_contributors.rst
+
 
 Current developers
 ------------------
@@ -8,6 +10,7 @@ Current developers
 
 Other roles
 -----------
+
 
 Former developers
 -----------------

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -1,0 +1,15 @@
+Contributors
+============
+
+
+Current developers
+------------------
+
+
+Other roles
+-----------
+
+Former developers
+-----------------
+
+* Tom White: developer 2018-2019, distributed computing

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,5 +43,6 @@ Latest additions
    api/index
    external/index
    ecosystem
+   contributors
    release-notes
    references

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,4 +44,5 @@ Latest additions
    external/index
    ecosystem
    release-notes
+   contributors
    references

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,5 @@ Latest additions
    api/index
    external/index
    ecosystem
-   contributors
    release-notes
    references


### PR DESCRIPTION
As by a discussion with @ivirshup and based off the [Scanpy team meeting in July](https://docs.google.com/document/d/1MPVMsJMJcP6siljdvVJm5IQZUexTe2TO5Rqy_5EVE5w/edit), clarify roles in the key-contributors panel and add Malte and Giovanni.