### PR TITLE
Inherit layer argument in _highly_variable_genes_single_batch when using sc.pp.highly_variable_genes

### DIFF
--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -455,6 +455,7 @@ def highly_variable_genes(
 
             hvg = _highly_variable_genes_single_batch(
                 adata_subset,
+                layer=layer,		
                 min_disp=min_disp,
                 max_disp=max_disp,
                 min_mean=min_mean,


### PR DESCRIPTION
Quite a simple addition meant to fix a bug when one works with specific layers.