### PR TITLE
fix sc.tl.umap for umap-0.5

### DIFF
--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -1,5 +1,6 @@
 from types import MappingProxyType
 from typing import Union, Optional, Any, Mapping, Callable, NamedTuple, Generator, Tuple
+import warnings
 
 import numpy as np
 import scipy
@@ -267,7 +268,10 @@ def compute_neighbors_umap(
     -------
     **knn_indices**, **knn_dists** : np.arrays of shape (n_observations, n_neighbors)
     """
-    from umap.umap_ import nearest_neighbors
+    with warnings.catch_warnings():
+        # umap 0.5.0
+        warnings.filterwarnings("ignore", message=r"Tensorflow not installed")
+        from umap.umap_ import nearest_neighbors
 
     random_state = check_random_state(random_state)
 
@@ -344,7 +348,10 @@ def _compute_connectivities_umap(
     simplicial set for each such point, and then combining all the local
     fuzzy simplicial sets into a global one via a fuzzy union.
     """
-    from umap.umap_ import fuzzy_simplicial_set
+    with warnings.catch_warnings():
+        # umap 0.5.0
+        warnings.filterwarnings("ignore", message=r"Tensorflow not installed")
+        from umap.umap_ import fuzzy_simplicial_set
 
     X = coo_matrix(([], ([], [])), shape=(n_obs, 1))
     connectivities = fuzzy_simplicial_set(

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -156,7 +156,7 @@ def umap(
         # the data matrix X is really only used for determining the number of connected components
         # for the init condition in the UMAP embedding
         n_epochs = 0 if maxiter is None else maxiter
-        X_umap = simplicial_set_embedding(
+        X_umap, _ = simplicial_set_embedding(
             X,
             neighbors['connectivities'].tocoo(),
             n_components,
@@ -170,6 +170,9 @@ def umap(
             random_state,
             neigh_params.get('metric', 'euclidean'),
             neigh_params.get('metric_kwds', {}),
+            densmap=False,
+            densmap_kwds={},
+            output_dens=False,
             verbose=settings.verbosity > 3,
         )
     elif method == 'rapids':

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -1,6 +1,8 @@
 from typing import Optional, Union
+from warnings import simplefilter
 
 import numpy as np
+from packaging import version
 from anndata import AnnData
 from sklearn.utils import check_random_state, check_array
 
@@ -129,7 +131,24 @@ def umap(
     if ('params' not in neighbors
         or neighbors['params']['method'] != 'umap'):
         logg.warning(f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap')
-    from umap.umap_ import find_ab_params, simplicial_set_embedding
+
+    # Compat for umap 0.4 -> 0.5
+    import umap
+    if version.parse(umap.__version__) >= version.parse("0.5.0"):
+        def simplicial_set_embedding(*args, **kwargs):
+            from umap.umap_ import simplicial_set_embedding
+            X_umap, _ = simplicial_set_embedding(
+                *args,
+                densmap=False,
+                densmap_kwds={},
+                output_dens=False,
+                **kwargs,
+            )
+            return X_umap
+    else:
+        from umap.umap_ import simplicial_set_embedding
+    from umap.umap_ import find_ab_params
+
     if a is None or b is None:
         a, b = find_ab_params(spread, min_dist)
     else:
@@ -156,7 +175,7 @@ def umap(
         # the data matrix X is really only used for determining the number of connected components
         # for the init condition in the UMAP embedding
         n_epochs = 0 if maxiter is None else maxiter
-        X_umap, _ = simplicial_set_embedding(
+        X_umap = simplicial_set_embedding(
             X,
             neighbors['connectivities'].tocoo(),
             n_components,
@@ -170,9 +189,6 @@ def umap(
             random_state,
             neigh_params.get('metric', 'euclidean'),
             neigh_params.get('metric_kwds', {}),
-            densmap=False,
-            densmap_kwds={},
-            output_dens=False,
             verbose=settings.verbosity > 3,
         )
     elif method == 'rapids':

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -1,5 +1,5 @@
 from typing import Optional, Union
-from warnings import simplefilter
+import warnings
 
 import numpy as np
 from packaging import version
@@ -133,7 +133,11 @@ def umap(
         logg.warning(f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap')
 
     # Compat for umap 0.4 -> 0.5
-    import umap
+    with warnings.catch_warnings():
+        # umap 0.5.0
+        warnings.filterwarnings("ignore", message=r"Tensorflow not installed")
+        import umap
+
     if version.parse(umap.__version__) >= version.parse("0.5.0"):
         def simplicial_set_embedding(*args, **kwargs):
             from umap.umap_ import simplicial_set_embedding


### PR DESCRIPTION
@Koncopd, this seems to work as a bare minimum for making `sc.tl.umap` work for `umap-0.5`. `ingest` still does not work, and that definitely looks complicated to fix.

What would you say to adding a line like

```python
if umap.__version__ >= 0.5:
    raise ImportError("Ingest currently require umap-learn < 0.5")
```

We could then remove the pin, and free up user's environments.