### PR TITLE
Drop passing of **kwds

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -758,7 +758,6 @@ def violin(
                     size=size,
                     color="black",
                     ax=g.axes[0, ax_id],
-                    **kwds,
                 )
         if log:
             g.set(yscale='log')


### PR DESCRIPTION
This matches the else branch and fixes problem when `figsize` or `color` for instance
are passed in.

<!-- 
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
