### PR TITLE
Fix isinstance arg 2 must be a type error

### DIFF
--- a/docs/release-notes/1.9.1.md
+++ b/docs/release-notes/1.9.1.md
@@ -4,6 +4,7 @@
 ```
 
 ```{rubric} Bug fixes
+- {func}`~scanpy.pp.normalize_total` now works when Dask is not installed {pr}`2209` {smaller}`R Cannoodt`
 ```
 
 ```{rubric} Ecosystem

--- a/docs/release-notes/1.9.1.md
+++ b/docs/release-notes/1.9.1.md
@@ -4,8 +4,9 @@
 ```
 
 ```{rubric} Bug fixes
-- {func}`~scanpy.pp.normalize_total` now works when Dask is not installed {pr}`2209` {smaller}`R Cannoodt`
 ```
+
+- {func}`~scanpy.pp.normalize_total` works when Dask is not installed {pr}`2209` {smaller}`R Cannoodt`
 
 ```{rubric} Ecosystem
 ```

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -22,7 +22,7 @@ def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
     if issubclass(X.dtype.type, (int, np.integer)):
         X = X.astype(np.float32)  # TODO: Check if float64 should be used
-    if isinstance(counts, DaskArray):
+    if DaskArray is not None and isinstance(counts, DaskArray):
         counts_greater_than_zero = counts[counts > 0].compute_chunk_sizes()
     else:
         counts_greater_than_zero = counts[counts > 0]

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -9,7 +9,10 @@ from sklearn.utils import sparsefuncs
 try:
     from dask.array import Array as DaskArray
 except ImportError:
-    DaskArray = None
+
+    class DaskArray:
+        pass
+
 
 from scanpy import logging as logg
 from scanpy._compat import Literal
@@ -22,7 +25,7 @@ def _normalize_data(X, counts, after=None, copy=False):
     X = X.copy() if copy else X
     if issubclass(X.dtype.type, (int, np.integer)):
         X = X.astype(np.float32)  # TODO: Check if float64 should be used
-    if DaskArray is not None and isinstance(counts, DaskArray):
+    if isinstance(counts, DaskArray):
         counts_greater_than_zero = counts[counts > 0].compute_chunk_sizes()
     else:
         counts_greater_than_zero = counts[counts > 0]


### PR DESCRIPTION
When I call `sc.pp.normalize_total(adata)` on a system that does not have Dask installed, I get the following error:

```
AnnData object with n_obs × n_vars = 710 × 33538
    obs: 'filter_with_counts', 'scrublet_doublet_score', 'filter_with_scrublet'
    var: 'gene_ids', 'feature_types', 'genome', 'filter_with_counts'

  File "/viash_automount/home/rcannood/workspace/viash_temp//viash-run-normalize_total-ppLnd4", line 32, in <module>
    sc.pp.normalize_total(
  File "/usr/local/lib/python3.10/site-packages/scanpy/preprocessing/_normalization.py", line 200, in normalize_total
    adata, _normalize_data(X, counts_per_cell, target_sum), layer=layer
  File "/usr/local/lib/python3.10/site-packages/scanpy/preprocessing/_normalization.py", line 25, in _normalize_data
    if isinstance(counts, DaskArray):
TypeError: isinstance() arg 2 must be a type, a tuple of types, or a union
```

The error was introduced in [9cb915](https://github.com/scverse/scanpy/commit/9cb915bee5bfe11f62ffb37c0405656aae4574f2#diff-34d549afa2b23d0b2066964a51f698d918398edffd38379a73d02390e31ae5e8R24). 

This PR solves the issue by checking that DaskArray is not None, though I'm sure alternative solutions are also possible.