### PR TITLE
Fix clipped images in docs

### DIFF
--- a/docs/matplotlibrc
+++ b/docs/matplotlibrc
@@ -1,0 +1,1 @@
+savefig.bbox : tight


### PR DESCRIPTION
Fixes #1705

Found this over on `seaborn`: https://github.com/mwaskom/seaborn/blob/master/doc/matplotlibrc