### PR TITLE
Fix progress bar, use requests, tqdm version

### DIFF
--- a/docs/release-latest.rst
+++ b/docs/release-latest.rst
@@ -6,6 +6,7 @@ On master
 
 .. rubric:: Bugfixes
 
+* Fixed the width of the progress bar when downloading data :pr:`1507` :smaller:`M Klein`
 * Fixed `log1p` inplace on integer dense arrays :pr:`1400` :smaller:`I Virshup`
 * Fixed `marker_gene_overlap` default value for `top_n_markers` :pr:`1464` :smaller:`MD Luecken`
 * Fixed download path of `pbmc3k_processed` :pr:`1472` :smaller:`D Strobl`

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scipy>=1.4
 seaborn
 h5py>=2.10.0
 tables
-tqdm>=4.29.1
+tqdm
 importlib_metadata>=0.7; python_version < '3.8'
 scikit-learn>=0.21.2
 statsmodels>=0.10.0rc2
@@ -22,4 +22,3 @@ umap-learn>=0.3.10
 legacy-api-wrap
 packaging
 sinfo
-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ scipy>=1.4
 seaborn
 h5py>=2.10.0
 tables
-tqdm
+tqdm>=4.29.1
 importlib_metadata>=0.7; python_version < '3.8'
 scikit-learn>=0.21.2
 statsmodels>=0.10.0rc2
@@ -22,3 +22,4 @@ umap-learn>=0.3.10
 legacy-api-wrap
 packaging
 sinfo
+requests

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -938,7 +938,7 @@ def _download(url: str, path: Path):
                 while block:
                     f.write(block)
                     blocknum += 1
-                    t.update(blocknum * blocksize - t.n)
+                    t.update(len(block))
                     block = resp.read(blocksize)
 
     except (KeyboardInterrupt, Exception):


### PR DESCRIPTION
This fixes the small progress when downloading the data as `sc.datasets.paul_15()`, etc..
Also fixes removing the file when `KeyboardInterrupt` occurs (previously, it was just on exceptions and at least for me I sometimes stop a download by interupting the jupyter kernel - now it also correctly removes the partially downloaded file).

I've also opted for `requests` library, since it's much cleaner than urllib3 and as a dependency.
However, this is completely unrelated to the 2 things I've mentioned above and can be quickly reverted.

Relevant PRs I could find:
- tqdm version (I opted for bumping the version [search through open issues, lowest one had 4.32]): https://github.com/theislab/scanpy/issues/1244

Not relevant:
My [reaction](https://www.youtube.com/watch?v=nixR6wVa4HY&t=72) when using the progress bar (slightly NSFW [foul language]).