### PR TITLE
Fix failing CI for scanorama and python3.6

### DIFF
--- a/scanpy/tests/external/test_scanorama_integrate.py
+++ b/scanpy/tests/external/test_scanorama_integrate.py
@@ -13,5 +13,5 @@ def test_scanorama_integrate():
     adata = sc.datasets.pbmc68k_reduced()
     sc.tl.pca(adata)
     adata.obs['batch'] = 350 * ['a'] + 350 * ['b']
-    sce.pp.scanorama_integrate(adata, 'batch')
+    sce.pp.scanorama_integrate(adata, 'batch', approx=False)
     assert adata.obsm['X_scanorama'].shape == adata.obsm['X_pca'].shape


### PR DESCRIPTION
Suggested by: https://github.com/brianhie/scanorama/issues/73#issuecomment-775647669

See referenced issue for more details. This should be back ported to the 1.7.x branch.