### PR TITLE
Attempt server-side search

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
     # 'ipython_directive',
     # 'ipython_console_highlighting',
     'scanpydoc',
+    "sphinx_search.extension",
     *[p.stem for p in (HERE / 'extensions').glob('*.py')],
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
         doc=[
             'sphinx>=3.2',
             'sphinx_rtd_theme>=0.3.1',
+            'readthedocs-sphinx-search',
             'sphinx_autodoc_typehints',
             'scanpydoc>=0.5',
             'typing_extensions; python_version < "3.8"',  # for `Literal`


### PR DESCRIPTION
Inspired by @gokceneraslan pointing to [Hail.is]()'s cool doc search I did a little research. It looks like `readthedocs` might offer something similar: https://docs.readthedocs.io/en/stable/server-side-search.html

While those docs make it seem like it should be on by default, that doesn't seem to be the case. This is an attempt to figure out how to get nice search like that with read the docs. An alternative is to use [DocSearch](https://docsearch.algolia.com).

First attempt: add [readthedocs-sphinx-search](https://readthedocs-sphinx-search.readthedocs.io/en/latest/index.html).