### PR TITLE
pca_loadings add n_points to account for less than 30 features

### DIFF
--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -92,6 +92,7 @@ def pca_loadings(
     adata: AnnData,
     components: Union[str, Sequence[int], None] = None,
     include_lowest: bool = True,
+    n_points=30,
     show: Optional[bool] = None,
     save: Union[str, bool, None] = None,
 ):
@@ -143,6 +144,7 @@ def pca_loadings(
         adata,
         'varm',
         'PCs',
+        n_points=n_points,
         indices=components,
         include_lowest=include_lowest,
     )


### PR DESCRIPTION
When less than 30 features are present in adata.X, pca_loadings will plot some components twice.
The patch solves the problem by adding an n_point parameter (default value 30, same as anndata.ranking())that is then passed to anndata.ranking(). 


<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
