### PR TITLE
Go back to regular pip

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -95,8 +95,11 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install flit twine wheel
-    displayName: 'Install build tools'
+      pip install flit twine wheel pytoml
+      python -c \
+        'import pytoml; c=pytoml.load(open("pyproject.toml")); print("\0".join(c["build-system"]["requires"]), end="")' \
+        | xargs -0 pip install -y
+    displayName: 'Install build tools and requirements'
 
   - script: pip list
     displayName: 'Display installed versions'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -42,7 +42,6 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install -r .pip-2033.txt
       pip install pytest-cov wheel
       pip install .[dev,doc,test,louvain,leiden,magic,scvi,harmony,scrublet,scanorama]
     displayName: 'Install dependencies'
@@ -103,7 +102,6 @@ jobs:
     displayName: 'Display installed versions'
 
   - script: |
-      pip install flit
       flit build
       twine check dist/*
     displayName: 'Build & Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -95,16 +95,13 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install flit twine wheel pytoml
-      python -c \
-        'import pytoml; c=pytoml.load(open("pyproject.toml")); print("\0".join(c["build-system"]["requires"]), end="")' \
-        | xargs -0 pip install
+      pip install build twine wheel pytoml
     displayName: 'Install build tools and requirements'
 
   - script: pip list
     displayName: 'Display installed versions'
 
   - script: |
-      flit build
+      python -m build --sdist --wheel .
       twine check dist/*
     displayName: 'Build & Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -102,6 +102,7 @@ jobs:
     displayName: 'Display installed versions'
 
   - script: |
+      pip install flit
       flit build
       twine check dist/*
     displayName: 'Build & Twine check'

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install build twine wheel pytoml
+      pip install build twine
     displayName: 'Install build tools and requirements'
 
   - script: pip list

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -98,7 +98,7 @@ jobs:
       pip install flit twine wheel pytoml
       python -c \
         'import pytoml; c=pytoml.load(open("pyproject.toml")); print("\0".join(c["build-system"]["requires"]), end="")' \
-        | xargs -0 pip install -y
+        | xargs -0 pip install
     displayName: 'Install build tools and requirements'
 
   - script: pip list

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -95,14 +95,13 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install setuptools setuptools_scm pytoml wheel twine
-    displayName: 'Install build dependencies'
+      pip install flit twine wheel
+    displayName: 'Install build tools'
 
   - script: pip list
     displayName: 'Display installed versions'
 
   - script: |
-      pip install flit
       flit build
       twine check dist/*
     displayName: 'Build & Twine check'

--- a/.pip-2033.txt
+++ b/.pip-2033.txt
@@ -1,4 +1,0 @@
-# Flit mangles the +local part of the version spec in compliance with PEP 427,
-# but pip 20.3.4 started expecting wheel filenames to contain the local part unmangled.
-# https://github.com/pypa/pip/issues/9628
-pip==20.3.3

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,7 +6,6 @@ sphinx:
 python:
   version: 3.8
   install:
-  - requirements: .pip-2033.txt
   - method: pip
     path: .
     extra_requirements:

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -54,6 +54,10 @@ if you are not able to give yourself the `create symbolic links`_ privilege.
 
 .. _create symbolic links: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/create-symbolic-links
 
+.. note::
+
+    `pip install -e` still works, but may not in future versions.
+
 Docker
 ~~~~~~
 If you're using Docker_, you can use e.g. the image `gcfntnu/scanpy`_ from Docker Hub.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -41,22 +41,13 @@ cloned version after you update with `git pull`) call::
 
 .. _on GitHub: https://github.com/theislab/scanpy
 
-.. note::
-
-   Due to a `bug in pip`_, packages installed by `flit` can be uninstalled by normal pip operations.
-   For now, you can avoid this by using::
-
-       pip install -e ".[dev,doc,test]"
-
-.. _bug in pip: https://github.com/pypa/pip/issues/9670
-
 If you want to let conda_ handle the installations of dependencies, do::
 
     pip install beni
     beni pyproject.toml > environment.yml
     conda env create -f environment.yml
     conda activate scanpy
-    flit install -s --deps=develop  # or: pip install -e ".[dev,doc,test]"
+    flit install -s --deps=develop
 
 On Windows, you might have to use `flit install --pth-file`
 if you are not able to give yourself the `create symbolic links`_ privilege.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 build-backend = 'flit_core.buildapi'
 requires = [
-    'flit_core >=2,<4',
+    'flit_core >=3.1,<4',
     'setuptools_scm',
     'pytoml',
     'importlib_metadata>=0.7; python_version < "3.8"',

--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,7 @@ if __name__ == "__main__":
     if "develop" in sys.argv:
         msg = (
             "Please use `flit install -s` or `flit install --pth-file` "
-            "instead of `pip install -e`/`python setup.py develop` "
-            "once https://github.com/pypa/pip/issues/9670 is fixed."
+            "instead of `pip install -e`/`python setup.py develop`"
         )
     elif "install" in sys.argv:
         msg = 'Please use `pip install "$d"` instead of `python "$d/setup.py" install`'


### PR DESCRIPTION
Hahaha and of course after weeks of this bug, everything gets resolved the day I press the merge button. takluyver/flit#395 should fix the issues where

1. `pip install scvelo` downgrades a `flit install -s` installed scanpy (now the `dist-info` dir name contains the correct version)
2. The wheel built by flit now corresponds to the freshly-changed spec’s [mangling rules](https://packaging.python.org/specifications/binary-distribution-format/#escaping-and-unicode)

So we can remove the workarounds. No problem, `git blame` won’t be affected much, this almost exclusively deletes lines.