### PR TITLE
Allowing resolution parameter to be used with RAPIDS Louvain clustering

### DIFF
--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -55,8 +55,8 @@ def louvain(
     adata
         The annotated data matrix.
     resolution
-        For the default flavor (``'vtraag'``), you can provide a resolution
-        (higher resolution means finding more and smaller clusters),
+        For the default flavor (``'vtraag'``) or for ```RAPIDS```, you can provide a
+        resolution (higher resolution means finding more and smaller clusters),
         which defaults to 1.0.
         See “Time as a resolution parameter” in [Lambiotte09]_.
     random_state
@@ -181,7 +181,7 @@ def louvain(
             g.from_cudf_adjlist(offsets, indices, weights)
 
         logg.info('    using the "louvain" package of rapids')
-        louvain_parts, _ = cugraph.louvain(g)
+        louvain_parts, _ = cugraph.louvain(g, resolution=resolution)
         groups = (
             louvain_parts.to_pandas()
             .sort_values('vertex')[['partition']]

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -181,7 +181,10 @@ def louvain(
             g.from_cudf_adjlist(offsets, indices, weights)
 
         logg.info('    using the "louvain" package of rapids')
-        louvain_parts, _ = cugraph.louvain(g, resolution=resolution)
+        if resolution is not None:
+            louvain_parts, _ = cugraph.louvain(g, resolution=resolution)
+        else:
+            louvain_parts, _ = cugraph.louvain(g)
         groups = (
             louvain_parts.to_pandas()
             .sort_values('vertex')[['partition']]


### PR DESCRIPTION
I allowed the 'resolution' parameter to be used in Louvain clustering when flavor='rapids'. The resolution parameter works with cuGraph Louvain clustering: https://docs.rapids.ai/api/cugraph/stable/api.html#module-cugraph.community.louvain

Tested that the function works and docs are built correctly.