### PR TITLE
Use joblib for parallelism in regress_out

### DIFF
--- a/docs/release-notes/1.7.2.rst
+++ b/docs/release-notes/1.7.2.rst
@@ -6,7 +6,7 @@
 .. rubric:: Bug fixes
 
 - :func:`scanpy.logging.print_versions` now works when `python<3.8` :pr:`1691` :smaller:`I Virshup`
-- :func:`scanpy.preprocessing.regress_out` now uses `joblib` as the parallel backend, and should stop oversubscribing threads :pr:`1694` :smaller:`I Virshup`
+- :func:`scanpy.pp.regress_out` now uses `joblib` as the parallel backend, and should stop oversubscribing threads :pr:`1694` :smaller:`I Virshup`
 
 .. rubric:: Deprecations
 

--- a/docs/release-notes/1.7.2.rst
+++ b/docs/release-notes/1.7.2.rst
@@ -6,6 +6,7 @@
 .. rubric:: Bug fixes
 
 - :func:`scanpy.logging.print_versions` now works when `python<3.8` :pr:`1691` :smaller:`I Virshup`
+- :func:`scanpy.preprocessing.regress_out` now uses `joblib` as the parallel backend, and should stop oversubscribing threads :pr:`1694` :smaller:`I Virshup`
 
 .. rubric:: Deprecations
 

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -663,6 +663,7 @@ def regress_out(
         tasks.append(tuple((data_chunk, regres, variable_is_categorical)))
 
     from joblib import Parallel, delayed
+
     res = Parallel(n_jobs=n_jobs)(delayed(_regress_out_chunk)(task) for task in tasks)
 
     # res is a list of vectors (each corresponding to a regressed gene column).

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -664,6 +664,7 @@ def regress_out(
 
     from joblib import Parallel, delayed
 
+    # TODO: figure out how to test that this doesn't oversubscribe resources
     res = Parallel(n_jobs=n_jobs)(delayed(_regress_out_chunk)(task) for task in tasks)
 
     # res is a list of vectors (each corresponding to a regressed gene column).

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -662,15 +662,8 @@ def regress_out(
             regres = regressors
         tasks.append(tuple((data_chunk, regres, variable_is_categorical)))
 
-    if n_jobs > 1 and n_chunks > 1:
-        import multiprocessing
-
-        pool = multiprocessing.Pool(n_jobs)
-        res = pool.map_async(_regress_out_chunk, tasks).get(9999999)
-        pool.close()
-
-    else:
-        res = list(map(_regress_out_chunk, tasks))
+    from joblib import Parallel, delayed
+    res = Parallel(n_jobs=n_jobs)(delayed(_regress_out_chunk)(task) for task in tasks)
 
     # res is a list of vectors (each corresponding to a regressed gene column).
     # The transpose is needed to get the matrix in the shape needed


### PR DESCRIPTION
Fixes  #1396

Branch which I had sitting on my computer, but forgot to open a PR for (doh).

Uses joblib to parallelize `regress_out` instead of `multiprocessing` in order to prevent oversubscription of threads.

Not sure how to test this.

Should I also allow passing more arguments to joblib?