### PR TITLE
Speedup embedding plots when len(cluster_colors) < len(cluster_categories)

### DIFF
--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -1129,8 +1129,13 @@ def _color_vector(
     if not is_categorical_dtype(values):
         return values, False
     else:  # is_categorical_dtype(values)
-        color_map = _get_palette(adata, values_key, palette=palette)
-        color_vector = values.map(color_map).map(to_hex)
+        color_map = {
+            k: to_hex(v)
+            for k, v in _get_palette(adata, values_key, palette=palette).items()
+        }
+        # If color_map does not have unique values, this can be slow as the
+        # result is not categorical
+        color_vector = values.map(color_map)
 
         # Set color to 'missing color' for all missing values
         if color_vector.isna().any():


### PR DESCRIPTION
If values of color dict are not unique, `categorical.map(non_unique)` returns a string array, which caused `to_hex` to be called on each element, not just the categories. This was quite slow.

Using a dataset of 13million cells, with 38 clusters but only 20 colors, benchmarking the following line 

```python
sc.pl.umap(adata, color="louvain")
```

On master:

```
CPU times: user 12.3 s, sys: 187 ms, total: 12.4 s
Wall time: 12.4 s
```

This pr:

```
CPU times: user 6.82 s, sys: 149 ms, total: 6.97 s
Wall time: 6.97 s
```
