### PR TITLE
Fix print_versions for python<3.8

### DIFF
--- a/docs/release-notes/1.7.2.rst
+++ b/docs/release-notes/1.7.2.rst
@@ -1,0 +1,12 @@
+1.7.2 :small:`the future`
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. rubric:: Performance enhancements
+
+.. rubric:: Bug fixes
+
+- :func:`scanpy.logging.print_versions` now works when `python<3.8` :pr:`1691` :smaller:`I Virshup`
+
+.. rubric:: Deprecations
+
+.. rubric:: Documentation

--- a/docs/release-notes/release-latest.rst
+++ b/docs/release-notes/release-latest.rst
@@ -6,5 +6,6 @@ Version 1.8
 Version 1.7
 -----------
 
+.. include:: /release-notes/1.7.2.rst
 .. include:: /release-notes/1.7.1.rst
 .. include:: /release-notes/1.7.0.rst

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -167,7 +167,14 @@ def print_versions(*, file=None):
         buf = sys.stdout = io.StringIO()
         sinfo(
             dependencies=True,
-            excludes=['builtins', 'stdlib_list', 'importlib_metadata'],
+            excludes=[
+                'builtins',
+                'stdlib_list',
+                'importlib_metadata',
+                # Special module present if test coverage being calculated
+                # https://gitlab.com/joelostblom/sinfo/-/issues/10
+                "$coverage",
+            ],
         )
     finally:
         sys.stdout = stdout

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -165,7 +165,10 @@ def print_versions(*, file=None):
     stdout = sys.stdout
     try:
         buf = sys.stdout = io.StringIO()
-        sinfo(dependencies=True)
+        sinfo(
+            dependencies=True,
+            excludes=['builtins', 'stdlib_list', 'importlib_metadata'],
+        )
     finally:
         sys.stdout = stdout
     output = buf.getvalue()

--- a/scanpy/tests/test_logging.py
+++ b/scanpy/tests/test_logging.py
@@ -1,3 +1,4 @@
+from contextlib import redirect_stdout
 import sys
 from datetime import datetime
 from io import StringIO
@@ -5,6 +6,7 @@ from io import StringIO
 import pytest
 
 from scanpy import Verbosity, settings as s, logging as l
+import scanpy as sc
 
 
 @pytest.fixture
@@ -91,3 +93,24 @@ def test_timing(monkeypatch, capsys, logging_state):
     assert counter == 4 and capsys.readouterr().err == '4 (0:00:02)\n'
     l.info('5 {time_passed}', time=start)
     assert counter == 5 and capsys.readouterr().err == '5 0:00:03\n'
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        sc.logging.print_header,
+        sc.logging.print_versions,
+        sc.logging.print_version_and_date,
+    ],
+)
+def test_call_outputs(func):
+    """
+    Tests that these functions print to stdout and don't error.
+
+    Checks that https://github.com/theislab/scanpy/issues/1437 is fixed.
+    """
+    output_io = StringIO()
+    with redirect_stdout(output_io):
+        func()
+    output = output_io.getvalue()
+    assert output != ""

--- a/scanpy/tests/test_logging.py
+++ b/scanpy/tests/test_logging.py
@@ -1,7 +1,7 @@
 from contextlib import redirect_stdout
-import sys
 from datetime import datetime
 from io import StringIO
+import sys
 
 import pytest
 


### PR DESCRIPTION
`importlib_metadata` does not have a `__version__` attribute. This breaks `sinfo`. We can just skip getting it's version. Also, test that `print_versions` works.

Fixes #1437