### PR TITLE
Check dendrogram fix

### DIFF
--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -525,11 +525,11 @@ def test_violin_without_raw(tmpdir):
     pbmc = sc.datasets.pbmc68k_reduced()
     pbmc_no_raw = pbmc.raw.to_adata().copy()
 
-    sc.pl.violin(pbmc, 'CST3', groupby="bulk_labels", show=False)
+    sc.pl.violin(pbmc, 'CST3', groupby="bulk_labels", jitter=False, show=False)
     plt.savefig(has_raw_pth)
     plt.close()
 
-    sc.pl.violin(pbmc_no_raw, 'CST3', groupby="bulk_labels", show=False)
+    sc.pl.violin(pbmc_no_raw, 'CST3', groupby="bulk_labels", jitter=False, show=False)
     plt.savefig(no_raw_pth)
     plt.close()
 

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -136,7 +136,7 @@ def dendrogram(
     from scipy.spatial import distance
 
     corr_matrix = mean_df.T.corr(method=cor_method)
-    corr_condensed = distance.squareform(1 - corr_matrix)
+    corr_condensed = distance.squareform(1 - corr_matrix, checks=False)
     z_var = sch.linkage(
         corr_condensed, method=linkage_method, optimal_ordering=optimal_ordering
     )

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -140,7 +140,7 @@ def dendrogram(
     # np.fill_diagonal(corr_matrix, 1)  # Diagonal isn't quite 1, squareform errors
     # corr_condensed = distance.squareform(1 - corr_matrix)
     corr_matrix = mean_df.T.corr(method=cor_method)
-    corr_condensed = distance.squareform(1 - corr_matrix, checks=False)
+    corr_condensed = distance.squareform(1 - corr_matrix)
     z_var = sch.linkage(
         corr_condensed, method=linkage_method, optimal_ordering=optimal_ordering
     )

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -5,6 +5,7 @@ Computes a dendrogram based on a given categorical observation.
 from typing import Optional, Sequence, Dict, Any
 
 import pandas as pd
+import numpy as np
 from anndata import AnnData
 from pandas.api.types import is_categorical_dtype
 
@@ -135,8 +136,9 @@ def dendrogram(
     import scipy.cluster.hierarchy as sch
     from scipy.spatial import distance
 
-    corr_matrix = mean_df.T.corr(method=cor_method)
-    corr_condensed = distance.squareform(1 - corr_matrix, checks=False)
+    corr_matrix = mean_df.T.corr(method=cor_method).values
+    np.fill_diagonal(corr_matrix, 1)  # Diagonal isn't quite 1, squareform errors
+    corr_condensed = distance.squareform(1 - corr_matrix)
     z_var = sch.linkage(
         corr_condensed, method=linkage_method, optimal_ordering=optimal_ordering
     )
@@ -151,7 +153,7 @@ def dendrogram(
         categories_ordered=dendro_info['ivl'],
         categories_idx_ordered=dendro_info['leaves'],
         dendrogram_info=dendro_info,
-        correlation_matrix=corr_matrix.values,
+        correlation_matrix=corr_matrix,
     )
 
     if inplace:

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -136,9 +136,11 @@ def dendrogram(
     import scipy.cluster.hierarchy as sch
     from scipy.spatial import distance
 
-    corr_matrix = mean_df.T.corr(method=cor_method).values
-    np.fill_diagonal(corr_matrix, 1)  # Diagonal isn't quite 1, squareform errors
-    corr_condensed = distance.squareform(1 - corr_matrix)
+    # corr_matrix = mean_df.T.corr(method=cor_method).values
+    # np.fill_diagonal(corr_matrix, 1)  # Diagonal isn't quite 1, squareform errors
+    # corr_condensed = distance.squareform(1 - corr_matrix)
+    corr_matrix = mean_df.T.corr(method=cor_method)
+    corr_condensed = distance.squareform(1 - corr_matrix, checks=False)
     z_var = sch.linkage(
         corr_condensed, method=linkage_method, optimal_ordering=optimal_ordering
     )
@@ -153,7 +155,7 @@ def dendrogram(
         categories_ordered=dendro_info['ivl'],
         categories_idx_ordered=dendro_info['leaves'],
         dendrogram_info=dendro_info,
-        correlation_matrix=corr_matrix,
+        correlation_matrix=corr_matrix.values,
     )
 
     if inplace:


### PR DESCRIPTION
The tests and docs now fail due to https://github.com/theislab/scanpy/issues/2125.
For some reason, this https://github.com/theislab/scanpy/blob/b69015e9e7007193c9ac461d5c6fbf845b3d6962/scanpy/tools/_dendrogram.py#L139
has small values instead of 0s on the diagonal and thus fails the check of `is_valid_dm` inside `squareform` if `checks=True`. I don't understand why small values instead of 0s are there. New version of pandas? numpy?
This fix just sets `checks=False`, not sure if it is a good idea actually.