### PR TITLE
Update for cope with issue introduced in umap-learn 0.5.2

### DIFF
--- a/docs/release-notes/1.8.2.rst
+++ b/docs/release-notes/1.8.2.rst
@@ -6,6 +6,7 @@
 - Fix plotting after :func:`scanpy.tl.filter_rank_genes_groups` :pr:`1942` :smaller:`S Rybakov`
 - Fix ``use_raw=None`` using :attr:`anndata.AnnData.var_names` if :attr:`anndata.AnnData.raw`
   is present in :func:`scanpy.tl.score_genes` :pr:`1999` :smaller:`M Klein`
+- Fix compatibility with UMAP 0.5.2 :pr:`2028` :smaller:`L Mcinnes`
 
 .. rubric:: Performance enhancements
 

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -199,7 +199,7 @@ class Ingest:
 
         self._umap._initial_alpha = self._umap.learning_rate
         self._umap._raw_data = self._rep
-        self.knn_dists = None
+        self._umap.knn_dists = None
 
         self._umap._validate_parameters()
 

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -199,6 +199,7 @@ class Ingest:
 
         self._umap._initial_alpha = self._umap.learning_rate
         self._umap._raw_data = self._rep
+        self.knn_dists = None
 
         self._umap._validate_parameters()
 

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -189,7 +189,8 @@ def umap(
     if method == 'umap':
         # the data matrix X is really only used for determining the number of connected components
         # for the init condition in the UMAP embedding
-        n_epochs = 0 if maxiter is None else maxiter
+        default_epochs = 500 if neighbors['connectivities'].shape[0] <= 10000 else 200
+        n_epochs = default_epochs if maxiter is None else maxiter
         X_umap = simplicial_set_embedding(
             X,
             neighbors['connectivities'].tocoo(),


### PR DESCRIPTION
As of umap-learn 0.5.2 an ``n_epochs`` value of 0 is now a valid value and None is used instead to indicate a value should be generated. To maintain forward compatability and backward compatibility with older umap-learn versions we instead make use of the epch setting criterion internal to umap-learn here directly. This should resolve issue #2026 and lmcinnes/umap#798

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
