### PR TITLE
Fix dataset warnings

### DIFF
--- a/docs/release-notes/1.8.3.rst
+++ b/docs/release-notes/1.8.3.rst
@@ -5,10 +5,9 @@
 
 .. rubric:: Bug fixes
 
-- Fixed finding variables with ``use_raw=True`` and ``basis=None`` in
-  :func:`scanpy.pl.scatter` :pr:`2027` :small:`E Rice`
-- Fixed :func:`scanpy.external.pp.scrublet` to address :issue:`1957`
-  :smaller:`FlMai` and ensure raw counts are used for simulation
+- Fixed finding variables with ``use_raw=True`` and ``basis=None`` in :func:`scanpy.pl.scatter` :pr:`2027` :small:`E Rice`
+- Fixed :func:`scanpy.external.pp.scrublet` to address :issue:`1957` :smaller:`FlMai` and ensure raw counts are used for simulation
+- Functions in :mod:`scanpy.datasets` no longer throw `OldFormatWarnings` when using `anndata` `0.8` :pr:`2096` :small:`I Virshup`
 
 .. rubric:: Performance
 

--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -4,13 +4,14 @@ import warnings
 
 import numpy as np
 import pandas as pd
-from anndata import AnnData
+import anndata as ad
+from packaging import version
 
 from .. import logging as logg, _utils
 from .._compat import Literal
 from .._settings import settings
 from ..readwrite import read, read_visium
-from ._utils import check_datasetdir_exists
+from ._utils import check_datasetdir_exists, filter_oldformatwarning
 
 HERE = Path(__file__).parent
 
@@ -20,7 +21,7 @@ def blobs(
     n_centers: int = 5,
     cluster_std: float = 1.0,
     n_observations: int = 640,
-) -> AnnData:
+) -> ad.AnnData:
     """\
     Gaussian Blobs.
 
@@ -50,11 +51,11 @@ def blobs(
         cluster_std=cluster_std,
         random_state=0,
     )
-    return AnnData(X, obs=dict(blobs=y.astype(str)), dtype=X.dtype)
+    return ad.AnnData(X, obs=dict(blobs=y.astype(str)), dtype=X.dtype)
 
 
 @check_datasetdir_exists
-def burczynski06() -> AnnData:
+def burczynski06() -> ad.AnnData:
     """\
     Bulk data with conditions ulcerative colitis (UC) and Crohn's disease (CD).
 
@@ -75,7 +76,7 @@ def burczynski06() -> AnnData:
     return adata
 
 
-def krumsiek11() -> AnnData:
+def krumsiek11() -> ad.AnnData:
     """\
     Simulated myeloid progenitors [Krumsiek11]_.
 
@@ -110,7 +111,7 @@ def krumsiek11() -> AnnData:
 
 
 @check_datasetdir_exists
-def moignard15() -> AnnData:
+def moignard15() -> ad.AnnData:
     """\
     Hematopoiesis in early mouse embryos [Moignard15]_.
 
@@ -148,7 +149,7 @@ def moignard15() -> AnnData:
 
 
 @check_datasetdir_exists
-def paul15() -> AnnData:
+def paul15() -> ad.AnnData:
     """\
     Development of Myeloid Progenitors [Paul15]_.
 
@@ -179,7 +180,7 @@ def paul15() -> AnnData:
         clusters = f['cluster.id'][()].flatten().astype(int)
         infogenes_names = f['info.genes_strings'][()].astype(str)
     # each row has to correspond to a observation, therefore transpose
-    adata = AnnData(X.transpose(), dtype=X.dtype)
+    adata = ad.AnnData(X.transpose(), dtype=X.dtype)
     adata.var_names = gene_names
     adata.row_names = cell_names
     # names reflecting the cell type identifications from the paper
@@ -202,7 +203,7 @@ def paul15() -> AnnData:
     return adata
 
 
-def toggleswitch() -> AnnData:
+def toggleswitch() -> ad.AnnData:
     """\
     Simulated toggleswitch.
 
@@ -220,7 +221,8 @@ def toggleswitch() -> AnnData:
     return adata
 
 
-def pbmc68k_reduced() -> AnnData:
+@filter_oldformatwarning
+def pbmc68k_reduced() -> ad.AnnData:
     """\
     Subsampled and processed 68k PBMCs.
 
@@ -245,8 +247,9 @@ def pbmc68k_reduced() -> AnnData:
         return read(filename)
 
 
+@filter_oldformatwarning
 @check_datasetdir_exists
-def pbmc3k() -> AnnData:
+def pbmc3k() -> ad.AnnData:
     """\
     3k PBMCs from 10x Genomics.
 
@@ -288,8 +291,9 @@ def pbmc3k() -> AnnData:
     return adata
 
 
+@filter_oldformatwarning
 @check_datasetdir_exists
-def pbmc3k_processed() -> AnnData:
+def pbmc3k_processed() -> ad.AnnData:
     """Processed 3k PBMCs from 10x Genomics.
 
     Processed using the `basic tutorial <https://scanpy-tutorials.readthedocs.io/en/latest/pbmc3k.html>`__.
@@ -391,7 +395,7 @@ def visium_sge(
     ] = 'V1_Breast_Cancer_Block_A_Section_1',
     *,
     include_hires_tiff: bool = False,
-) -> AnnData:
+) -> ad.AnnData:
     """\
     Processed Visium Spatial Gene Expression data from 10x Genomics.
     Database: https://support.10xgenomics.com/spatial-gene-expression/datasets

--- a/scanpy/datasets/_ebi_expression_atlas.py
+++ b/scanpy/datasets/_ebi_expression_atlas.py
@@ -57,11 +57,18 @@ def read_mtx_from_stream(stream: BinaryIO) -> sparse.csr_matrix:
     while curline.startswith(b"%"):
         curline = stream.readline()
     n, m, _ = (int(x) for x in curline[:-1].split(b" "))
+
+    max_int32 = np.iinfo(np.int32).max
+    if n > max_int32 or m > max_int32:
+        coord_dtype = np.int64
+    else:
+        coord_dtype = np.int32
+
     data = pd.read_csv(
         stream,
         sep=r"\s+",
         header=None,
-        dtype={0: np.integer, 1: np.integer, 2: np.float32},
+        dtype={0: coord_dtype, 1: coord_dtype, 2: np.float32},
     )
     mtx = sparse.csr_matrix((data[2], (data[1] - 1, data[0] - 1)), shape=(m, n))
     return mtx

--- a/scanpy/datasets/_utils.py
+++ b/scanpy/datasets/_utils.py
@@ -1,4 +1,9 @@
 from functools import wraps
+import warnings
+
+from packaging import version
+
+import anndata as ad
 
 from .._settings import settings
 
@@ -8,5 +13,22 @@ def check_datasetdir_exists(f):
     def wrapper(*args, **kwargs):
         settings.datasetdir.mkdir(exist_ok=True)
         return f(*args, **kwargs)
+
+    return wrapper
+
+
+def filter_oldformatwarning(f):
+    """
+    Filters anndata.OldFormatWarning from being thrown by the wrapped function.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        with warnings.catch_warnings():
+            if version.parse(ad.__version__).release >= (0, 8):
+                warnings.filterwarnings(
+                    "ignore", category=ad.OldFormatWarning, module="anndata"
+                )
+            return f(*args, **kwargs)
 
     return wrapper

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -1,16 +1,14 @@
 from functools import partial
 from itertools import repeat, chain
-import re
-from scanpy import datasets
 
 import numpy as np
-from numpy.core.fromnumeric import trace
 import pandas as pd
 import pytest
 from anndata import AnnData
 from scipy import sparse
 
 import scanpy as sc
+from scanpy.datasets._utils import filter_oldformatwarning
 
 
 TRANSPOSE_PARAMS = pytest.mark.parametrize(
@@ -175,6 +173,7 @@ def test_repeated_gene_symbols():
     pd.testing.assert_frame_equal(expected, result)
 
 
+@filter_oldformatwarning
 def test_backed_vs_memory():
     "compares backed vs. memory"
     from pathlib import Path


### PR DESCRIPTION
Clears up warnings from using the provided datasets

* Filter out the OldFormatWarnings from using anndata > 0.8
* Fixes numpy warning from ebi dataset parsing
* Fix old format warning from reading `pbmc68k_reduced` file directly