### PR TITLE
If raw was not used, use_raw should be False

### DIFF
--- a/docs/release-notes/1.8.0.rst
+++ b/docs/release-notes/1.8.0.rst
@@ -35,6 +35,7 @@
 - Fixed reproducibility of :func:`scanpy.tl.diffmap` (added random_state) :pr:`1858` :smaller:`I Kucinski`
 - Fixed errors and warnings from embedding plots with small numbers of categories after `sns.set_palette` was called :pr:`1886` :smaller:`I Virshup`
 - Fixed handling of `gene_symbols` argument in a number of `sc.pl.rank_genes_groups*` functions :pr:`1529` :smaller:`F Ramirez` :smaller:`I Virshup`
+- Fixed handling of `use_raw` for `sc.tl.rank_genes_groups` when no `.raw` is present :pr:`1895` :smaller:`I Virshup`
 
 .. rubric:: Deprecations
 

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -73,6 +73,7 @@ def test_results_dense():
     seed(1234)
 
     adata = get_example_data()
+    assert adata.raw is None  # Assumption for later checks
 
     (
         true_names_t_test,
@@ -92,6 +93,7 @@ def test_results_dense():
             true_scores_t_test[name], adata.uns['rank_genes_groups']['scores'][name]
         )
     assert np.array_equal(true_names_t_test, adata.uns['rank_genes_groups']['names'])
+    assert adata.uns["rank_genes_groups"]["params"]["use_raw"] is False
 
     rank_genes_groups(adata, 'true_groups', n_genes=20, method='wilcoxon')
 
@@ -107,6 +109,7 @@ def test_results_dense():
     assert np.array_equal(
         true_names_wilcoxon[:7], adata.uns['rank_genes_groups']['names'][:7]
     )
+    assert adata.uns["rank_genes_groups"]["params"]["use_raw"] is False
 
 
 def test_results_sparse():
@@ -132,6 +135,7 @@ def test_results_sparse():
             true_scores_t_test[name], adata.uns['rank_genes_groups']['scores'][name]
         )
     assert np.array_equal(true_names_t_test, adata.uns['rank_genes_groups']['names'])
+    assert adata.uns["rank_genes_groups"]["params"]["use_raw"] is False
 
     rank_genes_groups(adata, 'true_groups', n_genes=20, method='wilcoxon')
 
@@ -147,6 +151,7 @@ def test_results_sparse():
     assert np.array_equal(
         true_names_wilcoxon[:7], adata.uns['rank_genes_groups']['names'][:7]
     )
+    assert adata.uns["rank_genes_groups"]["params"]["use_raw"] is False
 
 
 def test_results_layers():
@@ -169,9 +174,9 @@ def test_results_layers():
         'true_groups',
         method='wilcoxon',
         layer="to_test",
-        use_raw=False,
         n_genes=20,
     )
+    assert adata.uns["rank_genes_groups"]["params"]["use_raw"] is False
     for name in true_scores_t_test.dtype.names:
         assert np.allclose(
             true_scores_wilcoxon[name][:7],
@@ -236,6 +241,7 @@ def test_wilcoxon_symmetry():
         method='wilcoxon',
         rankby_abs=True,
     )
+    assert pbmc.uns["rank_genes_groups"]["params"]["use_raw"] is True
 
     stats_mono = (
         rank_genes_groups_df(pbmc, group="CD14+ Monocyte")

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -429,7 +429,7 @@ class _RankGenes:
 def rank_genes_groups(
     adata: AnnData,
     groupby: str,
-    use_raw: bool = True,
+    use_raw: Optional[bool] = None,
     groups: Union[Literal['all'], Iterable[str]] = 'all',
     reference: str = 'rest',
     n_genes: Optional[int] = None,
@@ -533,6 +533,11 @@ def rank_genes_groups(
     >>> # to visualize the results
     >>> sc.pl.rank_genes_groups(adata)
     """
+    if use_raw is None:
+        use_raw = adata.raw is not None
+    elif use_raw is True and adata.raw is not None:
+        raise ValueError("Received `use_raw=True`, but `adata.raw` is empty.")
+
     if method is None:
         logg.warning(
             "Default of the method has been changed to 't-test' from 't-test_overestim_var'"


### PR DESCRIPTION
On current master:

```python
import scanpy as sc

a = sc.datasets.krumsiek11()
assert a.raw is None

sc.tl.rank_genes_groups(a, "cell_type", method="wilcoxon")

a.uns["rank_genes_groups"]["params"]["use_raw"]
# True
```

This is bad, and causes issues with downstream plotting functions which use `use_raw` to check where they should be getting expression values from. This PR fixes that.

Along with other recent bug fixes, fixes #1114.