### PR TITLE
Replace sklearn.utils.testing with numpy.testing

### DIFF
--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -2,7 +2,7 @@ from importlib.util import find_spec
 
 import numpy as np
 import pytest
-from sklearn.utils.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal
 
 import scanpy as sc
 

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -5,7 +5,7 @@ import numpy as np
 import pandas as pd
 from scipy import sparse as sp
 import scanpy as sc
-from sklearn.utils.testing import assert_allclose
+from numpy.testing import assert_allclose
 import pytest
 from anndata import AnnData
 from anndata.tests.helpers import assert_equal, asarray


### PR DESCRIPTION
sklearn.utils.testing is deprecated in scikit-learn 0.24: https://github.com/scikit-learn/scikit-learn/pull/17133