### PR TITLE
Pin sphinx-autodoc-typehints version to avoid KeyError: 'argname'

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ test = [
 doc = [
     "sphinx>=4.1,<4.2",
     "sphinx-rtd-theme>=0.3.1",
-    "sphinx-autodoc-typehints",
+    "sphinx-autodoc-typehints==1.12.0",
     "scanpydoc>=0.7.3",
     "typing_extensions; python_version < '3.8'",  # for `Literal`
     "python-igraph",


### PR DESCRIPTION
Building the docs fails ever since the version of `sphinx-autodoc-typehints` increased from v1.12.0 to v1.13.0.

This PR temporarily pins this dependency's version to v1.12.0.

See https://github.com/theislab/scanpy/pull/1828#issuecomment-1005072811 and cc @Zethson 