### PR TITLE
Fix graph metrics when some variables are constant

### DIFF
--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -1,4 +1,7 @@
 """Utility functions and classes
+
+This file largely consists of the old _utils.py file. Over time, these functions
+should be moved of this file.
 """
 import sys
 import inspect
@@ -19,9 +22,11 @@ from anndata import AnnData, __version__ as anndata_version
 from textwrap import dedent
 from packaging import version
 
-from ._settings import settings
-from ._compat import Literal
-from . import logging as logg
+from .._settings import settings
+from .._compat import Literal
+from .. import logging as logg
+
+from .compute.is_constant import is_constant
 
 
 class Empty(Enum):
@@ -37,12 +42,12 @@ EPS = 1e-15
 
 
 def check_versions():
-    from ._compat import pkg_version
+    from .._compat import pkg_version
 
     umap_version = pkg_version("umap-learn")
 
     if version.parse(anndata_version) < version.parse('0.6.10'):
-        from . import __version__
+        from .. import __version__
 
         raise ImportError(
             f'Scanpy {__version__} needs anndata version >=0.6.10, '
@@ -635,7 +640,7 @@ def subsample_n(
 def check_presence_download(filename: Path, backup_url):
     """Check if file is present otherwise download."""
     if not filename.is_file():
-        from .readwrite import _download
+        from ..readwrite import _download
 
         _download(backup_url, filename)
 

--- a/scanpy/_utils/compute/is_constant.py
+++ b/scanpy/_utils/compute/is_constant.py
@@ -1,0 +1,111 @@
+from functools import singledispatch
+from numbers import Integral
+
+import numpy as np
+from numba import njit
+from scipy import sparse
+
+
+@singledispatch
+def is_constant(a, axis=None) -> np.ndarray:
+    """
+    Check whether values in array are constant.
+
+    Params
+    ------
+    a
+        Array to check
+    axis
+        Axis to reduce over.
+
+
+    Returns
+    -------
+    Boolean array, True values were constant.
+
+    Example
+    -------
+
+    >>> a = np.array([[0, 1], [0, 0]])
+    >>> a
+    array([[0, 1],
+            [0, 0]])
+    >>> is_constant(a)
+    False
+    >>> is_constant(a, axis=0)
+    array([ False, True])
+    >>> is_constant(a, axis=1)
+    array([ True, False])
+    """
+    raise NotImplementedError()
+
+
+@is_constant.register(np.ndarray)
+def _(a, axis=None):
+    # Should eventually support nd, not now.
+    if axis is None:
+        return np.array_equal(a, a.flat[0])
+    if not isinstance(axis, Integral):
+        raise TypeError("axis must be integer or None.")
+    assert axis in (0, 1)
+    if axis == 0:
+        return _is_constant_rows(a.T)
+    elif axis == 1:
+        return _is_constant_rows(a)
+
+
+def _is_constant_rows(a):
+    b = np.broadcast_to(a[:, 0][:, np.newaxis], a.shape)
+    return (a == b).all(axis=1)
+
+
+@is_constant.register(sparse.csr_matrix)
+def _(a, axis=None):
+    if axis is None:
+        if len(a.data) == np.multiply(*a.shape):
+            return is_constant(a.data)
+        else:
+            return (a.data == 0).all()
+    if not isinstance(axis, Integral):
+        raise TypeError("axis must be integer or None.")
+    assert axis in (0, 1)
+    if axis == 1:
+        return _is_constant_csr_rows(a.data, a.indices, a.indptr, a.shape)
+    elif axis == 0:
+        a = a.T.tocsr()
+        return _is_constant_csr_rows(a.data, a.indices, a.indptr, a.shape)
+
+
+@njit
+def _is_constant_csr_rows(data, indices, indptr, shape):
+    N = len(indptr) - 1
+    result = np.ones(N, dtype=np.bool_)
+    for i in range(N):
+        start = indptr[i]
+        stop = indptr[i + 1]
+        if stop - start == shape[1]:
+            val = data[start]
+        else:
+            val = 0
+        for j in range(start, stop):
+            if data[j] != val:
+                result[i] = False
+                break
+    return result
+
+
+@is_constant.register(sparse.csc_matrix)
+def _(a, axis=None):
+    if axis is None:
+        if len(a.data) == np.multiply(*a.shape):
+            return is_constant(a.data)
+        else:
+            return (a.data == 0).all()
+    if not isinstance(axis, Integral):
+        raise TypeError("axis must be integer or None.")
+    assert axis in (0, 1)
+    if axis == 0:
+        return _is_constant_csr_rows(a.data, a.indices, a.indptr, a.shape[::-1])
+    elif axis == 1:
+        a = a.T.tocsc()
+        return _is_constant_csr_rows(a.data, a.indices, a.indptr, a.shape[::-1])

--- a/scanpy/metrics/_gearys_c.py
+++ b/scanpy/metrics/_gearys_c.py
@@ -278,6 +278,9 @@ def _check_vals(vals):
     Checks that values wont cause issues in computation.
 
     Returns new set of vals, and indexer to put values back into result.
+
+    For details on why this is neccesary, see:
+    https://github.com/theislab/scanpy/issues/1806
     """
     from scanpy._utils import is_constant
 

--- a/scanpy/tests/test_utils.py
+++ b/scanpy/tests/test_utils.py
@@ -1,8 +1,11 @@
 from types import ModuleType
-from scipy.sparse import csr_matrix
+from scipy.sparse import csr_matrix, csc_matrix
 import numpy as np
 
 from scanpy._utils import descend_classes_and_funcs, check_nonnegative_integers
+
+from anndata.tests.helpers import assert_equal, asarray
+import pytest
 
 
 def test_descend_classes_and_funcs():
@@ -37,3 +40,28 @@ def test_check_nonnegative_integers():
 
     X_ = csr_matrix(X_)
     assert check_nonnegative_integers(X_) is False
+
+
+@pytest.mark.parametrize(
+    'array_type', [asarray, csr_matrix, csc_matrix], ids=lambda x: x.__name__
+)
+def test_is_constant(array_type):
+    from scanpy._utils import is_constant
+
+    constant_inds = [1, 3]
+    A = np.arange(20).reshape(5, 4)
+    A[constant_inds, :] = 10
+    A = array_type(A)
+    AT = array_type(A.T)
+
+    assert not is_constant(A)
+    assert not np.any(is_constant(A, axis=0))
+    np.testing.assert_array_equal(
+        [False, True, False, True, False], is_constant(A, axis=1)
+    )
+
+    assert not is_constant(AT)
+    assert not np.any(is_constant(AT, axis=1))
+    np.testing.assert_array_equal(
+        [False, True, False, True, False], is_constant(AT, axis=0)
+    )


### PR DESCRIPTION
Fixes #1806

New behaviour for Moran's I and Geary's C. If one of the variables passed has constant values, the score for that variable is `nan` and the function warns the user about this. Previously, the presence of this variable would silently fail, corrupting the other outputs as well.

Adds a new utility `is_constant` to check if values in an array are constant.

* Could have less code repetition, since now there's some logic that is applied to any case which is 2d, but the conditional isn't structured this way.
* Performance hit pretty minor, as computing the metric itself is expensive.