### PR TITLE
Making var_group_rotation work when swap_axes is True

### DIFF
--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -953,13 +953,13 @@ class BasePlot(object):
         # verts and codes are used by PathPatch to make the brackets
         verts = []
         codes = []
+        if rotation is None and group_labels:
+            if max([len(x) for x in group_labels]) > 4:
+                rotation = 90
+            else:
+                rotation = 0
         if orientation == 'top':
             # rotate labels if any of them is longer than 4 characters
-            if rotation is None and group_labels:
-                if max([len(x) for x in group_labels]) > 4:
-                    rotation = 90
-                else:
-                    rotation = 0
             for idx, (left_coor, right_coor) in enumerate(zip(left, right)):
                 verts.append((left_coor, 0))  # lower-left
                 verts.append((left_coor, 0.6))  # upper-left
@@ -981,6 +981,7 @@ class BasePlot(object):
                     rotation=rotation,
                 )
         else:
+            rotation -= 90
             top = left
             bottom = right
             for idx, (top_coor, bottom_coor) in enumerate(zip(top, bottom)):
@@ -996,16 +997,16 @@ class BasePlot(object):
 
                 diff = bottom[idx] - top[idx]
                 group_y_center = top[idx] + float(diff) / 2
-                if diff * 2 < len(group_labels[idx]):
-                    # cut label to fit available space
-                    group_labels[idx] = group_labels[idx][: int(diff * 2)] + "."
+                #if diff * 2 < len(group_labels[idx]):
+                #    # cut label to fit available space
+                #    group_labels[idx] = group_labels[idx][: int(diff * 2)] + "."
                 gene_groups_ax.text(
-                    1.1,
+                    0.8,
                     group_y_center,
                     group_labels[idx],
-                    ha='right',
+                    ha='left',
                     va='center',
-                    rotation=270,
+                    rotation=rotation,
                     fontsize='small',
                 )
 

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -997,7 +997,7 @@ class BasePlot(object):
 
                 diff = bottom[idx] - top[idx]
                 group_y_center = top[idx] + float(diff) / 2
-                #if diff * 2 < len(group_labels[idx]):
+                # if diff * 2 < len(group_labels[idx]):
                 #    # cut label to fit available space
                 #    group_labels[idx] = group_labels[idx][: int(diff * 2)] + "."
                 gene_groups_ax.text(


### PR DESCRIPTION
It'd be great if  `var_group_rotation` option works also when `swap_axes` is True (right now rotation 270 is hard-coded). I tried to modify the code but I am not sure how to solve it properly (e.g. if labels are too long etc). Please have a look whenever you guys have time and feel free to modify the PR.

```python

import scanpy as sc

ad = sc.datasets.paul15()
sc.pp.log1p(ad)
sc.tl.rank_genes_groups(ad, 'paul15_clusters')

sc.pl.rank_genes_groups_dotplot(ad, n_genes=3, dendrogram=False, var_group_rotation=0, groups=['1Ery', '2Ery', '3Ery'])
sc.pl.rank_genes_groups_dotplot(ad, n_genes=3, dendrogram=False, var_group_rotation=90, groups=['1Ery', '2Ery', '3Ery'])
sc.pl.rank_genes_groups_dotplot(ad, n_genes=3, dendrogram=False, swap_axes=True, var_group_rotation=0, groups=['1Ery', '2Ery', '3Ery'])
sc.pl.rank_genes_groups_dotplot(ad, n_genes=3, dendrogram=False, swap_axes=True, var_group_rotation=90, groups=['1Ery', '2Ery', '3Ery'])
```

Output:

<img width="423" alt="image" src="https://user-images.githubusercontent.com/1140359/112549850-d4374400-8d94-11eb-8a43-c975b70bc4fd.png">
<img width="437" alt="image" src="https://user-images.githubusercontent.com/1140359/112549869-d9948e80-8d94-11eb-91d1-695f50c53aba.png">
