### PR TITLE
Turn off pre-commit auto commit for PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,6 @@ repos:
     -   id: check-yaml
     -   id: check-merge-conflict
     -   id: detect-private-key
+
+ci:
+    autofix_prs: false


### PR DESCRIPTION
It seems like a good way to get conflicts