### PR TITLE
Change dorothea-py and progeny-py to decoupler

### DIFF
--- a/docs/ecosystem.rst
+++ b/docs/ecosystem.rst
@@ -94,8 +94,7 @@ Annotation/ Enrichment Analysis
 
 Analyses using curated prior knowledge
 
-* `dorothea <https://github.com/saezlab/dorothea-py>`__ for Transcription Factor activities :small:`Institute for Computational Biomedicine, Heidelberg University`
-* `progeny <https://github.com/saezlab/progeny-py>`__ for footprint-based pathway activities :small:`Institute for Computational Biomedicine, Heidelberg University`
+* `decoupler <https://github.com/saezlab/decoupler-py>`__ is a collection of footprint enrichment methods that allows to infer transcription factor or pathway activities.   :small:`Institute for Computational Biomedicine, Heidelberg University`
 * `Cubé <https://github.com/connerlambden/Cube>`__ :small:`Harvard University`
 
     | Intuitive Nonparametric Gene Network Search Algorithm that learns from existing biological pathways & multiplicative gene interference patterns.


### PR DESCRIPTION
The packages dorothea-py and progeny-py are now deprecated, instead one should use decoupler (https://github.com/saezlab/decoupler-py). It contains both prior knowledge resources plus many more since it integrates the meta-resource OmniPath, and it also contains many footprint enrichment methods instead of a fixed one.
