### PR TITLE
Bugfix in RAPIDS usage for neighbors(), and support for additional distance metrics

### DIFF
--- a/docs/release-notes/1.8.3.rst
+++ b/docs/release-notes/1.8.3.rst
@@ -8,6 +8,7 @@
 - Fixed finding variables with ``use_raw=True`` and ``basis=None`` in :func:`scanpy.pl.scatter` :pr:`2027` :small:`E Rice`
 - Fixed :func:`scanpy.external.pp.scrublet` to address :issue:`1957` :smaller:`FlMai` and ensure raw counts are used for simulation
 - Functions in :mod:`scanpy.datasets` no longer throw `OldFormatWarnings` when using `anndata` `0.8` :pr:`2096` :small:`I Virshup`
+- Fixed use of :func:`scanpy.pp.neighbors` with ``method='rapids'``: RAPIDS cuML no longer returns a squared Euclidean distance matrix, so we should not square-root the kNN distance matrix. :pr:`1828` :small:`M Zaslavsky`
 
 .. rubric:: Performance
 

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -339,8 +339,8 @@ def compute_neighbors_rapids(
     nn = NearestNeighbors(n_neighbors=n_neighbors, metric=metric)
     X_contiguous = np.ascontiguousarray(X, dtype=np.float32)
     nn.fit(X_contiguous)
-    knn_distsq, knn_indices = nn.kneighbors(X_contiguous)
-    return knn_indices, np.sqrt(knn_distsq)  # cuml uses sqeuclidean metric so take sqrt
+    knn_dist, knn_indices = nn.kneighbors(X_contiguous)
+    return knn_indices, knn_dist
 
 
 def _get_sparse_matrix_from_indices_distances_umap(


### PR DESCRIPTION
Now that RAPIDS/cuML [supports multiple distance metrics for kNN graphs](https://github.com/rapidsai/cuml/issues/2104):

1. cuML no longer returns squared Euclidean distances by default. I believe we should not be square-rooting the kNN distance matrix.

2. Calling `sc.pp.neighbors` with `method='rapids'` currently requires `metric='euclidean'`. I believe we should loosen this restriction and pass the requested `metric` on to cuML.

(Big fan — thanks for the excellent library!)
