### PR TITLE
Make scrublet plotting function more like Scanpy standards for saving plot etc

### DIFF
--- a/scanpy/external/pl.py
+++ b/scanpy/external/pl.py
@@ -325,7 +325,6 @@ def wishbone_marker_trajectory(
         return ax
 
 
-@_doc_params(show_save_ax=doc_show_save_ax)
 def scrublet_score_distribution(
     adata,
     scale_hist_obs: str = 'log',
@@ -334,7 +333,6 @@ def scrublet_score_distribution(
     return_fig: bool = False,
     show: bool = True,
     save: Optional[Union[str, bool]] = None,
-    ax: Optional[Axes] = None,
 ):
     """\
     Plot histogram of doublet scores for observed transcriptomes and simulated doublets.
@@ -354,7 +352,12 @@ def scrublet_score_distribution(
         doublets (e.g. "linear", "log", "symlog", "logit")
     figsize
         width, height
-    {show_save_ax}
+    show
+         Show the plot, do not return axis.
+    save
+        If `True` or a `str`, save the figure.
+        A string is appended to the default filename.
+        Infer the filetype if ending on {`'.pdf'`, `'.png'`, `'.svg'`}.
 
     Returns
     -------

--- a/scanpy/external/pl.py
+++ b/scanpy/external/pl.py
@@ -325,11 +325,16 @@ def wishbone_marker_trajectory(
         return ax
 
 
+@_doc_params(show_save_ax=doc_show_save_ax)
 def scrublet_score_distribution(
     adata,
     scale_hist_obs: str = 'log',
     scale_hist_sim: str = 'linear',
     figsize: Optional[Tuple[float, float]] = (8, 3),
+    return_fig: bool = False,
+    show: bool = True,
+    save: Optional[Union[str, bool]] = None,
+    ax: Optional[Axes] = None,
 ):
     """\
     Plot histogram of doublet scores for observed transcriptomes and simulated doublets.
@@ -349,11 +354,17 @@ def scrublet_score_distribution(
         doublets (e.g. "linear", "log", "symlog", "logit")
     figsize
         width, height
+    {show_save_ax}
+    
+    Returns
+    -------
+    If `return_fig` is True, a :class:`~matplotlib.figure.Figure`.
+    If `show==False` a list of :class:`~matplotlib.axes.Axes`.
 
     See also
     --------
     :func:`~scanpy.external.pp.scrublet`: Main way of running Scrublet, runs
-        preprocessing, doublet simulation (this function) and calling.
+        preprocessing, doublet simulation and calling. 
     :func:`~scanpy.external.pp.scrublet_simulate_doublets`: Run Scrublet's doublet
         simulation separately for advanced usage.
     """
@@ -395,4 +406,8 @@ def scrublet_score_distribution(
 
     fig.tight_layout()
 
-    return fig, axs
+    _utils.savefig_or_show('scrublet_score_distribution', show=show, save=save)
+    if return_fig:
+        return fig
+    elif not show:
+        return axs

--- a/scanpy/external/pl.py
+++ b/scanpy/external/pl.py
@@ -355,7 +355,7 @@ def scrublet_score_distribution(
     figsize
         width, height
     {show_save_ax}
-    
+
     Returns
     -------
     If `return_fig` is True, a :class:`~matplotlib.figure.Figure`.
@@ -364,7 +364,7 @@ def scrublet_score_distribution(
     See also
     --------
     :func:`~scanpy.external.pp.scrublet`: Main way of running Scrublet, runs
-        preprocessing, doublet simulation and calling. 
+        preprocessing, doublet simulation and calling.
     :func:`~scanpy.external.pp.scrublet_simulate_doublets`: Run Scrublet's doublet
         simulation separately for advanced usage.
     """

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -130,14 +130,18 @@ def scrublet(
         ``.obs['predicted_doublets']``
             Boolean indicating predicted doublet status
 
-        ``adata.uns['scrublet']['doublet_scores_sim']``
+        ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
+<<<<<<< HEAD
         ``adata.uns['scrublet']['doublet_parents']``
+=======
+        ``.uns['scrublet']['doublet_parents']`` 
+>>>>>>> b5438c3c... Make 'Returns' docs consistent
             Pairs of ``.obs_names`` used to generate each simulated doublet
             transcriptome
 
-        ``uns['scrublet']['parameters']``
+        ``.uns['scrublet']['parameters']``
             Dictionary of Scrublet parameters
 
     See also
@@ -322,7 +326,7 @@ def _scrublet_call_doublets(
     Returns
     -------
     adata : anndata.AnnData
-        if ``copy=True`` it returns or else adds fields to ``adata``. Those fields:
+        if ``copy=True`` it returns or else adds fields to ``adata``:
 
         ``.obs['doublet_score']``
             Doublet scores for each observed transcriptome
@@ -330,13 +334,17 @@ def _scrublet_call_doublets(
         ``.obs['predicted_doublets']``
             Boolean indicating predicted doublet status
 
-        ``adata.uns['scrublet']['doublet_scores_sim']``
+        ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
+<<<<<<< HEAD
         ``adata.uns['scrublet']['doublet_parents']``
+=======
+        ``.uns['scrublet']['doublet_parents']`` 
+>>>>>>> b5438c3c... Make 'Returns' docs consistent
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
-        ``uns['scrublet']['parameters']``
+        ``.uns['scrublet']['parameters']``
             Dictionary of Scrublet parameters
     """
     try:
@@ -469,12 +477,12 @@ def scrublet_simulate_doublets(
     Returns
     -------
     adata : anndata.AnnData with simulated doublets in .X
-        if ``copy=True`` it returns or else adds fields to ``adata``:
+        Adds fields to ``adata``:
 
-        ``adata.uns['scrublet']['doublet_parents']`` 
+        ``.obsm['scrublet']['doublet_parents']`` 
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
-        ``uns['scrublet']['parameters']``
+        ``.uns['scrublet']['parameters']``
             Dictionary of Scrublet parameters
 
     See also

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -469,7 +469,9 @@ def scrublet_simulate_doublets(
     Returns
     -------
     adata : anndata.AnnData with simulated doublets in .X
-        ``adata.obsm['doublet_parents']`` 
+        if ``copy=True`` it returns or else adds fields to ``adata``:
+
+        ``adata.uns['scrublet']['doublet_parents']`` 
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
         ``uns['scrublet']['parameters']``

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -133,7 +133,7 @@ def scrublet(
         ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
-        ``.uns['scrublet']['doublet_parents']`` 
+        ``.uns['scrublet']['doublet_parents']``
             Pairs of ``.obs_names`` used to generate each simulated doublet
             transcriptome
 
@@ -333,7 +333,7 @@ def _scrublet_call_doublets(
         ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
-        ``.uns['scrublet']['doublet_parents']`` 
+        ``.uns['scrublet']['doublet_parents']``
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
         ``.uns['scrublet']['parameters']``
@@ -471,7 +471,7 @@ def scrublet_simulate_doublets(
     adata : anndata.AnnData with simulated doublets in .X
         Adds fields to ``adata``:
 
-        ``.obsm['scrublet']['doublet_parents']`` 
+        ``.obsm['scrublet']['doublet_parents']``
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
         ``.uns['scrublet']['parameters']``

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -469,9 +469,7 @@ def scrublet_simulate_doublets(
     Returns
     -------
     adata : anndata.AnnData with simulated doublets in .X
-        if ``copy=True`` it returns or else adds fields to ``adata``:
-
-        ``adata.uns['scrublet']['doublet_parents']``
+        ``adata.obsm['doublet_parents']`` 
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
         ``uns['scrublet']['parameters']``

--- a/scanpy/external/pp/_scrublet.py
+++ b/scanpy/external/pp/_scrublet.py
@@ -133,11 +133,7 @@ def scrublet(
         ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
-<<<<<<< HEAD
-        ``adata.uns['scrublet']['doublet_parents']``
-=======
         ``.uns['scrublet']['doublet_parents']`` 
->>>>>>> b5438c3c... Make 'Returns' docs consistent
             Pairs of ``.obs_names`` used to generate each simulated doublet
             transcriptome
 
@@ -337,11 +333,7 @@ def _scrublet_call_doublets(
         ``.uns['scrublet']['doublet_scores_sim']``
             Doublet scores for each simulated doublet transcriptome
 
-<<<<<<< HEAD
-        ``adata.uns['scrublet']['doublet_parents']``
-=======
         ``.uns['scrublet']['doublet_parents']`` 
->>>>>>> b5438c3c... Make 'Returns' docs consistent
             Pairs of ``.obs_names`` used to generate each simulated doublet transcriptome
 
         ``.uns['scrublet']['parameters']``


### PR DESCRIPTION
A small tweak to the plotting function for Scrublet, to use standard Scanpy patterns for saving the plot etc. 

Also some minor doc fixes.