### PR TITLE
Add extra descriptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,15 +115,15 @@ dev = [
     "black>=20.8b1",
     "docutils",
 ]
-louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]
-leiden = ["python-igraph", "leidenalg"]
-bbknn = ["bbknn"]
-rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]
-magic = ["magic-impute>=2.0"]
-skmisc = ["scikit-misc>=0.1.3"]
-harmony = ["harmonypy"]
-scanorama = ["scanorama"]
-scrublet = ["scrublet"]
+louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]  # Louvain community detection
+leiden = ["python-igraph", "leidenalg"]  # Leiden community detection
+bbknn = ["bbknn"]  # Batch balanced KNN (batch correction)
+rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
+magic = ["magic-impute>=2.0"]  # MAGIC imputation method
+skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
+harmony = ["harmonypy"]  # Harmony dataset integration
+scanorama = ["scanorama"]  # Scanorama dataset integration
+scrublet = ["scrublet"]  # Doublet detection
 
 [tool.flit.sdist]
 exclude = [


### PR DESCRIPTION
So people looking into this file know what they’re for.

Looking through these, I saw that the `skmisc` isn’t named after the feature it enables. Should we add a more descriptive copy?