### PR TITLE
Fixed randomness in tl.diffmap - compute_eigen (v0 argument)

### DIFF
--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -26,6 +26,7 @@
 
 - Fix :func:`scanpy.pl.paga_path` `TypeError` with recent versions of anndata :pr:`1047` :smaller:`P Angerer`
 - Fix detection of whether IPython is running :pr:`1844` :smaller:`I Virshup`
+- Fixed reproducibility of :func:`scanpy.tl.diffmap` (added random_state) :pr:`1858` :smaller:`I Kucinski`
 
 .. rubric:: Deprecations
 

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -937,6 +937,7 @@ class Neighbors:
         n_comps: int = 15,
         sym: Optional[bool] = None,
         sort: Literal['decrease', 'increase'] = 'decrease',
+        random_state: AnyRandom = 0,
     ):
         """\
         Compute eigen decomposition of transition matrix.
@@ -950,6 +951,8 @@ class Neighbors:
             Instead of computing the eigendecomposition of the assymetric
             transition matrix, computed the eigendecomposition of the symmetric
             Ktilde matrix.
+        random_state
+            A numpy random seed
 
         Returns
         -------
@@ -978,8 +981,14 @@ class Neighbors:
             which = 'LM' if sort == 'decrease' else 'SM'
             # it pays off to increase the stability with a bit more precision
             matrix = matrix.astype(np.float64)
+
+            # Setting the random initial vector
+            random_state = check_random_state(random_state)
+            np.random.set_state(random_state.get_state())
+            v0 = np.random.randn((matrix.shape[0]))
+
             evals, evecs = scipy.sparse.linalg.eigsh(
-                matrix, k=n_comps, which=which, ncv=ncv
+                matrix, k=n_comps, which=which, ncv=ncv, v0=v0
             )
             evals, evecs = evals.astype(np.float32), evecs.astype(np.float32)
         if sort == 'decrease':

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -984,7 +984,6 @@ class Neighbors:
 
             # Setting the random initial vector
             random_state = check_random_state(random_state)
-            np.random.set_state(random_state.get_state())
             v0 = random_state.standard_normal((matrix.shape[0]))
             evals, evecs = scipy.sparse.linalg.eigsh(
                 matrix, k=n_comps, which=which, ncv=ncv, v0=v0

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -985,8 +985,7 @@ class Neighbors:
             # Setting the random initial vector
             random_state = check_random_state(random_state)
             np.random.set_state(random_state.get_state())
-            v0 = np.random.randn((matrix.shape[0]))
-
+            v0 = random_state.standard_normal((matrix.shape[0]))
             evals, evecs = scipy.sparse.linalg.eigsh(
                 matrix, k=n_comps, which=which, ncv=ncv, v0=v0
             )

--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -2,7 +2,7 @@ from importlib.util import find_spec
 
 import numpy as np
 import pytest
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_almost_equal, assert_array_equal, assert_raises
 
 import scanpy as sc
 
@@ -28,3 +28,18 @@ def test_umap_init_paga(layout):
     sc.tl.paga(pbmc)
     sc.pl.paga(pbmc, layout=layout, show=False)
     sc.tl.umap(pbmc, init_pos="paga")
+
+
+def test_diffmap():
+    pbmc = sc.datasets.pbmc68k_reduced()
+
+    sc.tl.diffmap(pbmc)
+    d1 = pbmc.obsm['X_diffmap'].copy()
+    sc.tl.diffmap(pbmc)
+    d2 = pbmc.obsm['X_diffmap'].copy()
+    assert_array_equal(d1, d2)
+
+    # Checking if specifying random_state  works, arrays shouldn't be equal
+    sc.tl.diffmap(pbmc, random_state=1234)
+    d3 = pbmc.obsm['X_diffmap'].copy()
+    assert_raises(AssertionError, assert_array_equal, d1, d3)

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -42,7 +42,7 @@ def diffmap(
         .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
         respectively.
     random_state
-            A numpy random seed
+        A numpy random seed
     copy
         Return a copy instead of writing to adata.
 

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -2,12 +2,14 @@ from anndata import AnnData
 from typing import Optional
 
 from ._dpt import _diffmap
+from .._utils import AnyRandom
 
 
 def diffmap(
     adata: AnnData,
     n_comps: int = 15,
     neighbors_key: Optional[str] = None,
+    random_state: AnyRandom = 0,
     copy: bool = False,
 ):
     """\
@@ -39,6 +41,8 @@ def diffmap(
         .obsp[.uns[neighbors_key]['connectivities_key']],
         .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
         respectively.
+    random_state
+            A numpy random seed
     copy
         Return a copy instead of writing to adata.
 
@@ -70,5 +74,7 @@ def diffmap(
     if n_comps <= 2:
         raise ValueError('Provide any value greater than 2 for `n_comps`. ')
     adata = adata.copy() if copy else adata
-    _diffmap(adata, n_comps=n_comps, neighbors_key=neighbors_key)
+    _diffmap(
+        adata, n_comps=n_comps, neighbors_key=neighbors_key, random_state=random_state
+    )
     return adata if copy else None

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -10,11 +10,11 @@ from .. import logging as logg
 from ..neighbors import Neighbors, OnFlySymMatrix
 
 
-def _diffmap(adata, n_comps=15, neighbors_key=None):
+def _diffmap(adata, n_comps=15, neighbors_key=None, random_state=0):
     start = logg.info(f'computing Diffusion Maps using n_comps={n_comps}(=n_dcs)')
     dpt = DPT(adata, neighbors_key=neighbors_key)
     dpt.compute_transitions()
-    dpt.compute_eigen(n_comps=n_comps)
+    dpt.compute_eigen(n_comps=n_comps, random_state=random_state)
     adata.obsm['X_diffmap'] = dpt.eigen_basis
     adata.uns['diffmap_evals'] = dpt.eigen_values
     logg.info(


### PR DESCRIPTION
Currently tl.diffmap generates slightly different results on consequent runs. This is because the v0 argument is not provided in the scipy.sparse.linalg.eigsh call (inside the compute_eigen function). 

To fix this I set the random_state inside the compute_eigen function and generate a random vector to pass into scipy.sparse.linalg.eigsh as v0. 
I tried to follow how random_state is implemented in other scanpy functions, I hope this is consistent.

To allow user control of the random_state I added random_state arguments to:
- tools/_diffmap.py _diffmap function (tl.diffmap function)
- tools/_dpt.py _diffmap function
- neighbors/__init__.py compute_eigen function

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
