### PR TITLE
Cleanup normalize_total

### DIFF
--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -5,6 +5,7 @@
 
 - Switched to flit_ for building and deploying the package,
   a simple tool with an easy to understand command line interface and metadata.
+- Added `layer` and `copy` kwargs to :func:`~scanpy.pp.normalize_total` :pr:`1667` :smaller:`I Virshup`
 
 .. _flit: https://flit.readthedocs.io/en/latest/
 
@@ -15,3 +16,5 @@
 .. rubric:: Bug fixes
 
 .. rubric:: Deprecations
+
+- Deprecated `layers` and `layers_norm` kwargs to :func:`~scanpy.pp.normalize_total` :pr:`1667` :smaller:`I Virshup`

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -37,6 +37,7 @@ def normalize_total(
     layers: Union[Literal['all'], Iterable[str]] = None,
     layer_norm: Optional[str] = None,
     inplace: bool = True,
+    copy: bool = False,
 ) -> Optional[Dict[str, np.ndarray]]:
     """\
     Normalize counts per cell.
@@ -80,6 +81,8 @@ def normalize_total(
     inplace
         Whether to update `adata` or return dictionary with normalized copies of
         `adata.X` and `adata.layers`.
+    copy
+        Whether to modify copied input object. Not compatible with inplace=False.
 
     Returns
     -------
@@ -118,6 +121,11 @@ def normalize_total(
            [ 0.5,  0.5,  0.5,  1. ,  1. ],
            [ 0.5, 11. ,  0.5,  1. ,  1. ]], dtype=float32)
     """
+    if copy:
+        if not inplace:
+            raise ValueError()
+        adata = adata.copy()
+
     if max_fraction < 0 or max_fraction > 1:
         raise ValueError('Choose max_fraction between 0 and 1.')
 
@@ -212,4 +220,7 @@ def normalize_total(
             f'and added {key_added!r}, counts per cell before normalization (adata.obs)'
         )
 
-    return dat if not inplace else None
+    if copy:
+        return adata
+    elif not inplace:
+        return dat

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -123,7 +123,7 @@ def normalize_total(
     """
     if copy:
         if not inplace:
-            raise ValueError()
+            raise ValueError("`copy=True` cannot be used with `inplace=False`.")
         adata = adata.copy()
 
     if max_fraction < 0 or max_fraction > 1:

--- a/scanpy/tests/helpers.py
+++ b/scanpy/tests/helpers.py
@@ -9,13 +9,16 @@ import numpy as np
 
 from anndata.tests.helpers import asarray, assert_equal
 
+# TODO: Report more context on the fields being compared on error
+# TODO: Allow specifying paths to ignore on comparison
+
 ###########################
 # Representation choice
 ###########################
 # These functions can be used to check that functions are correctly using arugments like `layers`, `obsm`, etc.
 
 
-def check_rep_mutation(func, X, fields=["layer", "obsm"], **kwargs):
+def check_rep_mutation(func, X, *, fields=["layer", "obsm"], **kwargs):
     """Check that only the array meant to be modified is modified."""
     adata = sc.AnnData(X=X.copy(), dtype=X.dtype)
     for field in fields:
@@ -47,35 +50,36 @@ def check_rep_mutation(func, X, fields=["layer", "obsm"], **kwargs):
         np.testing.assert_array_equal(X_array, result_array)
 
 
-def check_rep_results(func, X, **kwargs):
+def check_rep_results(func, X, *, fields=["layer", "obsm"], **kwargs):
     """Checks that the results of a computation add values/ mutate the anndata object in a consistent way."""
     # Gen data
-    adata_X = sc.AnnData(
-        X=X.copy(),
-        layers={"layer": np.zeros(shape=X.shape, dtype=X.dtype)},
-        obsm={"obsm": np.zeros(shape=X.shape, dtype=X.dtype)},
+    empty_X = np.zeros(shape=X.shape, dtype=X.dtype)
+    adata = sc.AnnData(
+        X=empty_X.copy(),
+        layers={"layer": empty_X.copy()},
+        obsm={"obsm": empty_X.copy()},
     )
-    adata_layer = sc.AnnData(
-        X=np.zeros(shape=X.shape, dtype=X.dtype),
-        layers={"layer": X.copy()},
-        obsm={"obsm": np.zeros(shape=X.shape, dtype=X.dtype)},
-    )
-    adata_obsm = sc.AnnData(
-        X=np.zeros(shape=X.shape, dtype=X.dtype),
-        layers={"layer": np.zeros(shape=X.shape, dtype=X.dtype)},
-        obsm={"obsm": X.copy()},
-    )
+
+    adata_X = adata.copy()
+    adata_X.X = X.copy()
+
+    adatas_proc = {}
+    for field in fields:
+        cur = adata.copy()
+        sc.get._set_obs_rep(cur, X.copy(), **{field: field})
+        adatas_proc[field] = cur
 
     # Apply function
     func(adata_X, **kwargs)
-    func(adata_layer, layer="layer", **kwargs)
-    func(adata_obsm, obsm="obsm", **kwargs)
+    for field in fields:
+        func(adatas_proc[field], **{field: field}, **kwargs)
 
     # Reset X
-    adata_X.X = np.zeros(shape=X.shape, dtype=X.dtype)
-    adata_layer.layers["layer"] = np.zeros(shape=X.shape, dtype=X.dtype)
-    adata_obsm.obsm["obsm"] = np.zeros(shape=X.shape, dtype=X.dtype)
+    adata_X.X = empty_X.copy()
+    for field in fields:
+        sc.get._set_obs_rep(adatas_proc[field], empty_X.copy(), **{field: field})
 
-    # Check equality
-    assert_equal(adata_X, adata_layer)
-    assert_equal(adata_X, adata_obsm)
+    for field_a, field_b in permutations(fields, 2):
+        assert_equal(adatas_proc[field_a], adatas_proc[field_b])
+    for field in fields:
+        assert_equal(adata_X, adatas_proc[field])

--- a/scanpy/tests/helpers.py
+++ b/scanpy/tests/helpers.py
@@ -2,6 +2,8 @@
 This file contains helper functions for the scanpy test suite.
 """
 
+from itertools import permutations
+
 import scanpy as sc
 import numpy as np
 
@@ -13,26 +15,36 @@ from anndata.tests.helpers import asarray, assert_equal
 # These functions can be used to check that functions are correctly using arugments like `layers`, `obsm`, etc.
 
 
-def check_rep_mutation(func, X, **kwargs):
+def check_rep_mutation(func, X, fields=["layer", "obsm"], **kwargs):
     """Check that only the array meant to be modified is modified."""
-    adata = sc.AnnData(
-        X=X.copy(),
-        layers={"layer": X.copy()},
-        obsm={"obsm": X.copy()},
-        dtype=X.dtype,
-    )
+    adata = sc.AnnData(X=X.copy(), dtype=X.dtype)
+    for field in fields:
+        sc.get._set_obs_rep(adata, X, **{field: field})
+    X_array = asarray(X)
+
     adata_X = func(adata, copy=True, **kwargs)
-    adata_layer = func(adata, layer="layer", copy=True, **kwargs)
-    adata_obsm = func(adata, obsm="obsm", copy=True, **kwargs)
+    adatas_proc = {
+        field: func(adata, copy=True, **{field: field}, **kwargs) for field in fields
+    }
 
-    assert np.array_equal(asarray(adata_X.X), asarray(adata_layer.layers["layer"]))
-    assert np.array_equal(asarray(adata_X.X), asarray(adata_obsm.obsm["obsm"]))
+    # Modified fields
+    for field in fields:
+        result_array = asarray(
+            sc.get._get_obs_rep(adatas_proc[field], **{field: field})
+        )
+        np.testing.assert_array_equal(asarray(adata_X.X), result_array)
 
-    assert np.array_equal(asarray(adata_layer.X), asarray(adata_layer.obsm["obsm"]))
-    assert np.array_equal(asarray(adata_obsm.X), asarray(adata_obsm.layers["layer"]))
-    assert np.array_equal(
-        asarray(adata_X.layers["layer"]), asarray(adata_X.obsm["obsm"])
-    )
+    # Unmodified fields
+    for field in fields:
+        np.testing.assert_array_equal(X_array, asarray(adatas_proc[field].X))
+        np.testing.assert_array_equal(
+            X_array, asarray(sc.get._get_obs_rep(adata_X, **{field: field}))
+        )
+    for field_a, field_b in permutations(fields, 2):
+        result_array = asarray(
+            sc.get._get_obs_rep(adatas_proc[field_a], **{field_b: field_b})
+        )
+        np.testing.assert_array_equal(X_array, result_array)
 
 
 def check_rep_results(func, X, **kwargs):

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -5,7 +5,7 @@ from scipy.sparse import csr_matrix
 from scipy import sparse
 
 import scanpy as sc
-from scanpy.tests.helpers import check_rep_mutation
+from scanpy.tests.helpers import check_rep_mutation, check_rep_results
 from anndata.tests.helpers import assert_equal, asarray
 
 X_total = [[1, 0], [3, 0], [5, 6]]
@@ -32,6 +32,7 @@ def test_normalize_total_rep(typ, dtype):
     # Test that layer kwarg works
     X = typ(sparse.random(100, 50, format="csr", density=0.2, dtype=dtype))
     check_rep_mutation(sc.pp.normalize_total, X, fields=["layer"])
+    check_rep_results(sc.pp.normalize_total, X, fields=["layer"])
 
 
 @pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -2,9 +2,11 @@ import pytest
 import numpy as np
 from anndata import AnnData
 from scipy.sparse import csr_matrix
+from scipy import sparse
 
 import scanpy as sc
-from anndata.tests.helpers import assert_equal
+from scanpy.tests.helpers import check_rep_mutation
+from anndata.tests.helpers import assert_equal, asarray
 
 X_total = [[1, 0], [3, 0], [5, 6]]
 X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
@@ -22,6 +24,14 @@ def test_normalize_total(typ, dtype):
     adata = AnnData(typ(X_frac, dtype=dtype))
     sc.pp.normalize_total(adata, exclude_highly_expressed=True, max_fraction=0.7)
     assert np.allclose(np.ravel(adata.X[:, 1:3].sum(axis=1)), [1.0, 1.0, 1.0])
+
+
+@pytest.mark.parametrize('typ', [asarray, csr_matrix], ids=lambda x: x.__name__)
+@pytest.mark.parametrize('dtype', ['float32', 'int64'])
+def test_normalize_total_rep(typ, dtype):
+    # Test that layer kwarg works
+    X = typ(sparse.random(100, 50, format="csr", density=0.2, dtype=dtype))
+    check_rep_mutation(sc.pp.normalize_total, X, fields=["layer"])
 
 
 @pytest.mark.parametrize('typ', [np.array, csr_matrix], ids=lambda x: x.__name__)

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -39,7 +39,8 @@ def test_normalize_total_rep(typ, dtype):
 def test_normalize_total_layers(typ, dtype):
     adata = AnnData(typ(X_total), dtype=dtype)
     adata.layers["layer"] = adata.X.copy()
-    sc.pp.normalize_total(adata, layers=["layer"])
+    with pytest.warns(FutureWarning, match=r".*layers.*deprecated"):
+        sc.pp.normalize_total(adata, layers=["layer"])
     assert np.allclose(adata.layers["layer"].sum(axis=1), [3.0, 3.0, 3.0])
 
 


### PR DESCRIPTION
I was looking over normalize_total and saw some strange behaviour. Since it's such a common function, I think it's important that it has standard scanpy behaviour. To this end, this PR looks at cleanup up it's code.

### Addition

`layer` argument. A specific layer can now be normalized by itself.

### Deprecations

I've deprecated the `layers` and `layer_norm` argument. Normalizing multiple layers at once seems less useful than normalizing a specific layer. These seem like very specific use cases that are easy for user's to implement themselves, and are not common patterns in scanpy functions.

### TODO:

- [x] Tests for deprecations 
- [x] Scheduling of deprecations (deprecate in 1.8, remove in 1.9)