### PR TITLE
add twine check to azure CI + 3.8 matrix

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -79,7 +79,7 @@ jobs:
       rst2html.py --halt=2 README.rst >/dev/null
     displayName: 'rst2html'
 
-- job: Twine Check
+- job: Twine
   pool:
     vmImage: 'ubuntu-18.04'
   steps:
@@ -88,7 +88,7 @@ jobs:
         versionSpec: '3.8'
 
     - script: |
-      pip install setuptools twine wheel
-      python setup.py sdist bdist_wheel
-      twine check dist/*
-    displayName: 'Twine check'
+        pip install setuptools twine wheel
+        python setup.py sdist bdist_wheel
+        twine check dist/*
+      displayName: 'Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -87,7 +87,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install setuptools twine
+      pip install setuptools twine pytoml
     displayName: 'Install dependencies'
 
   - script: pip list

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -80,8 +80,7 @@ jobs:
     displayName: 'rst2html'
 
   - script: |
-      python -m pip install --upgrade pip
-      pip install setuptools twine wheel
+      pip install setuptools twine
       python setup.py sdist bdist_wheel
       twine check dist/*
     condition: in(variables['python.version'], '3.8')

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -14,9 +14,9 @@ jobs:
       Python38:
         python.version: '3.8'
       Python37:
-        python.version: '3.7'
+        python.version: '3.6'
       anndata_dev:
-        python.version: '3.7'
+        python.version: '3.8'
         ANNDATA_DEV: yes
         RUN_COVERAGE: yes
   steps:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,8 +11,6 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
       Python38:
         python.version: '3.8'
       Python37:

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -15,8 +15,6 @@ jobs:
         python.version: '3.8'
       Python37:
         python.version: '3.7'
-      Python36:
-        python.version: '3.6'
       anndata_dev:
         python.version: '3.7'
         ANNDATA_DEV: yes

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -11,6 +11,10 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
+      Python39:
+        python.version: '3.9'
+      Python38:
+        python.version: '3.8'
       Python37:
         python.version: '3.7'
       Python36:
@@ -79,3 +83,9 @@ jobs:
       python setup.py check --restructuredtext --strict
       rst2html.py --halt=2 README.rst >/dev/null
     displayName: 'rst2html'
+
+  - script: |
+      pip install setuptools twine
+      python setup.py sdist bdist_wheel
+      twine check dist/*
+    displayName: 'Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -76,12 +76,19 @@ jobs:
       testRunTitle: 'Publish test results for Python $(python.version)'
 
   - script: |
-      python setup.py check --restructuredtext --strict
       rst2html.py --halt=2 README.rst >/dev/null
     displayName: 'rst2html'
 
-  - script: |
-      pip install setuptools twine
+- job: Twine Check
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+    - task: UsePythonVersion@0
+      inputs:
+        versionSpec: '3.8'
+
+    - script: |
+      pip install setuptools twine wheel
       python setup.py sdist bdist_wheel
       twine check dist/*
     displayName: 'Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,94 +1,87 @@
 trigger:
-- master
+  - master
 
-variables:
-  ANNDATA_DEV: no
-  RUN_COVERAGE: no
+  variables:
+    ANNDATA_DEV: no
+    RUN_COVERAGE: no
 
-jobs:
-- job: PyTest
-  pool:
-    vmImage: 'ubuntu-18.04'
-  strategy:
-    matrix:
-      Python38:
-        python.version: '3.8'
-      Python37:
-        python.version: '3.6'
-      anndata_dev:
-        python.version: '3.8'
-        ANNDATA_DEV: yes
-        RUN_COVERAGE: yes
-  steps:
-  - task: UsePythonVersion@0
-    inputs:
-      versionSpec: '$(python.version)'
-    displayName: 'Use Python $(python.version)'
-
-  - script: |
-      export MPLBACKEND="agg"
-      echo $MPLBACKEND
-    displayName: 'Set env'
-
-  - script: |
-      python -m pip install --upgrade pip
-      pip install pytest-cov wheel
-      pip install -e .[dev,doc,test,louvain,leiden,magic,scvi,harmony,scrublet,scanorama]
-    displayName: 'Install dependencies'
-
-  - script: |
-      pip install -v git+https://github.com/theislab/anndata
-    displayName: 'Install development anndata'
-    condition: eq(variables['ANNDATA_DEV'], 'yes')
-
-  - script: |
-      pip list
-    displayName: 'Display installed versions'
-
-  - script: |
-      pip install black
-      black . --check --diff
-      python -m scanpy.tests.blackdiff 10
-    displayName: 'Black'
-
-  - script: |
-      pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml"
-    displayName: 'PyTest'
-    condition: eq(variables['RUN_COVERAGE'], 'no')
-
-  - script: |
-      pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml" --cov=scanpy --cov-report=xml
-    displayName: 'PyTest (coverage)'
-    condition: eq(variables['RUN_COVERAGE'], 'yes')
-
-  - task: PublishCodeCoverageResults@1
-    inputs:
-      codeCoverageTool: Cobertura
-      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-    condition: eq(variables['RUN_COVERAGE'], 'yes')
-
-  - task: PublishTestResults@2
-    condition: succeededOrFailed()
-    inputs:
-      testResultsFiles: 'nunit/test-results.xml'
-      testResultsFormat: NUnit
-      testRunTitle: 'Publish test results for Python $(python.version)'
-
-  - script: |
-      rst2html.py --halt=2 README.rst >/dev/null
-    displayName: 'rst2html'
-
-- job: Twine
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
+  jobs:
+  - job: PyTest
+    pool:
+      vmImage: 'ubuntu-18.04'
+    strategy:
+      matrix:
+        Python38:
+          python.version: '3.8'
+        Python37:
+          python.version: '3.6'
+        anndata_dev:
+          python.version: '3.8'
+          ANNDATA_DEV: yes
+          RUN_COVERAGE: yes
+    steps:
     - task: UsePythonVersion@0
       inputs:
-        versionSpec: '3.8'
+        versionSpec: '$(python.version)'
+      displayName: 'Use Python $(python.version)'
 
     - script: |
-        pip install setuptools twine wheel
+        export MPLBACKEND="agg"
+        echo $MPLBACKEND
+      displayName: 'Set env'
+
+    - script: |
+        python -m pip install --upgrade pip
+        pip install pytest-cov wheel
+        pip install -e .[dev,doc,test,louvain,leiden,magic,scvi,harmony,scrublet,scanorama]
+      displayName: 'Install dependencies'
+
+    - script: |
+        pip install -v git+https://github.com/theislab/anndata
+      displayName: 'Install development anndata'
+      condition: eq(variables['ANNDATA_DEV'], 'yes')
+
+    - script: |
+        pip list
+      displayName: 'Display installed versions'
+
+    - script: |
+        pip install black
+        black . --check --diff
+        python -m scanpy.tests.blackdiff 10
+      displayName: 'Black'
+
+    - script: |
+        pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml"
+      displayName: 'PyTest'
+      condition: eq(variables['RUN_COVERAGE'], 'no')
+
+    - script: |
+        pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml" --cov=scanpy --cov-report=xml
+      displayName: 'PyTest (coverage)'
+      condition: eq(variables['RUN_COVERAGE'], 'yes')
+
+    - task: PublishCodeCoverageResults@1
+      inputs:
+        codeCoverageTool: Cobertura
+        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+      condition: eq(variables['RUN_COVERAGE'], 'yes')
+
+    - task: PublishTestResults@2
+      condition: succeededOrFailed()
+      inputs:
+        testResultsFiles: 'nunit/test-results.xml'
+        testResultsFormat: NUnit
+        testRunTitle: 'Publish test results for Python $(python.version)'
+
+    - script: |
+        rst2html.py --halt=2 README.rst >/dev/null
+      displayName: 'rst2html'
+
+    - script: |
+        pip install setuptools twine
         python setup.py sdist bdist_wheel
         twine check dist/*
+      condition: in(variables['python.version'], '3.8')
       displayName: 'Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -87,8 +87,8 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install setuptools twine pytoml
-    displayName: 'Install dependencies'
+      pip install setuptools setuptools_scm pytoml wheel twine
+    displayName: 'Install build dependencies'
 
   - script: pip list
     displayName: 'Display installed versions'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -75,13 +75,25 @@ jobs:
       testResultsFormat: NUnit
       testRunTitle: 'Publish test results for Python $(python.version)'
 
-  - script: |
-      rst2html.py --halt=2 README.rst >/dev/null
-    displayName: 'rst2html'
+- job: CheckBuild
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
+
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '3.8'
+    displayName: 'Use Python 3.8'
 
   - script: |
+      python -m pip install --upgrade pip
       pip install setuptools twine
+    displayName: 'Install dependencies'
+
+  - script: pip list
+    displayName: 'Display installed versions'
+
+  - script: |
       python setup.py sdist bdist_wheel
       twine check dist/*
-    condition: in(variables['python.version'], '3.8')
-    displayName: 'Twine check'
+    displayName: 'Build & Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -1,87 +1,88 @@
 trigger:
-  - master
+- master
 
-  variables:
-    ANNDATA_DEV: no
-    RUN_COVERAGE: no
+variables:
+  ANNDATA_DEV: no
+  RUN_COVERAGE: no
 
-  jobs:
-  - job: PyTest
-    pool:
-      vmImage: 'ubuntu-18.04'
-    strategy:
-      matrix:
-        Python38:
-          python.version: '3.8'
-        Python37:
-          python.version: '3.6'
-        anndata_dev:
-          python.version: '3.8'
-          ANNDATA_DEV: yes
-          RUN_COVERAGE: yes
-    steps:
-    - task: UsePythonVersion@0
-      inputs:
-        versionSpec: '$(python.version)'
-      displayName: 'Use Python $(python.version)'
+jobs:
+- job: PyTest
+  pool:
+    vmImage: 'ubuntu-18.04'
+  strategy:
+    matrix:
+      Python38:
+        python.version: '3.8'
+      Python36:
+        python.version: '3.6'
+      anndata_dev:
+        python.version: '3.8'
+        ANNDATA_DEV: yes
+        RUN_COVERAGE: yes
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
 
-    - script: |
-        export MPLBACKEND="agg"
-        echo $MPLBACKEND
-      displayName: 'Set env'
+  - script: |
+      export MPLBACKEND="agg"
+      echo $MPLBACKEND
+    displayName: 'Set env'
 
-    - script: |
-        python -m pip install --upgrade pip
-        pip install pytest-cov wheel
-        pip install -e .[dev,doc,test,louvain,leiden,magic,scvi,harmony,scrublet,scanorama]
-      displayName: 'Install dependencies'
+  - script: |
+      python -m pip install --upgrade pip
+      pip install pytest-cov wheel
+      pip install -e .[dev,doc,test,louvain,leiden,magic,scvi,harmony,scrublet,scanorama]
+    displayName: 'Install dependencies'
 
-    - script: |
-        pip install -v git+https://github.com/theislab/anndata
-      displayName: 'Install development anndata'
-      condition: eq(variables['ANNDATA_DEV'], 'yes')
+  - script: |
+      pip install -v git+https://github.com/theislab/anndata
+    displayName: 'Install development anndata'
+    condition: eq(variables['ANNDATA_DEV'], 'yes')
 
-    - script: |
-        pip list
-      displayName: 'Display installed versions'
+  - script: |
+      pip list
+    displayName: 'Display installed versions'
 
-    - script: |
-        pip install black
-        black . --check --diff
-        python -m scanpy.tests.blackdiff 10
-      displayName: 'Black'
+  - script: |
+      pip install black
+      black . --check --diff
+      python -m scanpy.tests.blackdiff 10
+    displayName: 'Black'
 
-    - script: |
-        pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml"
-      displayName: 'PyTest'
-      condition: eq(variables['RUN_COVERAGE'], 'no')
+  - script: |
+      pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml"
+    displayName: 'PyTest'
+    condition: eq(variables['RUN_COVERAGE'], 'no')
 
-    - script: |
-        pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml" --cov=scanpy --cov-report=xml
-      displayName: 'PyTest (coverage)'
-      condition: eq(variables['RUN_COVERAGE'], 'yes')
+  - script: |
+      pytest --color=yes --ignore=scanpy/tests/_images --nunit-xml="nunit/test-results.xml" --cov=scanpy --cov-report=xml
+    displayName: 'PyTest (coverage)'
+    condition: eq(variables['RUN_COVERAGE'], 'yes')
 
-    - task: PublishCodeCoverageResults@1
-      inputs:
-        codeCoverageTool: Cobertura
-        summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-        reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
-      condition: eq(variables['RUN_COVERAGE'], 'yes')
+  - task: PublishCodeCoverageResults@1
+    inputs:
+      codeCoverageTool: Cobertura
+      summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
+      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+    condition: eq(variables['RUN_COVERAGE'], 'yes')
 
-    - task: PublishTestResults@2
-      condition: succeededOrFailed()
-      inputs:
-        testResultsFiles: 'nunit/test-results.xml'
-        testResultsFormat: NUnit
-        testRunTitle: 'Publish test results for Python $(python.version)'
+  - task: PublishTestResults@2
+    condition: succeededOrFailed()
+    inputs:
+      testResultsFiles: 'nunit/test-results.xml'
+      testResultsFormat: NUnit
+      testRunTitle: 'Publish test results for Python $(python.version)'
 
-    - script: |
-        rst2html.py --halt=2 README.rst >/dev/null
-      displayName: 'rst2html'
+  - script: |
+      rst2html.py --halt=2 README.rst >/dev/null
+    displayName: 'rst2html'
 
-    - script: |
-        pip install setuptools twine
-        python setup.py sdist bdist_wheel
-        twine check dist/*
-      condition: in(variables['python.version'], '3.8')
-      displayName: 'Twine check'
+  - script: |
+      python -m pip install --upgrade pip
+      pip install setuptools twine wheel
+      python setup.py sdist bdist_wheel
+      twine check dist/*
+    condition: in(variables['python.version'], '3.8')
+    displayName: 'Twine check'


### PR DESCRIPTION
Dear everyone,

This PR adds
1. Python 3.8 to the build matrix. We were currently only testing vs 3.6 and 3.7. 3.10 is already coming up in April, so it is in my opinion time to use the more latest Python versions. If you feel like this adds too much to the Azure/CI bill, then I would suggest to remove 3.6. 
2. Solves #1585 


Signed-off-by: Zethson <lukas.heumos@posteo.net>

