### PR TITLE
Bump matplotlib and pandas version deps

### DIFF
--- a/docs/release-notes/1.9.1.md
+++ b/docs/release-notes/1.9.1.md
@@ -7,6 +7,7 @@
 ```
 
 - {func}`~scanpy.pp.normalize_total` works when Dask is not installed {pr}`2209` {smaller}`R Cannoodt`
+- Fix embedding plots by bumping matplotlib dependency to version 3.4 {pr}`2212` {smaller}`I Virshup`
 
 ```{rubric} Ecosystem
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,10 +56,8 @@ dependencies = [
     "anndata>=0.7.4",
     # numpy needs a version due to #1320
     "numpy>=1.17.0",
-    # Matplotlib 3.1 causes an error in 3d scatter plots (https://github.com/matplotlib/matplotlib/issues/14298)
-    # But matplotlib 3.0 causes one in heatmaps
-    "matplotlib>=3.1.2",
-    "pandas>=0.21",
+    "matplotlib>=3.4",
+    "pandas>=1.0",
     "scipy>=1.4",
     "seaborn",
     "h5py>=3",


### PR DESCRIPTION
Fixes #2208

Bump matplotlib required version to 3.4, which has been out for a year.