### PR TITLE
Fix groupby logic if adata.uns[key]['params']['groupby'] is array

### DIFF
--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -379,7 +379,9 @@ def _rank_genes_groups_plot(
         key = 'rank_genes_groups'
 
     if groupby is None:
-        groupby = str(adata.uns[key]['params']['groupby'])
+        groupby = adata.uns[key]['params']['groupby']
+        if not isinstance(groupby, (str, np.ndarray)):
+            groupby = str(groupby)
     group_names = adata.uns[key]['names'].dtype.names if groups is None else groups
 
     var_names = {}  # dict in which each group is the key and the n_genes are the values


### PR DESCRIPTION
Otherwise this fails with:
```
~/miniconda3/envs/anndata/lib/python3.8/site-packages/scanpy/plotting/_anndata.py in _prepare_dataframe(adata, var_names, groupby, use_raw, log, num_categories, layer, gene_symbols)
   1828                 import IPython
   1829                 IPython.embed()
-> 1830                 raise ValueError(
   1831                     'groupby has to be a valid observation. '
   1832                     f'Given {group}, is not in observations: {adata.obs_keys()}' + msg

ValueError: groupby has to be a valid observation. Given ['cell_type'], is not in observations: ['cell_type'] or index name "index"
```

<!-- 
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
