### PR TITLE
Set theme fix

### DIFF
--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -26,6 +26,7 @@
 
 - Fix :func:`scanpy.pl.paga_path` `TypeError` with recent versions of anndata :pr:`1047` :smaller:`P Angerer`
 - Fix detection of whether IPython is running :pr:`1844` :smaller:`I Virshup`
+- Fixed errors and warnings from embedding plots with small numbers of categories after `sns.set_palette` was called :pr:`1886` :smaller:`I Virshup`
 
 .. rubric:: Deprecations
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -447,7 +447,6 @@ def _set_default_colors_for_categorical_obs(adata, value_to_plot):
     -------
     None
     """
-
     categories = adata.obs[value_to_plot].cat.categories
     length = len(categories)
 
@@ -470,7 +469,7 @@ def _set_default_colors_for_categorical_obs(adata, value_to_plot):
                 "'grey' color will be used for all categories."
             )
 
-    adata.uns[value_to_plot + '_colors'] = palette[:length]
+    _set_colors_for_categorical_obs(adata, value_to_plot, palette[:length])
 
 
 def add_colors_for_categorical_sample_annotation(

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -14,6 +14,7 @@ setup()
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.cm as cm
+import seaborn as sns
 import numpy as np
 import pandas as pd
 from matplotlib.testing.compare import compare_images
@@ -1249,3 +1250,20 @@ def test_groupby_list(image_comparer):
             adata, ['Gata1', 'Gata2'], groupby=['rand_cat', 'cell_type'], swap_axes=True
         )
         save_and_compare_images('master_dotplot_groupby_list_catorder')
+
+
+def test_color_cycler(caplog):
+    # https://github.com/theislab/scanpy/issues/1885
+    import logging
+
+    pbmc = sc.datasets.pbmc68k_reduced()
+    colors = sns.color_palette("deep")
+    cyl = sns.rcmod.cycler('color', sns.color_palette("deep"))
+
+    with caplog.at_level(logging.WARNING):
+        with plt.rc_context({'axes.prop_cycle': cyl, "patch.facecolor": colors[0]}):
+            sc.pl.umap(pbmc, color="phase")
+            plt.show()
+            plt.close()
+
+    assert caplog.text == ""


### PR DESCRIPTION
If you call `sns.set_palette`, seaborn sets the default color palette as rgb tuples. matplotlib sometimes complains about this, and something this causes errors with our other code. We were putting these tuples into `adata.uns[f"{key}_colors"]` without validation. Now we validate this.

Fixes #1885.