### PR TITLE
Fix version on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: xenial
 language: python
+git:
+  depth: false  # Version detection needs all info
 branches:
   only:
     - master  # All other branches should become (draft) PRs and be build that way


### PR DESCRIPTION
By default, Travis does `git clone --depth=50` which means the version can’t be detected from the git tag.

In case we ever start relying on the version being correct in the tests, this fixes it.