### PR TITLE
Split function in sc.get

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -334,7 +334,7 @@ useful formats.
    get.obs_df
    get.var_df
    get.rank_genes_groups_df
-   get.split
+   get.split_by
 
 
 Queries

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -334,6 +334,7 @@ useful formats.
    get.obs_df
    get.var_df
    get.rank_genes_groups_df
+   get.split
 
 
 Queries

--- a/docs/release-notes/1.9.0.rst
+++ b/docs/release-notes/1.9.0.rst
@@ -4,3 +4,4 @@
 .. rubric:: Features
 
 - :func:`~scanpy.tl.filter_rank_genes_groups` now allows to filter with absolute values of log fold change :pr:`1649` :smaller:`S Rybakov`
+- Added :func:`~scanpy.get.split_by` to split an AnnData object along an axis :pr:`1939` :smaller:`S Rybakov`

--- a/scanpy/get/__init__.py
+++ b/scanpy/get/__init__.py
@@ -1,5 +1,5 @@
 # Public
-from .get import rank_genes_groups_df, obs_df, var_df, split
+from .get import rank_genes_groups_df, obs_df, var_df, split_by
 
 # Private
 from .get import _get_obs_rep, _set_obs_rep

--- a/scanpy/get/__init__.py
+++ b/scanpy/get/__init__.py
@@ -1,5 +1,5 @@
 # Public
-from .get import rank_genes_groups_df, obs_df, var_df
+from .get import rank_genes_groups_df, obs_df, var_df, split
 
 # Private
 from .get import _get_obs_rep, _set_obs_rep

--- a/scanpy/get/get.py
+++ b/scanpy/get/get.py
@@ -488,7 +488,7 @@ def split_by(
     Split by all values in an `.obs` `key`:
 
     >>> adata = sc.datasets.pbmc68k_reduced()
-    >>> adatas = sc.get.split(adata, 'bulk_labels')
+    >>> adatas = sc.get.split_by(adata, 'bulk_labels')
     >>> adatas
     {'CD14+ Monocyte': View of AnnData object with n_obs × n_vars = 129 × 765
      ...,
@@ -500,7 +500,7 @@ def split_by(
     Select only specific groups from `.obs` `key`:
 
     >>> adata = sc.datasets.pbmc68k_reduced()
-    >>> adatas = sc.get.split(adata, 'bulk_labels', ['CD14+ Monocyte', 'CD34+'])
+    >>> adatas = sc.get.split_by(adata, 'bulk_labels', ['CD14+ Monocyte', 'CD34+'])
     >>> adatas
     {'CD14+ Monocyte': View of AnnData object with n_obs × n_vars = 129 × 765
      ...,
@@ -511,9 +511,9 @@ def split_by(
     Aggreagte some groups from `.obs` `key`, put all others to `others_key`:
 
     >>> adata = sc.datasets.pbmc68k_reduced()
-    >>> adatas = sc.get.split(adata, 'bulk_labels',
-                              dict(some=['CD14+ Monocyte', 'CD34+']),
-                              others_key='others')
+    >>> adatas = sc.get.split_by(adata, 'bulk_labels',
+                                 dict(some=['CD14+ Monocyte', 'CD34+']),
+                                 others_key='others')
     >>> adatas
     {'some': View of AnnData object with n_obs × n_vars = 142 × 765
      ...,

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -516,22 +516,22 @@ def test_rank_genes_groups_df():
 ###############
 
 
-def test_split():
+def test_split_by():
     adata = sc.datasets.pbmc68k_reduced()
 
-    adatas = sc.get.split(adata, 'bulk_labels')
+    adatas = sc.get.split_by(adata, 'bulk_labels')
     for g, ad in adatas.items():
         assert ad.obs['bulk_labels'].cat.categories.tolist() == [g]
         assert ad.is_view
 
     groups = ['CD14+ Monocyte', 'CD34+']
-    adatas = sc.get.split(adata, 'bulk_labels', groups, copy=True)
+    adatas = sc.get.split_by(adata, 'bulk_labels', groups, copy=True)
     assert list(adatas.keys()) == groups
     for g in groups:
         assert adatas[g].obs['bulk_labels'].cat.categories.tolist() == [g]
         assert not adatas[g].is_view
 
-    adatas = sc.get.split(
+    adatas = sc.get.split_by(
         adata,
         'bulk_labels',
         dict(some=groups),

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -545,4 +545,4 @@ def test_split_by():
     var_cats = pd.cut(adata.var.n_counts, 4).cat.rename_categories(str)
     adatas = sc.get.split_by(adata, var_cats, axis=1)
     assert set(adatas.keys()) == set(var_cats.cat.categories)
-    assert sum([a.n_vars for a in adatas.values()]) == adata.n_vars
+    assert sum(a.n_vars for a in adatas.values()) == adata.n_vars

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -545,3 +545,4 @@ def test_split_by():
     var_cats = pd.cut(adata.var.n_counts, 4).cat.rename_categories(str)
     adatas = sc.get.split_by(adata, var_cats, axis=1)
     assert set(adatas.keys()) == set(var_cats.cat.categories)
+    assert sum([a.n_vars for a in adatas.values()]) == adata.n_vars

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -541,3 +541,7 @@ def test_split_by():
     assert all(adatas['some'].obs['bulk_labels'].isin(groups))
     mask = ~adata.obs['bulk_labels'].isin(groups)
     assert adatas['others'].obs_names.equals(adata[mask].obs_names)
+
+    var_cats = pd.cut(adata.var.n_counts, 4).cat.rename_categories(str)
+    adatas = sc.get.split_by(adata, var_cats, axis=1)
+    assert set(adatas.keys()) == set(var_cats.cat.categories)


### PR DESCRIPTION
This adds `sc.get.split` to split adata based on an obs column. The examples are in the docstring.
