### PR TITLE
Fix timeseries_as_heatmap plot function

### DIFF
--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -197,13 +197,13 @@ def timeseries_as_heatmap(
         x_new[:, _hold:] = X[:, hold:]
 
     _, ax = pl.subplots(figsize=(1.5 * 4, 2 * 4))
-    ax.imshow(
+    img = ax.imshow(
         np.array(X, dtype=np.float_),
         aspect='auto',
         interpolation='nearest',
         cmap=color_map,
     )
-    pl.colorbar(shrink=0.5)
+    pl.colorbar(img, shrink=0.5)
     pl.yticks(range(X.shape[0]), var_names)
     for h in highlights_x:
         pl.plot([h, h], [0, X.shape[0]], '--', color='black')

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -854,6 +854,14 @@ def test_scatter_embedding_add_outline_vmin_vmax(image_comparer):
     save_and_compare_images('master_embedding_outline_vmin_vmax')
 
 
+def test_timeseries():
+    adata = sc.datasets.pbmc68k_reduced()
+    sc.pp.neighbors(adata, n_neighbors=5, method='gauss', knn=False)
+    sc.tl.diffmap(adata)
+    sc.tl.dpt(adata, n_branchings=1, n_dcs=10)
+    sc.pl.dpt_timeseries(adata, as_heatmap=True)
+
+
 def test_scatter_raw(tmp_path):
     pbmc = sc.datasets.pbmc68k_reduced()[:100].copy()
     raw_pth = tmp_path / "raw.png"


### PR DESCRIPTION
This fixes:
```
Traceback (most recent call last):
  File "/private/var/folders/df/6xqpqpcd7h73b6jpx9t6cwhw0000gn/T/tmpn9tl9wf0/job_working_directory/000/2/configs/tmp_r9i0cvx", line 15, in <module>
    sc.pl.dpt_timeseries(
  File "/Users/mvandenb/miniconda3/envs/anndata/lib/python3.8/site-packages/scanpy/plotting/_tools/__init__.py", line 171, in dpt_timeseries
    timeseries_as_heatmap(
  File "/Users/mvandenb/miniconda3/envs/anndata/lib/python3.8/site-packages/scanpy/plotting/_utils.py", line 206, in timeseries_as_heatmap
    pl.colorbar(shrink=0.5)
  File "/Users/mvandenb/miniconda3/envs/anndata/lib/python3.8/site-packages/matplotlib/pyplot.py", line 2188, in colorbar
    raise RuntimeError('No mappable was found to use for colorbar '
RuntimeError: No mappable was found to use for colorbar creation. First define a mappable such as an image (with imshow) or a contour set (with contourf).
```
I see that in other places plt.colobar is used in this module you're
doing the same thing. I believe this broke in
64f04d8.