### PR TITLE
bug fix: hue in sc.pl.violin

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -713,7 +713,7 @@ def violin(
 
     # appending by hue key if provided in kwds
     if kwds.get('hue') is not None:
-        keys = keys.append(kwds.get('hue'))
+        keys.append(kwds.get('hue'))
 
     if groupby is not None:
         obs_df = get.obs_df(adata, keys=[groupby] + keys, layer=layer, use_raw=use_raw)

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -711,6 +711,10 @@ def violin(
             f'found `{len(ylabel)}`.'
         )
 
+    # appending by hue key if provided in kwds
+    if kwds.get('hue') is not None:
+        keys = keys.append(kwds.get('hue'))
+
     if groupby is not None:
         obs_df = get.obs_df(adata, keys=[groupby] + keys, layer=layer, use_raw=use_raw)
         if kwds.get('palette', None) is None:


### PR DESCRIPTION
<!-- 
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
closses #1174 

hue key is now added to keys if hue is in kwds. before obs_tidy did not include this keyword, so this resulted in an ValueError

an alternative would be to add hue as a function parameter to `sc.pl.violin`