### PR TITLE
Fix doc caching

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import datetime
 
 import matplotlib  # noqa
+from packaging.version import parse as parse_version
 
 # Don’t use tkinter agg when importing scanpy → … → matplotlib
 matplotlib.use('agg')
@@ -29,6 +30,12 @@ project = 'Scanpy'
 author = 'Scanpy development team'
 copyright = f'{datetime.now():%Y}, the Scanpy development team.'
 version = scanpy.__version__.replace('.dirty', '')
+
+# Bumping the version updates all docs, so don't do that
+if parse_version(version).is_devrelease:
+    parsed = parse_version(version)
+    version = f"{parsed.major}.{parsed.minor}.{parsed.micro}.dev"
+
 release = version
 
 # default settings
@@ -52,7 +59,11 @@ extensions = [
     'sphinx_autodoc_typehints',  # needs to be after napoleon
     # 'ipython_directive',
     # 'ipython_console_highlighting',
-    'scanpydoc',
+    # 'scanpydoc',  # scanpydoc.elegant_typehints causes full doc rebuilds
+    'scanpydoc.rtd_github_links',
+    'scanpydoc.theme',
+    'scanpydoc.definition_list_typed_field',
+    'scanpydoc.autosummary_generate_imported',
     *[p.stem for p in (HERE / 'extensions').glob('*.py')],
 ]
 
@@ -68,6 +79,8 @@ napoleon_use_param = True
 napoleon_custom_sections = [('Params', 'Parameters')]
 todo_include_todos = False
 api_dir = HERE / 'api'  # function_images
+
+typehints_defaults = 'braces'
 
 scanpy_tutorials_url = 'https://scanpy-tutorials.readthedocs.io/en/latest/'
 


### PR DESCRIPTION
Every time I build the docs locally, they do a complete rebuild. This is painfully slow (especially with our examples that run on each build) and really discourages editing the docs.

This is happening because the sphinx sees the config being modified. There are two causes of this:

* The version being set dynamically – at each commit the version string changes.
*  `scanpydoc.elegant_typehints` sets some properties of the config after it's loaded. E.g.:

```
updating environment: [config changed ('typehints_formatter')] 317 added, 0 changed, 0 removed
```

### Solution

Version being set dynamically does really add that much value for us, so I just removed that part of the version string.

`scanpydoc.elegant_typehints` does make the doc-strings nicer, but it is not worth a five minute build to update the docs. Ideally it can be implemented in a way that doesn't make sphinx think the config has changed, but I am disabling it until then.