### PR TITLE
Fix sc.pl.violin when use_raw=None

### DIFF
--- a/scanpy/_utils.py
+++ b/scanpy/_utils.py
@@ -176,6 +176,21 @@ def _check_array_function_arguments(**kwargs):
         )
 
 
+def _check_use_raw(adata: AnnData, use_raw: Union[None, bool]) -> bool:
+    """
+    Normalize checking `use_raw`.
+
+    My intentention here is to also provide a single place to throw a deprecation warning from in future.
+    """
+    if use_raw is not None:
+        return use_raw
+    else:
+        if adata.raw is not None:
+            return True
+        else:
+            return False
+
+
 # --------------------------------------------------------------------------------
 # Graph stuff
 # --------------------------------------------------------------------------------

--- a/scanpy/get.py
+++ b/scanpy/get.py
@@ -323,6 +323,10 @@ def _get_obs_rep(adata, *, use_raw=False, layer=None, obsm=None, obsp=None):
     """
     Choose array aligned with obs annotation.
     """
+    # https://github.com/theislab/scanpy/issues/1546
+    if not isinstance(use_raw, bool):
+        raise TypeError(f"use_raw expected to be bool, was {type(use_raw)}.")
+
     is_layer = layer is not None
     is_raw = use_raw is not False
     is_obsm = obsm is not None

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -23,7 +23,7 @@ from matplotlib.colors import is_color_like, Colormap, ListedColormap
 from .. import get
 from .. import logging as logg
 from .._settings import settings
-from .._utils import sanitize_anndata, _doc_params
+from .._utils import sanitize_anndata, _doc_params, _check_use_raw
 from .._compat import Literal
 from . import _utils
 from ._utils import scatter_base, scatter_group, setup_axes
@@ -101,7 +101,7 @@ def scatter(
         or a hex color specification, e.g.,
         `'ann1'`, `'#fe57a1'`, or `['ann1', 'ann2']`.
     use_raw
-        Use `raw` attribute of `adata` if present.
+        Whether to use `raw` attribute of `adata`. Defaults to `True` if `.raw` is present.
     layers
         Use the `layers` attribute of `adata` if present: specify the layer for
         `x`, `y` and `color`. If `layers` is a string, then it is expanded to
@@ -177,8 +177,7 @@ def _scatter_obs(
     sanitize_anndata(adata)
     from scipy.sparse import issparse
 
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
+    use_raw = _check_use_raw(adata, use_raw)
 
     # Process layers
     if layers in ['X', None] or (
@@ -647,7 +646,7 @@ def violin(
     log
         Plot on logarithmic axis.
     use_raw
-        Use `raw` attribute of `adata` if present.
+        Whether to use `raw` attribute of `adata`. Defaults to `True` if `.raw` is present.
     stripplot
         Add a stripplot on top of the violin plot.
         See :func:`~seaborn.stripplot`.
@@ -689,8 +688,7 @@ def violin(
     import seaborn as sns  # Slow import, only import if called
 
     sanitize_anndata(adata)
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
+    use_raw = _check_use_raw(adata, use_raw)
     if isinstance(keys, str):
         keys = [keys]
     keys = list(OrderedDict.fromkeys(keys))  # remove duplicates, preserving the order
@@ -848,7 +846,7 @@ def clustermap(
         Categorical annotation to plot with a different color map.
         Currently, only a single key is supported.
     use_raw
-        Use `raw` attribute of `adata` if present.
+        Whether to use `raw` attribute of `adata`. Defaults to `True` if `.raw` is present.
     {show_save_ax}
     **kwds
         Keyword arguments passed to :func:`~seaborn.clustermap`.
@@ -871,8 +869,7 @@ def clustermap(
     if not isinstance(obs_keys, (str, type(None))):
         raise ValueError('Currently, only a single key is supported.')
     sanitize_anndata(adata)
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
+    use_raw = _check_use_raw(adata, use_raw)
     X = adata.raw.X if use_raw else adata.X
     if issparse(X):
         X = X.toarray()
@@ -1779,7 +1776,7 @@ def _prepare_dataframe(
         groupby is a categorical. If groupby is not a categorical observation,
         it would be subdivided into `num_categories`.
     use_raw
-        Use `raw` attribute of `adata` if present.
+        Whether to use `raw` attribute of `adata`. Defaults to `True` if `.raw` is present.
     log
         Use the log of the values
     num_categories
@@ -1796,8 +1793,7 @@ def _prepare_dataframe(
     from scipy.sparse import issparse
 
     sanitize_anndata(adata)
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
+    use_raw = _check_use_raw(adata, use_raw)
     if isinstance(var_names, str):
         var_names = [var_names]
 

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -960,9 +960,6 @@ def heatmap(
     --------
     rank_genes_groups_heatmap: to plot marker genes identified using the :func:`~scanpy.tl.rank_genes_groups` function.
     """
-    if use_raw is None and adata.raw is not None:
-        use_raw = True
-
     var_names, var_group_labels, var_group_positions = _check_var_names_type(
         var_names, var_group_labels, var_group_positions
     )

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -91,9 +91,6 @@ class BasePlot(object):
         self.var_group_rotation = var_group_rotation
         self.width, self.height = figsize if figsize is not None else (None, None)
 
-        if use_raw is None and adata.raw is not None:
-            use_raw = True
-
         self.has_var_groups = (
             True
             if var_group_positions is not None and len(var_group_positions) > 0

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -490,6 +490,28 @@ def test_violin(image_comparer):
     save_and_compare_images('master_violin_multi_panel_with_layer')
 
 
+# TODO: Generalize test to more plotting types
+def test_violin_without_raw(tmpdir):
+    # https://github.com/theislab/scanpy/issues/1546
+    TESTDIR = Path(tmpdir)
+
+    has_raw_pth = TESTDIR / "has_raw.png"
+    no_raw_pth = TESTDIR / "no_raw.png"
+
+    pbmc = sc.datasets.pbmc68k_reduced()
+    pbmc_no_raw = pbmc.raw.to_adata().copy()
+
+    sc.pl.violin(pbmc, 'CST3', groupby="bulk_labels", show=False)
+    plt.savefig(has_raw_pth)
+    plt.close()
+
+    sc.pl.violin(pbmc_no_raw, 'CST3', groupby="bulk_labels", show=False)
+    plt.savefig(no_raw_pth)
+    plt.close()
+
+    assert compare_images(has_raw_pth, no_raw_pth, tol=5) is None
+
+
 def test_dendrogram(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=10)
 

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -124,8 +124,6 @@ def dendrogram(
         rep_df.set_index(categorical, inplace=True)
         categories = rep_df.index.categories
     else:
-        if use_raw is None and adata.raw is not None:
-            use_raw = True
         gene_names = adata.raw.var_names if use_raw else adata.var_names
         from ..plotting._anndata import _prepare_dataframe
 

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -9,6 +9,7 @@ from scipy.sparse import issparse
 
 from .. import logging as logg
 from .._utils import AnyRandom
+from scanpy._utils import _check_use_raw
 
 
 def _sparse_nanmean(X, axis):
@@ -77,7 +78,7 @@ def score_genes(
     copy
         Copy `adata` or modify it inplace.
     use_raw
-        Use `raw` attribute of `adata` if present.
+        Whether to use `raw` attribute of `adata`. Defaults to `True` if `.raw` is present.
 
         .. versionchanged:: 1.4.5
            Default value changed from `False` to `None`.
@@ -121,8 +122,7 @@ def score_genes(
     # Basically we need to compare genes against random genes in a matched
     # interval of expression.
 
-    if use_raw is None:
-        use_raw = True if adata.raw is not None else False
+    use_raw = _check_use_raw(adata, use_raw)
     _adata = adata.raw if use_raw else adata
 
     _adata_subset = _adata[:, gene_pool] if len(gene_pool) < len(_adata.var_names) else _adata


### PR DESCRIPTION
Fixes #1546

I've done a couple things here:

1. I've fixed the bug (`sc.pl.violin` being called on an `AnnData` without `.raw` would throw an error), and added a regression test
2. I've tried to normalize how we choose what to do when `use_raw=None`, basically this is just a new utility `_check_use_raw`. The benefit of having a single function for this is that it makes it easy to globally change how we handle this argument (e.g. deprecate the `None` case).
3. Reworded the docs for functions where `use_raw=None` can become `use_raw=True`