### PR TITLE
Fix long test output

### DIFF
--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -22,6 +22,27 @@ def close_figures_on_teardown():
     pyplot.close("all")
 
 
+def clear_loggers():
+    """Remove handlers from all loggers
+
+    Fixes: https://github.com/theislab/scanpy/issues/1736
+
+    Code from: https://github.com/pytest-dev/pytest/issues/5502#issuecomment-647157873
+    """
+    import logging
+
+    loggers = [logging.getLogger()] + list(logging.Logger.manager.loggerDict.values())
+    for logger in loggers:
+        handlers = getattr(logger, 'handlers', [])
+        for handler in handlers:
+            logger.removeHandler(handler)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def close_logs_on_teardown(request):
+    request.addfinalizer(clear_loggers)
+
+
 @pytest.fixture
 def imported_modules():
     return IMPORTED


### PR DESCRIPTION
Maybe fixes #1736, tested with #1735 and it seemed to do the trick.

@flying-sheep, you're the most familiar with the logging setup. Any thoughts?