### PR TITLE
Remove dependency on scvelo for doc builds

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,7 +84,6 @@ intersphinx_mapping = dict(
     pytest=('https://docs.pytest.org/en/latest/', None),
     python=('https://docs.python.org/3', None),
     scipy=('https://docs.scipy.org/doc/scipy/reference/', None),
-    scvelo=('https://scvelo.readthedocs.io/', None),
     seaborn=('https://seaborn.pydata.org/', None),
     sklearn=('https://scikit-learn.org/stable/', None),
     scanpy_tutorials=(scanpy_tutorials_url, None),

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -37,8 +37,7 @@ neighbors_key
     If specified, this looks
     .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
 arrows
-    Show arrows (requires to run :func:`scvelo.tl.velocity_embedding` before).
-    Deprecated in favor of :func:`scvelo.pl.velocity_embedding` and friends.
+    Show arrows (deprecated in favour of `scvelo.pl.velocity_embedding`).
 arrows_kwds
     Passed to :meth:`~matplotlib.axes.Axes.quiver`\
 """


### PR DESCRIPTION
scvelo docs have been changed so the url for the sphinx inventory is different. We also probably don't want to depend on scvelo's documentation for our doc builds, especially since it's pre 1.0, and we weren't really doing much with it. Should fix current doc build problems.