### PR TITLE
Restrict umap to <0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ networkx>=2.3
 natsort
 joblib
 numba>=0.41.0
-umap-learn>=0.3.10
+umap-learn>=0.3.10,<0.5
 legacy-api-wrap
 packaging
 sinfo


### PR DESCRIPTION
Restricting umap to below `0.5` so we can fix changes before it's released (see #1509).

