### PR TITLE
Fix passing of arguments between scrublet routines

### DIFF
--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -212,7 +212,7 @@ def scrublet(
         n_prin_comps=n_prin_comps,
         use_approx_neighbors=use_approx_neighbors,
         knn_dist_metric=knn_dist_metric,
-        get_doublet_neighbor_parents=get_doublet_neighbor_parents, 
+        get_doublet_neighbor_parents=get_doublet_neighbor_parents,
         threshold=threshold,
         random_state=random_state,
         verbose=verbose,
@@ -395,10 +395,7 @@ def _scrublet_call_doublets(
 
     # Actually call doublets
 
-    scrub.call_doublets(
-        threshold=threshold,
-        verbose=verbose
-    )
+    scrub.call_doublets(threshold=threshold, verbose=verbose)
 
     # Store results in AnnData for return
 

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -207,7 +207,15 @@ def scrublet(
         n_neighbors=n_neighbors,
         expected_doublet_rate=expected_doublet_rate,
         stdev_doublet_rate=stdev_doublet_rate,
+        mean_center=mean_center,
+        normalize_variance=normalize_variance,
+        n_prin_comps=n_prin_comps,
+        use_approx_neighbors=use_approx_neighbors,
+        knn_dist_metric=knn_dist_metric,
+        get_doublet_neighbor_parents=get_doublet_neighbor_parents, 
+        threshold=threshold,
         random_state=random_state,
+        verbose=verbose,
     )
 
     logg.info('    Scrublet finished', time=start)
@@ -236,6 +244,7 @@ def _scrublet_call_doublets(
     use_approx_neighbors: bool = True,
     knn_dist_metric: str = 'euclidean',
     get_doublet_neighbor_parents: bool = False,
+    threshold: Optional[float] = None,
     random_state: int = 0,
     verbose: bool = True,
 ) -> AnnData:
@@ -246,7 +255,7 @@ def _scrublet_call_doublets(
     transcriptomes and simulated doublets. This is a wrapper around the core
     functions of `Scrublet <https://github.com/swolock/scrublet>`__ to allow
     for flexibility in applying Scanpy filtering operations upstream. Unless
-    you know what you're doing you should use scrub_doublets().    
+    you know what you're doing you should use the main scrublet() function.    
 
     .. note::
         More information and bug reports `here
@@ -296,6 +305,13 @@ def _scrublet_call_doublets(
         doublet neighbors of each observed transcriptome. This information can 
         be used to infer the cell states that generated a given 
         doublet state. 
+    threshold
+        Doublet score threshold for calling a transcriptome a doublet. If
+        `None`, this is set automatically by looking for the minimum between
+        the two modes of the `doublet_scores_sim_` histogram. It is best
+        practice to check the threshold visually using the
+        `doublet_scores_sim_` histogram and/or based on co-localization of
+        predicted doublets in a 2-D embedding.
     random_state
         Initial state for doublet simulation and nearest neighbors.
     verbose 
@@ -379,7 +395,10 @@ def _scrublet_call_doublets(
 
     # Actually call doublets
 
-    scrub.call_doublets(verbose=verbose)
+    scrub.call_doublets(
+        threshold=threshold,
+        verbose=verbose
+    )
 
     # Store results in AnnData for return
 

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -4,6 +4,7 @@ import scanpy as sc
 import scanpy.external as sce
 from anndata.tests.helpers import assert_equal
 
+
 def test_scrublet():
     """
     Test that Scrublet run works.

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -13,7 +13,7 @@ def test_scrublet():
     pytest.importorskip("scrublet")
 
     adata = sc.datasets.pbmc3k()
-    sce.pp.scrublet(adata, use_approx_neighbors = False)
+    sce.pp.scrublet(adata, use_approx_neighbors=False)
 
     errors = []
 

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -2,9 +2,7 @@ import pytest
 
 import scanpy as sc
 import scanpy.external as sce
-import io
-from contextlib import redirect_stdout
-
+from anndata.tests.helpers import assert_equal
 
 def test_scrublet():
     """

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -40,7 +40,7 @@ def test_scrublet_params():
 
     f = io.StringIO()
     with redirect_stdout(f):
-        sce.pp.scrublet(adata)
+        sce.pp.scrublet(adata, use_approx_neighbors=False)
 
     default = f.getvalue()
 
@@ -59,7 +59,7 @@ def test_scrublet_params():
     # Test each parameter and make sure something changes
 
     for param in test_params.keys():
-        test_args = {'adata': adata, param: test_params[param]}
+        test_args = {'adata': adata, use_approx_neighbors=False, param: test_params[param]}
         f = io.StringIO()
         with redirect_stdout(f):
             sc.external.pp.scrublet(**test_args)

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -34,7 +34,9 @@ def test_scrublet_params():
     """
     pytest.importorskip("scrublet")
 
-    adata = sc.datasets.pbmc3k()
+    # Reduce size of input for faster test
+    adata = sc.datasets.pbmc3k()[:500].copy()
+    sc.pp.filter_genes(adata, min_counts=100)
 
     # Get the default output
 

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -13,7 +13,7 @@ def test_scrublet():
     pytest.importorskip("scrublet")
 
     adata = sc.datasets.pbmc3k()
-    sce.pp.scrublet(adata)
+    sce.pp.scrublet(adata, use_approx_neighbors = False)
 
     errors = []
 

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -59,7 +59,11 @@ def test_scrublet_params():
     # Test each parameter and make sure something changes
 
     for param in test_params.keys():
-        test_args = {'adata': adata, use_approx_neighbors=False, param: test_params[param]}
+        test_args = {
+            'adata': adata,
+            use_approx_neighbors: False,
+            param: test_params[param],
+        }
         f = io.StringIO()
         with redirect_stdout(f):
             sc.external.pp.scrublet(**test_args)

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -61,7 +61,7 @@ def test_scrublet_params():
     for param in test_params.keys():
         test_args = {
             'adata': adata,
-            use_approx_neighbors: False,
+            'use_approx_neighbors': False,
             param: test_params[param],
         }
         f = io.StringIO()

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -40,11 +40,7 @@ def test_scrublet_params():
 
     # Get the default output
 
-    f = io.StringIO()
-    with redirect_stdout(f):
-        sce.pp.scrublet(adata, use_approx_neighbors=False)
-
-    default = f.getvalue()
+    default = sce.pp.scrublet(adata, use_approx_neighbors=False, copy=True)
 
     test_params = {
         'expected_doublet_rate': 0.1,
@@ -64,14 +60,12 @@ def test_scrublet_params():
         test_args = {
             'adata': adata,
             'use_approx_neighbors': False,
+            'copy': True,
             param: test_params[param],
         }
-        f = io.StringIO()
-        with redirect_stdout(f):
-            sc.external.pp.scrublet(**test_args)
-        diff_result = f.getvalue()
-
-        assert diff_result != default
+        curr = sc.external.pp.scrublet(**test_args)
+        with pytest.raises(AssertionError):
+            assert_equal(default, curr)
 
 
 def test_scrublet_simulate_doublets():

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -2,6 +2,8 @@ import pytest
 
 import scanpy as sc
 import scanpy.external as sce
+import io
+from contextlib import redirect_stdout
 
 
 def test_scrublet():
@@ -22,6 +24,48 @@ def test_scrublet():
     assert "doublet_score" in adata.obs.columns
 
     assert adata.obs["predicted_doublet"].any(), "Expect some doublets to be identified"
+
+
+def test_scrublet_params():
+    """
+    Test that Scrublet args are passed.
+
+    Check that changes to parameters change scrublet results.
+    """
+    pytest.importorskip("scrublet")
+
+    adata = sc.datasets.pbmc3k()
+
+    # Get the default output
+
+    f = io.StringIO()
+    with redirect_stdout(f):
+        sce.pp.scrublet(adata)
+
+    default = f.getvalue()
+
+    test_params = {
+        'expected_doublet_rate': 0.1,
+        'synthetic_doublet_umi_subsampling': 0.8,
+        'knn_dist_metric': 'manhattan',
+        'normalize_variance': False,
+        'log_transform': True,
+        'mean_center': False,
+        'n_prin_comps': 10,
+        'n_neighbors': 2,
+        'threshold': 0.1,
+    }
+
+    # Test each parameter and make sure something changes
+
+    for param in test_params.keys():
+        test_args = {'adata': adata, param: test_params[param]}
+        f = io.StringIO()
+        with redirect_stdout(f):
+            sc.external.pp.scrublet(**test_args)
+        diff_result = f.getvalue()
+
+        assert diff_result != default
 
 
 def test_scrublet_simulate_doublets():

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         harmony=['harmonypy'],
         scanorama=['scanorama'],
         scrublet=['scrublet'],
+        annoy=['annoy<1.17.0'],
         dev=['setuptools_scm', 'pytoml', 'black>=20.8b1'],
         doc=[
             'sphinx>=3.2',

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         harmony=['harmonypy'],
         scanorama=['scanorama'],
         scrublet=['scrublet'],
-        annoy=['annoy<1.17.0'],
         dev=['setuptools_scm', 'pytoml', 'black>=20.8b1'],
         doc=[
             'sphinx>=3.2',


### PR DESCRIPTION
Just a small PR to reinstate correct passing of parameters to Scrublet. Addresses https://github.com/theislab/scanpy/issues/1644.