### PR TITLE
add n_top_genes argument to rank_genes_groups_df

### DIFF
--- a/scanpy/get/get.py
+++ b/scanpy/get/get.py
@@ -22,6 +22,7 @@ def rank_genes_groups_df(
     pval_cutoff: Optional[float] = None,
     log2fc_min: Optional[float] = None,
     log2fc_max: Optional[float] = None,
+    n_top_genes: Optional[int] = None,
     gene_symbols: Optional[str] = None,
 ) -> pd.DataFrame:
     """\
@@ -44,6 +45,8 @@ def rank_genes_groups_df(
         Minimum logfc to return.
     log2fc_max
         Maximum logfc to return.
+    n_top_genes
+        Maximum number of genes per group to return. 
     gene_symbols
         Column name in `.var` DataFrame that stores gene symbols. Specifying
         this will add that column to the returned dataframe.
@@ -73,6 +76,8 @@ def rank_genes_groups_df(
         d = d[d["logfoldchanges"] > log2fc_min]
     if log2fc_max is not None:
         d = d[d["logfoldchanges"] < log2fc_max]
+    if n_top_genes is not None:
+        d = d.groupby('group').head(n_top_genes)
     if gene_symbols is not None:
         d = d.join(adata.var[gene_symbols], on="names")
 

--- a/scanpy/get/get.py
+++ b/scanpy/get/get.py
@@ -46,7 +46,7 @@ def rank_genes_groups_df(
     log2fc_max
         Maximum logfc to return.
     n_top_genes
-        Maximum number of genes per group to return. 
+        Maximum number of genes per group to return.
     gene_symbols
         Column name in `.var` DataFrame that stores gene symbols. Specifying
         this will add that column to the returned dataframe.

--- a/scanpy/queries/_queries.py
+++ b/scanpy/queries/_queries.py
@@ -241,7 +241,7 @@ def enrich(
         `all_results=True` which returns all results including the non-significant ones.
     **kwargs
         All other keyword arguments are passed to `sc.get.rank_genes_groups_df`. E.g.
-        pval_cutoff, log2fc_min.
+        pval_cutoff, log2fc_min. pval_cutoff=0.5 by default.
 
     Returns
     -------
@@ -288,6 +288,7 @@ def _enrich_anndata(
     pval_cutoff: float = 0.05,
     log2fc_min: Optional[float] = None,
     log2fc_max: Optional[float] = None,
+    n_top_genes: Optional[int] = None,
     gene_symbols: Optional[str] = None,
     gprofiler_kwargs: Mapping[str, Any] = MappingProxyType({}),
 ) -> pd.DataFrame:
@@ -298,6 +299,7 @@ def _enrich_anndata(
         pval_cutoff=pval_cutoff,
         log2fc_min=log2fc_min,
         log2fc_max=log2fc_max,
+        n_top_genes=n_top_genes,
         gene_symbols=gene_symbols,
     )
     if gene_symbols is not None:

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -489,7 +489,10 @@ def test_rank_genes_groups_df():
     assert sc.get.rank_genes_groups_df(adata, "a", pval_cutoff=0.9).shape[0] == 1
     assert sc.get.rank_genes_groups_df(adata, "a", n_top_genes=2).shape[0] == 2
     assert sc.get.rank_genes_groups_df(adata, "a", n_top_genes=100).shape[0] == 3
-    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_max=0.1, n_top_genes=1).shape[0] == 1
+    assert (
+        sc.get.rank_genes_groups_df(adata, "a", log2fc_max=0.1, n_top_genes=1).shape[0]
+        == 1
+    )
     del adata.uns["rank_genes_groups"]
     sc.tl.rank_genes_groups(
         adata,
@@ -509,6 +512,11 @@ def test_rank_genes_groups_df():
     dedf3 = sc.get.rank_genes_groups_df(adata, group=None, key="different_key")
     assert 'a' in dedf3['group'].unique()
     assert 'b' in dedf3['group'].unique()
-    assert sc.get.rank_genes_groups_df(adata, group=None, key="different_key", n_top_genes=2).shape[0] == 4
+    assert (
+        sc.get.rank_genes_groups_df(
+            adata, group=None, key="different_key", n_top_genes=2
+        ).shape[0]
+        == 4
+    )
     adata.var_names.name = 'pr1388'
     sc.get.rank_genes_groups_df(adata, group=None, key="different_key")

--- a/scanpy/tests/test_get.py
+++ b/scanpy/tests/test_get.py
@@ -487,6 +487,9 @@ def test_rank_genes_groups_df():
     assert sc.get.rank_genes_groups_df(adata, "a", log2fc_max=0.1).shape[0] == 2
     assert sc.get.rank_genes_groups_df(adata, "a", log2fc_min=0.1).shape[0] == 1
     assert sc.get.rank_genes_groups_df(adata, "a", pval_cutoff=0.9).shape[0] == 1
+    assert sc.get.rank_genes_groups_df(adata, "a", n_top_genes=2).shape[0] == 2
+    assert sc.get.rank_genes_groups_df(adata, "a", n_top_genes=100).shape[0] == 3
+    assert sc.get.rank_genes_groups_df(adata, "a", log2fc_max=0.1, n_top_genes=1).shape[0] == 1
     del adata.uns["rank_genes_groups"]
     sc.tl.rank_genes_groups(
         adata,
@@ -506,5 +509,6 @@ def test_rank_genes_groups_df():
     dedf3 = sc.get.rank_genes_groups_df(adata, group=None, key="different_key")
     assert 'a' in dedf3['group'].unique()
     assert 'b' in dedf3['group'].unique()
+    assert sc.get.rank_genes_groups_df(adata, group=None, key="different_key", n_top_genes=2).shape[0] == 4
     adata.var_names.name = 'pr1388'
     sc.get.rank_genes_groups_df(adata, group=None, key="different_key")

--- a/scanpy/tests/test_queries.py
+++ b/scanpy/tests/test_queries.py
@@ -14,6 +14,11 @@ def test_enrich():
     de_genes = de.loc[lambda x: x["pvals_adj"] < 0.05, "names"]
     enrich_list = sc.queries.enrich(list(de_genes))
     assert (enrich_anndata == enrich_list).all().all()
+    
+    de_genes_top10 = de_genes[:10]
+    enrich_list_top10 = sc.queries.enrich(list(de_genes_top10))
+    enrich_anndata_top10 = sc.queries.enrich(pbmc, "1", n_top_genes=10)
+    assert (enrich_anndata == enrich_list).all().all()
 
     # theislab/scanpy/#1043
     sc.tl.filter_rank_genes_groups(pbmc, min_fold_change=1)

--- a/scanpy/tests/test_queries.py
+++ b/scanpy/tests/test_queries.py
@@ -14,11 +14,11 @@ def test_enrich():
     de_genes = de.loc[lambda x: x["pvals_adj"] < 0.05, "names"]
     enrich_list = sc.queries.enrich(list(de_genes))
     assert (enrich_anndata == enrich_list).all().all()
-    
+
     de_genes_top10 = de_genes[:10]
     enrich_list_top10 = sc.queries.enrich(list(de_genes_top10))
     enrich_anndata_top10 = sc.queries.enrich(pbmc, "1", n_top_genes=10)
-    assert (enrich_anndata == enrich_list).all().all()
+    assert (enrich_anndata_top10 == enrich_list_top10).all().all()
 
     # theislab/scanpy/#1043
     sc.tl.filter_rank_genes_groups(pbmc, min_fold_change=1)


### PR DESCRIPTION
This PR addresses https://scanpy.discourse.group/t/workflow-for-selecting-number-of-marker-genes-in-sc-queries-enrich/286

I wanted to have a simple interface to get the top n marker genes. Right now, `rank_genes_groups_df` only allows to threshold on logfc and pval, but especially for marker genes pval computation might not be statistically meaningful.

It adds the following kind of functionality:
```python
import scanpy as sc

adata = sc.datasets.pbmc68k_reduced()
sc.tl.rank_genes_groups(adata, 'louvain')

print(sc.get.rank_genes_groups_df(adata, "1", n_top_genes=2))
```
output is just the top 2 genes of the list.
```
    names     scores  logfoldchanges          pvals      pvals_adj
0  FCGR3A  47.682064        5.891937  3.275554e-141  3.579712e-139
1     FTL  45.653259        2.497682  9.003150e-208  6.887410e-205
```

it also works for multiple groups:

```python
print(sc.get.rank_genes_groups_df(adata, None, n_top_genes=2))
```
```
   group    names     scores  logfoldchanges          pvals      pvals_adj
0      0     CD3D  26.250046        3.859759   4.379061e-75   2.233321e-73
1      0     LDHB  21.207499        2.134979   1.488480e-67   5.993089e-66
2      1   FCGR3A  47.682064        5.891937  3.275554e-141  3.579712e-139
3      1      FTL  45.653259        2.497682  9.003150e-208  6.887410e-205
4      2      LYZ  38.981312        5.096991  1.697105e-172  1.298285e-169
5      2     CST3  34.241749        4.388617  1.448193e-149  5.539337e-147
6      3     NKG7  34.214161        6.089183   2.356710e-55   2.575547e-53
7      3     CTSW  24.584066        5.091688   2.026294e-39   9.118324e-38
8      4    CD79A  52.583344        6.626956   4.032974e-84   7.713062e-82
9      4    CD79B  32.102913        4.990217   1.958507e-51   1.872822e-49
10     5      FTL  26.084383        1.844273   1.236398e-74   2.364611e-72
11     5     LST1  25.554073        3.170759   5.653851e-81   4.325196e-78
12     6      LYZ  31.497107        4.328516  9.041131e-106  6.916466e-103
13     6     CST3  23.850258        3.281016   2.491629e-83   9.530482e-81
14     7     CST3  33.024582        4.195395  5.768439e-136  4.412856e-133
15     7      LYZ  31.264187        4.267053  9.712334e-101   1.485987e-98
16     8     PPIB  39.260998        3.990153   7.159966e-47   3.651583e-45
17     8     MZB1  33.305500        8.979518   7.611322e-26   1.878278e-24
18     9    STMN1  27.133045        5.936039   4.998127e-18   8.312102e-17
19     9    HMGB2  15.229477        5.016804   3.184879e-12   4.060720e-11
20    10  HNRNPA1  18.405415        2.040915   1.570832e-12   1.560632e-11
21    10     NPM1  14.230449        2.183721   3.424469e-10   3.046185e-09
```

This also extends to enrichment queries (this is what I wanted originally):

```python
sc.queries.enrich(adata, "1", n_top_genes=10)
```

For enrichment queries, I added to the doc string that a pval threshold of 0.05 is used. Previously, this was not obvious to me (and for cluster marker genes, this might not always be sensible).

I didn't add anything to `docs/release-notes/`, yet. I first wanted to get your opinion. Is it useful, what is still needed here?
