### PR TITLE
Allow users to pass inner to sc.pl.violin when multi_panel=True

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -799,7 +799,6 @@ def violin(
             sharey=False,
             order=keys,
             cut=0,
-            inner=None,
             **kwds,
         )
 


### PR DESCRIPTION
Might fix my proposed solution for #2051

@WeilerP, do you remember why you explicitly set `inner=None` here in #1422?