### PR TITLE
Add scNym as an external tool `sce.tl.scnym`

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip
       pip install pytest-cov wheel
-      pip install .[dev,doc,test,louvain,leiden,magic,harmony,scrublet,scanorama,skmisc]
+      pip install .[dev,doc,test,louvain,leiden,magic,harmony,scrublet,scanorama,scnym,skmisc]
     displayName: 'Install dependencies'
 
   - script: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ cache:
 - directories:
   - data
 install:
-- pip install .[dev,test,louvain,leiden,magic,harmony,skmisc,scrublet,scanorama]
+- pip install .[dev,test,louvain,leiden,magic,harmony,skmisc,scrublet,scanorama,scnym]
 env:
 - MPLBACKEND=Agg
 script:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ skmisc = ['scikit-misc>=0.1.3']
 harmony = ['harmonypy']
 scanorama = ['scanorama']
 scrublet = ['scrublet']
+scnym = ['scnym']
 dev = [
     # getting the dev version
     'setuptools_scm',

--- a/scanpy/external/__init__.py
+++ b/scanpy/external/__init__.py
@@ -74,6 +74,15 @@ Embeddings
    tl.trimap
    tl.sam
 
+Cell identity classification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autosummary::
+    :toctree: .
+
+    tl.scnym
+
+
 Clustering and trajectory inference
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/scanpy/external/tl/__init__.py
+++ b/scanpy/external/tl/__init__.py
@@ -5,4 +5,5 @@ from ._palantir import palantir, palantir_results
 from ._trimap import trimap
 from ._harmony_timeseries import harmony_timeseries
 from ._sam import sam
+from ._scnym import scnym
 from ._wishbone import wishbone

--- a/scanpy/external/tl/_scnym.py
+++ b/scanpy/external/tl/_scnym.py
@@ -1,0 +1,125 @@
+"""
+Classify cell identities using scNym
+"""
+
+
+def scnym(*args, **kwargs) -> None:
+    """
+    scNym: Semi-supervised adversarial neural networks for
+    single cell classification [Kimmel2020]_.
+
+    scNym is a cell identity classifier that transfers annotations from one
+    single cell experiment to another. The model is implemented as a neural
+    network that employs MixMatch semi-supervision and a domain adversary to
+    take advantage of unlabeled data during training. scNym offers superior
+    performance to many baseline single cell identity classification methods.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix used for training or prediction.
+        If `"scNym_split"` in `.obs_keys()`, uses the cells annotated
+        `"train", "val"` to select data splits.
+    task
+        Task to perform, either "train" or "predict".
+        If "train", uses `adata` as labeled training data.
+        If "predict", uses `trained_model` to infer cell identities for
+        observations in `adata`.
+    groupby
+        Column in `adata.obs` that contains cell identity annotations.
+        Values of `"Unlabeled"` indicate that a given cell should be used
+        only as unlabeled data during training.
+    domain_groupby
+        Column in `adata.obs` that contains domain labels as integers.
+        Each domain of origin (e.g. batch, species) should be given a unique
+        domain label.
+        If `domain_groupby is None`, train and target data are each considered
+        a unique domain.
+    out_path
+        Path to a directory for saving scNym model weights and training logs.
+    trained_model
+        Path to the output directory of an scNym training run
+        or a string specifying a pretrained model.
+        If provided while `task == "train"`, used as an initialization.
+    config
+        Configuration name or dictionary of configuration of parameters.
+        Pre-defined configurations:
+            "new_identity_discovery" - Default. Employs pseudolabel thresholding to
+            allow for discovery of new cell identities in the target dataset using
+            scNym confidence scores.
+            "no_new_identity" - Assumes all cells in the target data belong to one
+            of the classes in the training data. Recommended to improve performance
+            when this assumption is valid.
+    key_added
+        Key added to `adata.obs` with scNym predictions if `task=="predict"`.
+    copy
+        copy the AnnData object before predicting cell types.
+
+    Returns
+    -------
+    Depending on `copy`, returns or updates `adata` with the following fields.
+
+    `X_scnym` : :class:`~numpy.ndarray`, (:attr:`~anndata.AnnData.obsm`, shape=(n_samples, n_hidden), dtype `float`)
+        scNym embedding coordinates of data.
+    `scNym` : (`adata.obs`, dtype `str`)
+        scNym cell identity predictions for each observation.
+    `scNym_train_results` : :class:`~dict`, (:attr:`~anndata.AnnData.uns`)
+        results of scNym model training.
+
+    Examples
+    --------
+    >>> import scanpy as sc
+    >>> from scnym.api import scnym_api, atlas2target
+
+    **Loading Data and preparing labels**
+
+    >>> adata = sc.datasets.kang17()
+    >>> target_bidx = adata.obs['stim']=='stim'
+    >>> adata.obs['cell'] = np.array(adata.obs['cell'])
+    >>> adata.obs.loc[target_bidx, 'cell'] = 'Unlabeled'
+
+    **Train an scNym model**
+
+    >>> scnym_api(
+    ...   adata=adata,
+    ...   task='train',
+    ...   groupby='clusters',
+    ...   out_path='./scnym_outputs',
+    ...   config='no_new_identity',
+    ... )
+
+    **Predict cell identities with the trained scNym model**
+
+    >>> path_to_model = './scnym_outputs/'
+    >>> scnym_api(
+    ...   adata=adata,
+    ...   task='predict',
+    ...   groupby='scNym',
+    ...   trained_model=path_to_model,
+    ...   config='no_new_identity',
+    ... )
+
+    **Perform semi-supervised training with an atlas**
+
+    >>> joint_adata = atlas2target(
+    ...   adata=adata,
+    ...   species='mouse',
+    ...   key_added='annotations',
+    ... )
+    >>> scnym_api(
+    ...   adata=joint_adata,
+    ...   task='train',
+    ...   groupby='annotations',
+    ...   out_path='./scnym_outputs',
+    ...   config='no_new_identity',
+    ... )
+    """
+    try:
+        import scnym
+    except ImportError:
+        print("Please install `scnym`:\n\t`pip install scnym`.")
+
+    # native `scnym` API is `scanpy` compatibile
+    # modifies `adata` in place, no returns
+    scnym.api.scnym_api(*args, **kwargs)
+    return

--- a/scanpy/external/tl/_scnym.py
+++ b/scanpy/external/tl/_scnym.py
@@ -54,8 +54,6 @@ def scnym(*args, **kwargs) -> None:
             when this assumption is valid.
     key_added
         Key added to `adata.obs` with scNym predictions if `task=="predict"`.
-    copy
-        copy the AnnData object before predicting cell types.
 
     Returns
     -------

--- a/scanpy/external/tl/_scnym.py
+++ b/scanpy/external/tl/_scnym.py
@@ -6,13 +6,15 @@ Classify cell identities using scNym
 def scnym(*args, **kwargs) -> None:
     """
     scNym: Semi-supervised adversarial neural networks for
-    single cell classification [Kimmel2020]_.
+    single cell classification [Kimmel2021]_.
 
-    scNym is a cell identity classifier that transfers annotations from one
-    single cell experiment to another. The model is implemented as a neural
-    network that employs MixMatch semi-supervision and a domain adversary to
-    take advantage of unlabeled data during training. scNym offers superior
-    performance to many baseline single cell identity classification methods.
+    scNym is a cell identity classifier that transfers annotations across
+    single cell experiments. The model is implemented as a neural network
+    that employs MixMatch semi-supervision and a domain adversary to take
+    advantage of unlabeled data during training. These training approaches
+    allow scNym to an integrated representation of cell identity across
+    distinct experimental domains, such as different sequencing technologies,
+    biological sample types, or perturbation conditions.
 
     Parameters
     ----------

--- a/scanpy/tests/external/test_scnym.py
+++ b/scanpy/tests/external/test_scnym.py
@@ -1,0 +1,76 @@
+import pytest
+
+import scanpy as sc
+import scanpy.external as sce
+import numpy as np
+import os
+import os.path as osp
+
+
+def test_scnym():
+    """Test that scNym runs and returns plausible classifications
+    on a demonstration dataset.
+    """
+    pytest.importorskip("scnym")
+    TEST_URL = "https://storage.googleapis.com/calico-website-mca-storage/kang_2017_stim_pbmc.h5ad"
+
+    np.random.seed(1)
+    # load a testing dataset
+    adata = sc.datasets._datasets.read(
+        sc.settings.datasetdir / 'kang17.h5ad', backup_url=TEST_URL
+    )
+    target_bidx = adata.obs['stim'] == 'stim'
+    adata.obs['cell'] = np.array(adata.obs['cell'])
+    adata.obs['ground_truth'] = np.array(adata.obs['cell'])
+    adata.obs.loc[target_bidx, 'cell'] = 'Unlabeled'
+
+    # downsample to speed up testing
+    ridx = np.random.choice(
+        adata.shape[0],
+        size=2048,
+        replace=False,
+    )
+    adata = adata[ridx, :].copy()
+
+    # train an scNym model
+    print("training...")
+    config = {'n_epochs': 1}
+    sce.tl.scnym(
+        adata=adata,
+        task='train',
+        groupby='cell',
+        out_path=str(sc.settings.datasetdir),
+        config=config,
+    )
+
+    assert 'scNym_train_results' in adata.uns.keys()
+    assert osp.exists(
+        osp.join(str(sc.settings.datasetdir), '00_best_model_weights.pkl')
+    )
+
+    # predict cell types with an scNym model
+    print("predicting...")
+    sce.tl.scnym(
+        adata=adata,
+        task='predict',
+        key_added='scNym',
+        out_path=str(sc.settings.datasetdir),
+        trained_model=str(sc.settings.datasetdir),
+        config=config,
+    )
+
+    assert 'X_scnym' in adata.obsm.keys()
+    assert 'scNym' in adata.obs.columns
+
+    # check accuracy
+    target_gt = np.array(adata.obs.loc[target_bidx, 'ground_truth'])
+    pred = np.array(adata.obs.loc[target_bidx, 'scNym'])
+    acc = np.sum(target_gt == pred) / len(pred)
+    print(f"acc: {acc:.6f}")
+    assert acc > 0.5, "low accuracy suggests a performance issue"
+
+    return
+
+
+if __name__ == "__main__":
+    test_scnym()


### PR DESCRIPTION
Hi scanpy folks,

This PR adds our cell identity classification model [`scnym`](https://github.com/calico/scnym) as a tool in `sc.external.tl.scnym`.

The `scnym` API was inspired by `scanpy` and intended to be compatible, so the implementation in `external/_scnym.py` is simply a wrapper.
I also added a test in `tests/external/test_scnym.py` that passes.
Everything was linted with `black,flake8,autopep8` through `pre-commit`.

Please let me know if there are any issues or changes you'd like to see.
Thanks for building a great ecosystem!

Best,
Jacob