### PR TITLE
Add sparsificiation step before sparse-dependent Scrublet calls

### DIFF
--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -364,18 +364,8 @@ def _scrublet_call_doublets(
     # Ensure normalised matrix sparseness as Scrublet does
     # https://github.com/swolock/scrublet/blob/67f8ecbad14e8e1aa9c89b43dac6638cebe38640/src/scrublet/scrublet.py#L100
 
-    def sparsify(mat):
-        if not sp.sparse.issparse(mat):
-            return sp.sparse.csc_matrix(mat)
-
-        elif not sp.sparse.isspmatrix_csc(mat):
-            return mat.tocsc()
-
-        else:
-            return mat
-
-    scrub._E_obs_norm = sparsify(adata_obs.X)
-    scrub._E_sim_norm = sparsify(adata_sim.X)
+    scrub._E_obs_norm = sp.sparse.csc_matrix(adata_obs.X)
+    scrub._E_sim_norm = sp.sparse.csc_matrix(adata_sim.X)
 
     scrub.doublet_parents_ = adata_sim.obsm['doublet_parents']
 

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -1,7 +1,8 @@
 from anndata import AnnData
 from typing import Collection, Tuple, Optional, Union
 import numpy as np
-import scipy as sp
+from scipy import sparse
+
 
 from ... import logging as logg
 from ... import preprocessing as pp
@@ -364,8 +365,8 @@ def _scrublet_call_doublets(
     # Ensure normalised matrix sparseness as Scrublet does
     # https://github.com/swolock/scrublet/blob/67f8ecbad14e8e1aa9c89b43dac6638cebe38640/src/scrublet/scrublet.py#L100
 
-    scrub._E_obs_norm = sp.sparse.csc_matrix(adata_obs.X)
-    scrub._E_sim_norm = sp.sparse.csc_matrix(adata_sim.X)
+    scrub._E_obs_norm = sparse.csc_matrix(adata_obs.X)
+    scrub._E_sim_norm = sparse.csc_matrix(adata_sim.X)
 
     scrub.doublet_parents_ = adata_sim.obsm['doublet_parents']
 

--- a/scanpy/tests/external/test_scrublet.py
+++ b/scanpy/tests/external/test_scrublet.py
@@ -25,6 +25,26 @@ def test_scrublet():
     assert adata.obs["predicted_doublet"].any(), "Expect some doublets to be identified"
 
 
+def test_scrublet_dense():
+    """
+    Test that Scrublet works for dense matrices.
+
+    Check that scrublet runs and detects some doublets when a dense matrix is supplied.
+    """
+    pytest.importorskip("scrublet")
+
+    adata = sc.datasets.paul15()[:500].copy()
+    sce.pp.scrublet(adata, use_approx_neighbors=False)
+
+    errors = []
+
+    # replace assertions by conditions
+    assert "predicted_doublet" in adata.obs.columns
+    assert "doublet_score" in adata.obs.columns
+
+    assert adata.obs["predicted_doublet"].any(), "Expect some doublets to be identified"
+
+
 def test_scrublet_params():
     """
     Test that Scrublet args are passed.


### PR DESCRIPTION
This PR addresses https://github.com/theislab/scanpy/issues/1645, which was caused by my injection of normalised matrices from Scanpy workflows, thereby bypassing a sparseness check Scrublet does with the raw matrix.

The fix contained here is apply the Scrublet sparseness check, before calling Scrublet functions with a dependency on sparseness. 