### PR TITLE
Add morans I

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -249,6 +249,7 @@ Collections of useful measurements for evaluating results.
 
    metrics.confusion_matrix
    metrics.gearys_c
+   metrics.morans_i
 
 
 Classes

--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -15,7 +15,7 @@
 
     - Added :func:`scanpy.metrics.confusion_matrix` for comparing labellings :pr:`915` :smaller:`I Virshup`
     - Added :func:`scanpy.metrics.gearys_c` for spatial autocorrelation :pr:`915` :smaller:`I Virshup`
-    - - Added :func:`scanpy.metrics.morans_i` for global spatial autocorrelation :pr:`1740` :smaller:`I Virshup, G Palla`
+    - Added :func:`scanpy.metrics.morans_i` for global spatial autocorrelation :pr:`1740` :smaller:`I Virshup, G Palla`
 
 .. rubric:: External tools
 

--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -15,6 +15,7 @@
 
     - Added :func:`scanpy.metrics.confusion_matrix` for comparing labellings :pr:`915` :smaller:`I Virshup`
     - Added :func:`scanpy.metrics.gearys_c` for spatial autocorrelation :pr:`915` :smaller:`I Virshup`
+    - - Added :func:`scanpy.metrics.morans_i` for global spatial autocorrelation :pr:`1740` :smaller:`I Virshup, G Palla`
 
 .. rubric:: External tools
 
@@ -25,3 +26,8 @@
 .. rubric:: Deprecations
 
 - Deprecated `layers` and `layers_norm` kwargs to :func:`~scanpy.pp.normalize_total` :pr:`1667` :smaller:`I Virshup`
+
+.. rubric:: Docs
+
+- Clarified docs issues for :func:`~scanpy.pp.neighbors`, 
+  :func:`~scanpy.tl.diffmap`, :func:`~scanpy.pp.calculate_qc_metrics` :pr:`1680` :smaller:`G Palla`

--- a/scanpy/metrics/__init__.py
+++ b/scanpy/metrics/__init__.py
@@ -1,2 +1,3 @@
 from ._gearys_c import gearys_c
 from ._metrics import confusion_matrix
+from ._morans_i import morans_i

--- a/scanpy/metrics/_gearys_c.py
+++ b/scanpy/metrics/_gearys_c.py
@@ -166,7 +166,7 @@ def _gearys_c_vec_W(data, indices, indptr, x, W):
 # https://github.com/numba/numba/issues/6774#issuecomment-788789663
 
 
-@numba.njit
+@numba.njit(cache=True)
 def _gearys_c_inner_sparse_x_densevec(g_data, g_indices, g_indptr, x, W):
     x_bar = x.mean()
     total = 0.0
@@ -182,7 +182,7 @@ def _gearys_c_inner_sparse_x_densevec(g_data, g_indices, g_indptr, x, W):
     return C
 
 
-@numba.njit
+@numba.njit(cache=True)
 def _gearys_c_inner_sparse_x_sparsevec(
     g_data, g_indices, g_indptr, x_data, x_indices, N, W
 ):

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -31,27 +31,21 @@ def morans_i(
     use_raw: bool = False,
 ) -> Union[np.ndarray, float]:
     r"""
-    Calculate `Geary's C <https://en.wikipedia.org/wiki/Geary's_C>`_, as used
-    by `VISION <https://doi.org/10.1038/s41467-019-12235-0>`_.
+    Calculate Moran’s I Global Autocorrelation Statistic.
 
-    Geary's C is a measure of autocorrelation for some measure on a graph. This
-    can be to whether measures are correlated between neighboring cells. Lower
-    values indicate greater correlation.
+    Moran’s I is a global autocorrelation statistic for some measure on a graph. It is commonly used in
+    spatial data analysis to assess autocorrelation on a 2D grid. It is closely related to Geary's C,
+    but not identical. More info can be found `here`<https://en.wikipedia.org/wiki/Moran%27s_I> .
 
     .. math::
 
-        C =
-        \frac{
-            (N - 1)\sum_{i,j} w_{i,j} (x_i - x_j)^2
-        }{
-            2W \sum_i (x_i - \bar{x})^2
-        }
+        I=\frac{n}{S_{0}} \frac{\sum_{i=1}^{n} \sum_{j=1}^{n} w_{i, j} z_{i} z_{j}}{\sum_{i=1}^{n} z_{i}^{2}}
 
     Params
     ------
     adata
     vals
-        Values to calculate Geary's C for. If this is two dimensional, should
+        Values to calculate Moran's I for. If this is two dimensional, should
         be of shape `(n_features, n_cells)`. Otherwise should be of shape
         `(n_cells,)`. This matrix can be selected from elements of the anndata
         object by using key word arguments: `layer`, `obsm`, `obsp`, or
@@ -91,21 +85,21 @@ def morans_i(
     Examples
     --------
 
-    Calculate Gearys C for each components of a dimensionality reduction:
+    Calculate Morans I for each components of a dimensionality reduction:
 
     .. code:: python
 
         import scanpy as sc, numpy as np
 
         pbmc = sc.datasets.pbmc68k_processed()
-        pc_c = sc.metrics.gearys_c(pbmc, obsm="X_pca")
+        pc_c = sc.metrics.morans_i(pbmc, obsm="X_pca")
 
 
     It's equivalent to call the function directly on the underlying arrays:
 
     .. code:: python
 
-        alt = sc.metrics.gearys_c(pbmc.obsp["connectivities"], pbmc.obsm["X_pca"].T)
+        alt = sc.metrics.morans_i(pbmc.obsp["connectivities"], pbmc.obsm["X_pca"].T)
         np.testing.assert_array_equal(pc_c, alt)
     """
     if use_graph is None:

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -11,6 +11,7 @@ import numba.types as nt
 from numba import njit, prange
 
 from scanpy.get import _get_obs_rep
+from scanpy.metrics._gearys_c import _resolve_vals
 
 it = nt.int64
 ft = nt.float32
@@ -211,26 +212,6 @@ def _morans_i_mtx_csr(
 ###############################################################################
 # Interface (taken from gearys C)
 ###############################################################################
-@singledispatch
-def _resolve_vals(val):
-    return np.asarray(val)
-
-
-@_resolve_vals.register(np.ndarray)
-@_resolve_vals.register(sparse.csr_matrix)
-def _(val):
-    return val
-
-
-@_resolve_vals.register(sparse.spmatrix)
-def _(val):
-    return sparse.csr_matrix(val)
-
-
-@_resolve_vals.register(pd.DataFrame)
-@_resolve_vals.register(pd.Series)
-def _(val):
-    return val.to_numpy()
 
 
 @morans_i.register(sparse.csr_matrix)

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -15,11 +15,11 @@ ip = np.int64
 fp = np.float64
 
 
-def moran(
+def morans_i(
     adata: AnnData,
-    connectivity_key: str = Key.obsp.spatial_conn(),
+    connectivity_key: str = "connectivities",
     genes: Optional[Union[str, Sequence[str]]] = None,
-    n_perms: int = 100,
+    n_perms: int = 1000,
     corr_method: Optional[str] = "fdr_bh",
     layer: Optional[str] = None,
     copy: bool = False,
@@ -79,7 +79,7 @@ def moran(
         mi = _moran_score_perms(counts, indptr, indices, data, n_perms)
         moran_list.append(mi)
 
-    df = pd.DataFrame(moran_list, columns=["I", "pval_sim", "VI_sim"], index=gen)
+    df = pd.DataFrame(moran_list, columns=["I", "pval_sim", "VI_sim"], index=genes)
 
     if corr_method is not None:
         _, pvals_adj, _, _ = multipletests(
@@ -144,7 +144,7 @@ def _moran_score_perms(
     res[0] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
 
     for p in range(len(perms)):
-        np.random.shuffle(counts)
+        np.random.shuffle(z)
         perms[p] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
     res[1] = (np.sum(perms > res[0]) + 1) / (n_perms + 1)
     res[2] = np.var(perms)

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -31,7 +31,12 @@ def morans_i(
 
     .. math::
 
-        I=\frac{n}{S_{0}} \frac{\sum_{i=1}^{n} \sum_{j=1}^{n} w_{i, j} z_{i} z_{j}}{\sum_{i=1}^{n} z_{i}^{2}}
+        I =
+            \frac{
+                N \sum_{i, j} w_{i, j} z_{i} z_{j}
+            }{
+                S_{0} \sum_{i} z_{i}^{2}
+            } 
 
     Params
     ------

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -1,13 +1,11 @@
 """Moran's I global spatial autocorrelation."""
-from typing import Any, Union, Optional
+from typing import Union, Optional
 from functools import singledispatch
 from anndata import AnnData
 
 import numpy as np
-import pandas as pd
 from scipy import sparse
 from numba import njit, prange
-import numba.types as nt
 
 from scanpy.get import _get_obs_rep
 from scanpy.metrics._gearys_c import _resolve_vals

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -19,7 +19,7 @@ def morans_i(
     adata: AnnData,
     connectivity_key: str = "connectivities",
     genes: Optional[Union[str, Sequence[str]]] = None,
-    n_perms: int = 1000,
+    n_perms: int = 100,
     corr_method: Optional[str] = "fdr_bh",
     layer: Optional[str] = None,
     copy: bool = False,

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -111,7 +111,7 @@ def morans_i(
     return morans_i(g, vals)
 
 
-@njit
+@njit(cache=True)
 def _morans_i_vec_W_sparse(
     x_data: np.ndarray,
     x_indices: np.ndarray,
@@ -126,7 +126,7 @@ def _morans_i_vec_W_sparse(
     return _morans_i_vec_W(x, data, indices, indptr, W)
 
 
-@njit
+@njit(cache=True)
 def _morans_i_vec_W(
     x: np.ndarray,
     data: np.ndarray,

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -1,8 +1,5 @@
 """Moran's I global spatial autocorrelation."""
-from typing import Any, Tuple, Union, Iterable, Optional, Sequence
-from itertools import chain
-
-from scanpy import logging as logg
+from typing import Any, Union, Optional, Sequence
 from anndata import AnnData
 
 import numpy as np
@@ -10,8 +7,6 @@ import pandas as pd
 import numba.types as nt
 
 from numba import njit
-from scipy.sparse import spmatrix
-from sklearn.metrics import pairwise_distances
 from statsmodels.stats.multitest import multipletests
 
 it = nt.int64
@@ -27,7 +22,6 @@ def moran(
     n_perms: int = 100,
     corr_method: Optional[str] = "fdr_bh",
     layer: Optional[str] = None,
-    seed: Optional[int] = None,
     copy: bool = False,
 ) -> Optional[pd.DataFrame]:
     """

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -27,7 +27,7 @@ def morans_i(
 
     Moran’s I is a global autocorrelation statistic for some measure on a graph. It is commonly used in
     spatial data analysis to assess autocorrelation on a 2D grid. It is closely related to Geary's C,
-    but not identical. More info can be found `here`<https://en.wikipedia.org/wiki/Moran%27s_I> .
+    but not identical. More info can be found `here <https://en.wikipedia.org/wiki/Moran%27s_I>`_.
 
     .. math::
 
@@ -36,7 +36,7 @@ def morans_i(
                 N \sum_{i, j} w_{i, j} z_{i} z_{j}
             }{
                 S_{0} \sum_{i} z_{i}^{2}
-            } 
+            }
 
     Params
     ------

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -8,7 +8,7 @@ import pandas as pd
 from scipy import sparse
 
 import numba.types as nt
-from numba import njit
+from numba import njit, prange
 
 from scanpy.get import _get_obs_rep
 
@@ -120,7 +120,7 @@ def morans_i(
 @njit(
     ft(ft[:], it[:], it[:], ft[:], ft[:], ft, ft),
     cache=True,
-    parallel=True,
+    parallel=False,
     fastmath=True,
 )
 def _morans_i_vec_W(
@@ -136,7 +136,7 @@ def _morans_i_vec_W(
     zl = np.empty(len(z))
     N = len(indptr) - 1
 
-    for i in range(N):
+    for i in prange(N):
         s = slice(indptr[i], indptr[i + 1])
         i_indices = indices[s]
         i_data = data[s]
@@ -170,7 +170,7 @@ def _morans_i_mtx(
     assert N == len(indptr) - 1
     W = data.sum()
     out = np.zeros(M, dtype=ft)
-    for k in range(M):
+    for k in prange(M):
         x = X[k, :].astype(ft)
         z = x - x.mean()
         z2ss = (z * z).sum()
@@ -198,7 +198,7 @@ def _morans_i_mtx_csr(
     out = np.zeros(M, dtype=ft)
     x_data_list = np.split(X_data, X_indptr[1:-1])
     x_indices_list = np.split(X_indices, X_indptr[1:-1])
-    for k in range(M):
+    for k in prange(M):
         x = np.zeros(N, dtype=ft)
         x_index = x_indices_list[k]
         x[x_index] = x_data_list[k]

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -1,115 +1,147 @@
 """Moran's I global spatial autocorrelation."""
-from typing import Any, Union, Optional, Sequence
+from typing import Any, Union, Optional
+from functools import singledispatch
 from anndata import AnnData
 
 import numpy as np
 import pandas as pd
-import numba.types as nt
+from scipy import sparse
 
+import numba.types as nt
 from numba import njit
-from statsmodels.stats.multitest import multipletests
+
+from scanpy.get import _get_obs_rep
 
 it = nt.int64
 ft = nt.float64
 ip = np.int64
 fp = np.float64
+tt = nt.UniTuple
 
 
+@singledispatch
 def morans_i(
     adata: AnnData,
-    connectivity_key: str = "connectivities",
-    genes: Optional[Union[str, Sequence[str]]] = None,
-    n_perms: int = 100,
-    corr_method: Optional[str] = "fdr_bh",
+    *,
+    vals: Optional[Union[np.ndarray, sparse.spmatrix]] = None,
+    use_graph: Optional[str] = None,
     layer: Optional[str] = None,
-    copy: bool = False,
-) -> Optional[pd.DataFrame]:
-    """
-    Calculate Moran’s I Global Autocorrelation Statistic.
+    obsm: Optional[str] = None,
+    obsp: Optional[str] = None,
+    use_raw: bool = False,
+) -> Union[np.ndarray, float]:
+    r"""
+    Calculate `Geary's C <https://en.wikipedia.org/wiki/Geary's_C>`_, as used
+    by `VISION <https://doi.org/10.1038/s41467-019-12235-0>`_.
 
-    The statistics is described here TODO.
+    Geary's C is a measure of autocorrelation for some measure on a graph. This
+    can be to whether measures are correlated between neighboring cells. Lower
+    values indicate greater correlation.
 
-    Parameters
-    ----------
+    .. math::
+
+        C =
+        \frac{
+            (N - 1)\sum_{i,j} w_{i,j} (x_i - x_j)^2
+        }{
+            2W \sum_i (x_i - \bar{x})^2
+        }
+
+    Params
+    ------
     adata
-    connectivity_key
-    genes
-        List of gene names, as stored in :attr:`anndata.AnnData.var_names`, used to compute Moran's I statistics.
-        If `None`, it's computed :attr:`anndata.AnnData.var` ``['highly_variable']``, if present. Otherwise,
-        it's computed for all genes.
-    n_perms
-        Number of permutations.
-    corr_method
-        FDR correction method.
+    vals
+        Values to calculate Geary's C for. If this is two dimensional, should
+        be of shape `(n_features, n_cells)`. Otherwise should be of shape
+        `(n_cells,)`. This matrix can be selected from elements of the anndata
+        object by using key word arguments: `layer`, `obsm`, `obsp`, or
+        `use_raw`.
+    use_graph
+        Key to use for graph in anndata object. If not provided, default
+        neighbors connectivities will be used instead.
     layer
-        Layer in :attr:`anndata.AnnData.layers` to use. If `None`, use :attr:`anndata.AnnData.X`.
-    copy
-        Whether to modify copied input object.
+        Key for `adata.layers` to choose `vals`.
+    obsm
+        Key for `adata.obsm` to choose `vals`.
+    obsp
+        Key for `adata.obsp` to choose `vals`.
+    use_raw
+        Whether to use `adata.raw.X` for `vals`.
+
+
+    This function can also be called on the graph and values directly. In this case
+    the signature looks like:
+
+    Params
+    ------
+    g
+        The graph
+    vals
+        The values
+
+
+    See the examples for more info.
 
     Returns
     -------
-    If ``copy = True``, returns a :class:`pandas.DataFrame` with the following keys:
+    If vals is two dimensional, returns a 1 dimensional ndarray array. Returns
+    a scalar if `vals` is 1d.
 
-        - `'I'` - Moran's I statistic.
-        - `'pval_sim'` - p-value based on permutations.
-        - `'VI_sim'` - variance of `'I'` from permutations.
-        - `'pval_sim_{{corr_method}}'` - the corrected p-values if ``corr_method != None`` .
 
-    Otherwise, modifies the ``adata`` with the following key:
+    Examples
+    --------
 
-        - :attr:`anndata.AnnData.uns` ``['moranI']`` - the above mentioned dataframe.
+    Calculate Gearys C for each components of a dimensionality reduction:
+
+    .. code:: python
+
+        import scanpy as sc, numpy as np
+
+        pbmc = sc.datasets.pbmc68k_processed()
+        pc_c = sc.metrics.gearys_c(pbmc, obsm="X_pca")
+
+
+    It's equivalent to call the function directly on the underlying arrays:
+
+    .. code:: python
+
+        alt = sc.metrics.gearys_c(pbmc.obsp["connectivities"], pbmc.obsm["X_pca"].T)
+        np.testing.assert_array_equal(pc_c, alt)
     """
-
-    if genes is None:
-        if "highly_variable" in adata.var.columns:
-            genes = adata[:, adata.var.highly_variable.values].var_names.values
+    if use_graph is None:
+        # Fix for anndata<0.7
+        if hasattr(adata, "obsp") and "connectivities" in adata.obsp:
+            g = adata.obsp["connectivities"]
+        elif "neighbors" in adata.uns:
+            g = adata.uns["neighbors"]["connectivities"]
         else:
-            genes = adata.var_names.values
-
-    adj = adata.obsp[connectivity_key]
-
-    moran_list = []
-    indptr = adj.indptr.astype(ip)
-    indices = adj.indices.astype(ip)
-    data = adj.data.astype(fp)
-
-    for g in genes:
-        counts = adata.obs_vector(g, layer=layer).astype(fp, copy=True)
-        mi = _moran_score_perms(counts, indptr, indices, data, n_perms)
-        moran_list.append(mi)
-
-    df = pd.DataFrame(moran_list, columns=["I", "pval_sim", "VI_sim"], index=genes)
-
-    if corr_method is not None:
-        _, pvals_adj, _, _ = multipletests(
-            df["pval_sim"].values, alpha=0.05, method=corr_method
-        )
-        df[f"pval_sim_{corr_method}"] = pvals_adj
-
-    df.sort_values(by="I", ascending=False, inplace=True)
-
-    if copy:
-        return df
-    adata.uns["moranI"] = df
+            raise ValueError("Must run neighbors first.")
+    else:
+        raise NotImplementedError()
+    if vals is None:
+        vals = _get_obs_rep(adata, use_raw=use_raw, layer=layer, obsm=obsm, obsp=obsp).T
+    return morans_i(g, vals)
 
 
 @njit(
     ft(ft[:], it[:], it[:], ft[:], ft[:], ft, ft),
-    parallel=False,
+    cache=True,
+    parallel=True,
     fastmath=True,
 )
-def _compute_moran(
-    counts: np.ndarray,
+def _morans_i_vec_W(
+    x: np.ndarray,
     indptr: np.ndarray,
     indices: np.ndarray,
     data: np.ndarray,
     z: np.ndarray,
-    data_sum: fp,
+    W: fp,
     z2ss: fp,
 ) -> Any:
 
     zl = np.empty(len(z))
     N = len(indptr) - 1
+
     for i in range(N):
         s = slice(indptr[i], indptr[i + 1])
         i_indices = indices[s]
@@ -117,34 +149,146 @@ def _compute_moran(
         zl[i] = np.sum(i_data * z[i_indices])
     inum = (z * zl).sum()
 
-    return len(counts) / data_sum * inum / z2ss
+    return len(x) / W * inum / z2ss
 
 
-@njit(
-    ft[:](ft[:], it[:], it[:], ft[:], it),
-    parallel=False,
-    fastmath=True,
-)
-def _moran_score_perms(
-    counts: np.ndarray,
+@njit(ft(ft[:], it[:], it[:], ft[:]), cache=True, parallel=True, fastmath=True)
+def _morans_i_vec(
+    x: np.ndarray,
     indptr: np.ndarray,
     indices: np.ndarray,
     data: np.ndarray,
-    n_perms: ip,
-) -> np.ndarray:
-
-    perms = np.empty(n_perms, dtype=ft)
-    res = np.empty(3, dtype=ft)
-
-    z = counts - counts.mean()
-    data_sum = data.sum()
+) -> Any:
+    W = data.sum()
+    z = x - x.mean()
     z2ss = (z * z).sum()
+    return _morans_i_vec_W(x, indptr, indices, data, z, W, z2ss)
 
-    res[0] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
 
-    for p in range(len(perms)):
-        np.random.shuffle(z)
-        perms[p] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
-    res[1] = (np.sum(perms > res[0]) + 1) / (n_perms + 1)
-    res[2] = np.var(perms)
-    return res
+@njit(ft[:](ft[:, :], it[:], it[:], ft[:]), cache=True, parallel=True, fastmath=True)
+def _morans_i_mtx(
+    X: np.ndarray,
+    indptr: np.ndarray,
+    indices: np.ndarray,
+    data: np.ndarray,
+) -> Any:
+    M, N = X.shape
+    assert N == len(indptr) - 1
+    W = data.sum()
+    out = np.zeros(M, dtype=ft)
+    for k in range(M):
+        x = X[k, :].astype(ft)
+        z = x - x.mean()
+        z2ss = (z * z).sum()
+        out[k] = _morans_i_vec_W(x, indptr, indices, data, z, W, z2ss)
+    return out
+
+
+@njit(
+    ft[:](ft[:], it[:], it[:], it[:], it[:], ft[:], tt(it, 2)),
+    cache=True,
+    parallel=True,
+    fastmath=True,
+)
+def _morans_i_mtx_csr(
+    X_data: np.ndarray,
+    X_indices: np.ndarray,
+    X_indptr: np.ndarray,
+    indptr: np.ndarray,
+    indices: np.ndarray,
+    data: np.ndarray,
+    X_shape: tuple,
+):
+    M, N = X_shape
+    W = data.sum()
+    out = np.zeros(M, dtype=ft)
+    x_data_list = np.split(X_data, X_indptr[1:-1])
+    x_indices_list = np.split(X_indices, X_indptr[1:-1])
+    for k in range(M):
+        x = np.zeros(N, dtype=ft)
+        x[x_indices_list[k]] = x_data_list[k]
+        z = x - x.mean()
+        z2ss = (z * z).sum()
+        out[k] = _morans_i_vec_W(x, indptr, indices, data, z, W, z2ss)
+    return out
+
+
+###############################################################################
+# Interface (taken from gearys C)
+###############################################################################
+@singledispatch
+def _resolve_vals(val):
+    return np.asarray(val)
+
+
+@_resolve_vals.register(np.ndarray)
+@_resolve_vals.register(sparse.csr_matrix)
+def _(val):
+    return val
+
+
+@_resolve_vals.register(sparse.spmatrix)
+def _(val):
+    return sparse.csr_matrix(val)
+
+
+@_resolve_vals.register(pd.DataFrame)
+@_resolve_vals.register(pd.Series)
+def _(val):
+    return val.to_numpy()
+
+
+@morans_i.register(sparse.csr_matrix)
+def _morans_i(g, vals) -> np.ndarray:
+    assert g.shape[0] == g.shape[1], "`g` should be a square adjacency matrix"
+    vals = _resolve_vals(vals)
+    g_data = g.data.astype(fp, copy=False)
+    if isinstance(vals, sparse.csr_matrix):
+        assert g.shape[0] == vals.shape[1]
+        return _morans_i_mtx_csr(
+            vals.data.astype(fp, copy=False),
+            vals.indices,
+            vals.indptr,
+            g.indices,
+            g.indptr,
+            g_data,
+            vals.shape,
+        )
+    elif isinstance(vals, np.ndarray) and vals.ndim == 1:
+        assert g.shape[0] == vals.shape[0]
+        return _morans_i_vec(vals, g.indptr, g.indices, g_data)
+    elif isinstance(vals, np.ndarray) and vals.ndim == 2:
+        assert g.shape[0] == vals.shape[1]
+        return _morans_i_mtx(vals, g.indptr, g.indices, g_data)
+    else:
+        raise NotImplementedError()
+
+
+# @njit(
+#     ft[:](ft[:], it[:], it[:], ft[:], it),
+#     parallel=False,
+#     fastmath=True,
+# )
+# def _moran_score_perms(
+#     counts: np.ndarray,
+#     indptr: np.ndarray,
+#     indices: np.ndarray,
+#     data: np.ndarray,
+#     n_perms: ip,
+# ) -> np.ndarray:
+
+#     perms = np.empty(n_perms, dtype=ft)
+#     res = np.empty(3, dtype=ft)
+
+#     z = counts - counts.mean()
+#     data_sum = data.sum()
+#     z2ss = (z * z).sum()
+
+#     res[0] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
+
+#     for p in range(len(perms)):
+#         np.random.shuffle(z)
+#         perms[p] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
+#     res[1] = (np.sum(perms > res[0]) + 1) / (n_perms + 1)
+#     res[2] = np.var(perms)
+#     return res

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -251,7 +251,9 @@ def _morans_i(g, vals) -> np.ndarray:
         )
     elif isinstance(vals, np.ndarray) and vals.ndim == 1:
         assert g.shape[0] == vals.shape[0]
-        return _morans_i_vec(vals, g.indptr, g.indices, g_data)
+        return _morans_i_vec(
+            vals.astype(fp), g.indptr.astype(ip), g.indices.astype(ip), g_data
+        )
     elif isinstance(vals, np.ndarray) and vals.ndim == 2:
         assert g.shape[0] == vals.shape[1]
         return _morans_i_mtx(
@@ -259,33 +261,3 @@ def _morans_i(g, vals) -> np.ndarray:
         )
     else:
         raise NotImplementedError()
-
-
-# @njit(
-#     ft[:](ft[:], it[:], it[:], ft[:], it),
-#     parallel=False,
-#     fastmath=True,
-# )
-# def _moran_score_perms(
-#     counts: np.ndarray,
-#     indptr: np.ndarray,
-#     indices: np.ndarray,
-#     data: np.ndarray,
-#     n_perms: ip,
-# ) -> np.ndarray:
-
-#     perms = np.empty(n_perms, dtype=ft)
-#     res = np.empty(3, dtype=ft)
-
-#     z = counts - counts.mean()
-#     data_sum = data.sum()
-#     z2ss = (z * z).sum()
-
-#     res[0] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
-
-#     for p in range(len(perms)):
-#         np.random.shuffle(z)
-#         perms[p] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
-#     res[1] = (np.sum(perms > res[0]) + 1) / (n_perms + 1)
-#     res[2] = np.var(perms)
-#     return res

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -13,9 +13,9 @@ from numba import njit, prange
 from scanpy.get import _get_obs_rep
 
 it = nt.int64
-ft = nt.float64
+ft = nt.float32
 ip = np.int64
-fp = np.float64
+fp = np.float32
 tt = nt.UniTuple
 
 

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -188,8 +188,8 @@ def _morans_i_mtx_csr(
     X_data: np.ndarray,
     X_indices: np.ndarray,
     X_indptr: np.ndarray,
-    indptr: np.ndarray,
     indices: np.ndarray,
+    indptr: np.ndarray,
     data: np.ndarray,
     X_shape: tuple,
 ):
@@ -200,7 +200,8 @@ def _morans_i_mtx_csr(
     x_indices_list = np.split(X_indices, X_indptr[1:-1])
     for k in range(M):
         x = np.zeros(N, dtype=ft)
-        x[x_indices_list[k]] = x_data_list[k]
+        x_index = x_indices_list[k]
+        x[x_index] = x_data_list[k]
         z = x - x.mean()
         z2ss = (z * z).sum()
         out[k] = _morans_i_vec_W(x, indptr, indices, data, z, W, z2ss)
@@ -241,10 +242,10 @@ def _morans_i(g, vals) -> np.ndarray:
         assert g.shape[0] == vals.shape[1]
         return _morans_i_mtx_csr(
             vals.data.astype(fp, copy=False),
-            vals.indices,
-            vals.indptr,
-            g.indices,
-            g.indptr,
+            vals.indices.astype(ip),
+            vals.indptr.astype(ip),
+            g.indices.astype(ip),
+            g.indptr.astype(ip),
             g_data,
             vals.shape,
         )
@@ -253,7 +254,9 @@ def _morans_i(g, vals) -> np.ndarray:
         return _morans_i_vec(vals, g.indptr, g.indices, g_data)
     elif isinstance(vals, np.ndarray) and vals.ndim == 2:
         assert g.shape[0] == vals.shape[1]
-        return _morans_i_mtx(vals, g.indptr, g.indices, g_data)
+        return _morans_i_mtx(
+            vals.astype(fp), g.indptr.astype(ip), g.indices.astype(ip), g_data
+        )
     else:
         raise NotImplementedError()
 

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -43,9 +43,8 @@ def morans_i(
         FDR correction method.
     layer
         Layer in :attr:`anndata.AnnData.layers` to use. If `None`, use :attr:`anndata.AnnData.X`.
-    %(seed)s
-    %(copy)s
-    %(parallelize)s
+    copy
+        Whether to modify copied input object.
 
     Returns
     -------

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -1,0 +1,157 @@
+"""Moran's I global spatial autocorrelation."""
+from typing import Any, Tuple, Union, Iterable, Optional, Sequence
+from itertools import chain
+
+from scanpy import logging as logg
+from anndata import AnnData
+
+import numpy as np
+import pandas as pd
+import numba.types as nt
+
+from numba import njit
+from scipy.sparse import spmatrix
+from sklearn.metrics import pairwise_distances
+from statsmodels.stats.multitest import multipletests
+
+it = nt.int64
+ft = nt.float64
+ip = np.int64
+fp = np.float64
+
+
+def moran(
+    adata: AnnData,
+    connectivity_key: str = Key.obsp.spatial_conn(),
+    genes: Optional[Union[str, Sequence[str]]] = None,
+    n_perms: int = 100,
+    corr_method: Optional[str] = "fdr_bh",
+    layer: Optional[str] = None,
+    seed: Optional[int] = None,
+    copy: bool = False,
+) -> Optional[pd.DataFrame]:
+    """
+    Calculate Moran’s I Global Autocorrelation Statistic.
+
+    The statistics is described here TODO.
+
+    Parameters
+    ----------
+    adata
+    connectivity_key
+    genes
+        List of gene names, as stored in :attr:`anndata.AnnData.var_names`, used to compute Moran's I statistics.
+        If `None`, it's computed :attr:`anndata.AnnData.var` ``['highly_variable']``, if present. Otherwise,
+        it's computed for all genes.
+    n_perms
+        Number of permutations.
+    corr_method
+        FDR correction method.
+    layer
+        Layer in :attr:`anndata.AnnData.layers` to use. If `None`, use :attr:`anndata.AnnData.X`.
+    %(seed)s
+    %(copy)s
+    %(parallelize)s
+
+    Returns
+    -------
+    If ``copy = True``, returns a :class:`pandas.DataFrame` with the following keys:
+
+        - `'I'` - Moran's I statistic.
+        - `'pval_sim'` - p-value based on permutations.
+        - `'VI_sim'` - variance of `'I'` from permutations.
+        - `'pval_sim_{{corr_method}}'` - the corrected p-values if ``corr_method != None`` .
+
+    Otherwise, modifies the ``adata`` with the following key:
+
+        - :attr:`anndata.AnnData.uns` ``['moranI']`` - the above mentioned dataframe.
+    """
+
+    if genes is None:
+        if "highly_variable" in adata.var.columns:
+            genes = adata[:, adata.var.highly_variable.values].var_names.values
+        else:
+            genes = adata.var_names.values
+
+    adj = adata.obsp[connectivity_key]
+
+    moran_list = []
+    indptr = adj.indptr.astype(ip)
+    indices = adj.indices.astype(ip)
+    data = adj.data.astype(fp)
+
+    for g in genes:
+        counts = adata.obs_vector(g, layer=layer).astype(fp, copy=True)
+        mi = _moran_score_perms(counts, indptr, indices, data, n_perms)
+        moran_list.append(mi)
+
+    df = pd.DataFrame(moran_list, columns=["I", "pval_sim", "VI_sim"], index=gen)
+
+    if corr_method is not None:
+        _, pvals_adj, _, _ = multipletests(
+            df["pval_sim"].values, alpha=0.05, method=corr_method
+        )
+        df[f"pval_sim_{corr_method}"] = pvals_adj
+
+    df.sort_values(by="I", ascending=False, inplace=True)
+
+    if copy:
+        return df
+    adata.uns["moranI"] = df
+
+
+@njit(
+    ft(ft[:], it[:], it[:], ft[:], ft[:], ft, ft),
+    parallel=False,
+    fastmath=True,
+)
+def _compute_moran(
+    counts: np.ndarray,
+    indptr: np.ndarray,
+    indices: np.ndarray,
+    data: np.ndarray,
+    z: np.ndarray,
+    data_sum: fp,
+    z2ss: fp,
+) -> Any:
+
+    zl = np.empty(len(z))
+    N = len(indptr) - 1
+    for i in range(N):
+        s = slice(indptr[i], indptr[i + 1])
+        i_indices = indices[s]
+        i_data = data[s]
+        zl[i] = np.sum(i_data * z[i_indices])
+    inum = (z * zl).sum()
+
+    return len(counts) / data_sum * inum / z2ss
+
+
+@njit(
+    ft[:](ft[:], it[:], it[:], ft[:], it),
+    parallel=False,
+    fastmath=True,
+)
+def _moran_score_perms(
+    counts: np.ndarray,
+    indptr: np.ndarray,
+    indices: np.ndarray,
+    data: np.ndarray,
+    n_perms: ip,
+) -> np.ndarray:
+
+    perms = np.empty(n_perms, dtype=ft)
+    res = np.empty(3, dtype=ft)
+
+    z = counts - counts.mean()
+    data_sum = data.sum()
+    z2ss = (z * z).sum()
+
+    res[0] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
+
+    for p in range(len(perms)):
+        np.random.shuffle(counts)
+        perms[p] = _compute_moran(counts, indptr, indices, data, z, data_sum, z2ss)
+    res[1] = (np.sum(perms > res[0]) + 1) / (n_perms + 1)
+    res[2] = np.var(perms)
+    return res

--- a/scanpy/tests/test_metrics.py
+++ b/scanpy/tests/test_metrics.py
@@ -34,6 +34,7 @@ def test_gearys_c_consistency():
 
     np.testing.assert_allclose(all_genes[0], first_gene)
 
+    # Test that results are similar for sparse and dense reps of same data
     np.testing.assert_allclose(
         sc.metrics.gearys_c(pbmc, layer="raw"),
         sc.metrics.gearys_c(pbmc, vals=pbmc.layers["raw"].T.toarray()),
@@ -90,9 +91,10 @@ def test_morans_i_consistency():
 
     np.testing.assert_allclose(all_genes[0], first_gene, rtol=1e-5)
 
+    # Test that results are similar for sparse and dense reps of same data
     np.testing.assert_allclose(
         sc.metrics.morans_i(pbmc, layer="raw"),
-        sc.metrics.morans_i(pbmc, vals=pbmc.layers["raw"].T),
+        sc.metrics.morans_i(pbmc, vals=pbmc.layers["raw"].T.toarray()),
     )
 
 

--- a/scanpy/tests/test_metrics.py
+++ b/scanpy/tests/test_metrics.py
@@ -88,7 +88,7 @@ def test_morans_i_consistency():
         pbmc, vals=pbmc.obs_vector(pbmc.var_names[0], layer="raw")
     )
 
-    np.testing.assert_allclose(all_genes[0], first_gene, rtol=1e-6)
+    np.testing.assert_allclose(all_genes[0], first_gene, rtol=1e-5)
 
     np.testing.assert_allclose(
         sc.metrics.morans_i(pbmc, layer="raw"),

--- a/scanpy/tests/test_metrics.py
+++ b/scanpy/tests/test_metrics.py
@@ -78,10 +78,9 @@ def test_morans_i_consistency():
         sc.metrics.morans_i(g, pbmc.obs["percent_mito"].values),
     )
 
-    np.testing.assert_allclose(
+    np.testing.assert_array_equal(
         sc.metrics.morans_i(pbmc, obsm="X_pca"),
         sc.metrics.morans_i(g, pbmc.obsm["X_pca"].T),
-        rtol=1.0,
     )
 
     all_genes = sc.metrics.morans_i(pbmc, layer="raw")
@@ -89,24 +88,24 @@ def test_morans_i_consistency():
         pbmc, vals=pbmc.obs_vector(pbmc.var_names[0], layer="raw")
     )
 
-    np.testing.assert_allclose(all_genes[0], first_gene)
+    np.testing.assert_allclose(all_genes[0], first_gene, rtol=1e-6)
 
     np.testing.assert_allclose(
         sc.metrics.morans_i(pbmc, layer="raw"),
-        sc.metrics.morans_i(pbmc, vals=pbmc.layers["raw"].T.toarray()),
+        sc.metrics.morans_i(pbmc, vals=pbmc.layers["raw"].T),
     )
 
 
 def test_morans_i_correctness():
     # Test case with perfectly seperated groups
     connected = np.zeros(100)
-    connected[np.random.choice(100, size=30, replace=False)] = 1
+    connected[np.random.choice(100, size=50, replace=False)] = 1
     graph = np.zeros((100, 100))
     graph[np.ix_(connected.astype(bool), connected.astype(bool))] = 1
     graph[np.ix_(~connected.astype(bool), ~connected.astype(bool))] = 1
     graph = sparse.csr_matrix(graph)
 
-    assert sc.metrics.morans_i(graph, connected) == 0.0
+    assert sc.metrics.morans_i(graph, connected) == 1.0
     assert eq(
         sc.metrics.morans_i(graph, connected),
         sc.metrics.morans_i(graph, sparse.csr_matrix(connected)),
@@ -117,7 +116,7 @@ def test_morans_i_correctness():
         adata = sc.AnnData(
             sparse.csr_matrix((100, 100)), obsp={"connectivities": graph}
         )
-        assert sc.metrics.morans_i(adata, vals=connected) == 0.0
+        assert sc.metrics.morans_i(adata, vals=connected) == 1.0
 
 
 def test_confusion_matrix():


### PR DESCRIPTION
close #1698 

this is the implementation as proposed here: https://github.com/theislab/squidpy/pull/304
Explicit design choices compared to first proposal in squidpy:
- no joblib present, with low n permutation is fine and saw that you don't even do it in gearys C (which btw, makes a lot of sense in this setting, should consider to skip permutation entirely as well )
- only working on genes. technically it could work on continuos covariates as well, should I add that option?
- I think it could be worth it to add a row wise normalization of the weights (standard in pysal)

@ivirshup would be good to have feedback on those points, I will then add tests. Thank you!
