### PR TITLE
Add CI job with minimal dependencies

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -2,9 +2,11 @@ trigger:
 - master
 
 variables:
+  python.version: '3.9'
   PIP_CACHE_DIR: $(Pipeline.Workspace)/.pip
   ANNDATA_DEV: no
   RUN_COVERAGE: no
+  TEST_EXTRA: 'test-full'
 
 jobs:
 - job: PyTest
@@ -12,10 +14,11 @@ jobs:
     vmImage: 'ubuntu-18.04'
   strategy:
     matrix:
-      Python39:
-        python.version: '3.9'
       Python37:
         python.version: '3.7'
+      Python39: {}
+      minimal_tests:
+        TEST_EXTRA: 'test'
       anndata_dev:
         python.version: '3.9'
         ANNDATA_DEV: yes
@@ -43,7 +46,7 @@ jobs:
   - script: |
       python -m pip install --upgrade pip
       pip install pytest-cov wheel
-      pip install .[dev,test,leiden,magic,harmony,scrublet,scanorama,skmisc]
+      pip install .[dev,$(TEST_EXTRA)]
     displayName: 'Install dependencies'
 
   - script: |

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
         python.version: '3.7'
       Python39: {}
       minimal_tests:
-        TEST_EXTRA: 'test'
+        TEST_EXTRA: 'test-min'
       anndata_dev:
         python.version: '3.9'
         ANNDATA_DEV: yes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ doc = [
     "scanpydoc[typehints]>=0.7.7",
     "typing_extensions; python_version < '3.8'",  # for `Literal`
     "myst-parser",
-    "scanpy[leiden]",
+    "scanpy[paga]",
 ]
 dev = [
     # getting the dev version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,11 +98,10 @@ test = [
 test-full = [
     "scanpy[test]",
     "scanpy[dask]",
-    "scanpy[zappy]",
     # tested algorithms
     "scanpy[leiden]",
     "scanpy[magic]",
-    "scanpy[seurat]",
+    "scanpy[skmisc]",
     "scanpy[harmony]",
     "scanpy[scanorama]",
     "scanpy[scrublet]",
@@ -128,14 +127,13 @@ louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]  # Louvain community detecti
 leiden = ["python-igraph", "leidenalg"]  # Leiden community detection
 bbknn = ["bbknn"]  # Batch balanced KNN (batch correction)
 magic = ["magic-impute>=2.0"]  # MAGIC imputation method
-seurat = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
+skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
 harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
 # Acceleration
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine
-zappy = ["zappy", "zarr"]  # Distributed array processing using Zarr
 # Backwards compat
 skmisc = ["scanpy[seurat]"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,21 +89,27 @@ scanpy = "scanpy.cli:console_main"
 test = [
     "pytest>=4.4",
     "pytest-nunit",
-    "dask[array]!=2.17.0",
-    "fsspec",
-    "zappy",
-    "zarr",
     "profimp",
-    # Test the metadata while this exists: https://github.com/takluyver/flit/issues/387
-    "flit_core",
+]
+test-full = [
+    "scanpy[test]",
+    "scanpy[speedups]",
+    "scanpy[io]",
+    # tested algorithms
+    "scanpy[leiden]",
+    "scanpy[magic]",
+    "scanpy[harmony]",
+    "scanpy[scrublet]",
+    "scanpy[scanorama]",
+    "scanpy[skmisc]",
 ]
 doc = [
     "sphinx>=4.4",
     "sphinx-rtd-theme>=1.0",
     "scanpydoc[typehints]>=0.7.7",
     "typing_extensions; python_version < '3.8'",  # for `Literal`
-    "python-igraph",
     "myst-parser",
+    "scanpy[leiden]",
 ]
 dev = [
     # getting the dev version
@@ -112,15 +118,23 @@ dev = [
     "black>=20.8b1",
     "docutils",
 ]
+# Algorithms
 louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]  # Louvain community detection
 leiden = ["python-igraph", "leidenalg"]  # Leiden community detection
 bbknn = ["bbknn"]  # Batch balanced KNN (batch correction)
-rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 magic = ["magic-impute>=2.0"]  # MAGIC imputation method
 skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
 harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
+# Acceleration
+rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
+speedups = ["scanpy[dask]", "scanpy[zarr]"]  # all CPU based speedups
+dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine
+zappy = ["zappy", "scanpy[zarr]"]  # Distributed array processing using Zarr
+# Optional I/O formats
+io = ["scanpy[zarr]"]  # all optional I/O formats
+zarr = ["zarr"]  # Support for the zarr data format
 
 [tool.flit.sdist]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,6 @@ requires = [
     "setuptools_scm",
     "tomli",
     "importlib_metadata>=0.7; python_version < '3.8'",
-    # setup.py stuff
-    "packaging",
 ]
 
 [project]
@@ -95,13 +93,7 @@ test-full = [
     "scanpy[test]",
     "scanpy[speedups]",
     "scanpy[io]",
-    # tested algorithms
-    "scanpy[leiden]",
-    "scanpy[magic]",
-    "scanpy[harmony]",
-    "scanpy[scrublet]",
-    "scanpy[scanorama]",
-    "scanpy[skmisc]",
+    "scanpy[algorithms]",
 ]
 doc = [
     "sphinx>=4.4",
@@ -119,6 +111,19 @@ dev = [
     "docutils",
 ]
 # Algorithms
+algorithms = [  # tested algorithms
+    "scanpy[leiden]",
+    "scanpy[magic]",
+    "scanpy[skmisc]",
+    "scanpy[harmony]",
+    "scanpy[scanorama]",
+    "scanpy[scrublet]",
+]
+algorithms-full = [
+    "scanpy[algorithms]",
+    "scanpy[louvain]",
+    "scanpy[bbknn]",
+]
 louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]  # Louvain community detection
 leiden = ["python-igraph", "leidenalg"]  # Leiden community detection
 bbknn = ["bbknn"]  # Batch balanced KNN (batch correction)
@@ -128,8 +133,9 @@ harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
 # Acceleration
+speedups = ["scanpy[dask]", "scanpy[zappy]"]  # all CPU based speedups
+speedups-full = ["scanpy[speedups]", "scanpy[rapids]"]
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
-speedups = ["scanpy[dask]", "scanpy[zarr]"]  # all CPU based speedups
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine
 zappy = ["zappy", "scanpy[zarr]"]  # Distributed array processing using Zarr
 # Optional I/O formats

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,16 +84,28 @@ Home-page = "https://scanpy.org"
 scanpy = "scanpy.cli:console_main"
 
 [project.optional-dependencies]
-test = [
+test-min = [
     "pytest>=4.4",
     "pytest-nunit",
     "profimp",
 ]
+test = [
+    "scanpy[test-min]",
+    # Optional but important dependencies
+    "scanpy[leiden]",
+    "zarr",
+]
 test-full = [
     "scanpy[test]",
-    "scanpy[speedups]",
-    "scanpy[io]",
-    "scanpy[algorithms]",
+    "scanpy[dask]",
+    "scanpy[zappy]",
+    # tested algorithms
+    "scanpy[leiden]",
+    "scanpy[magic]",
+    "scanpy[skmisc]",
+    "scanpy[harmony]",
+    "scanpy[scanorama]",
+    "scanpy[scrublet]",
 ]
 doc = [
     "sphinx>=4.4",
@@ -111,36 +123,21 @@ dev = [
     "docutils",
 ]
 # Algorithms
-algorithms = [  # tested algorithms
-    "scanpy[leiden]",
-    "scanpy[magic]",
-    "scanpy[skmisc]",
-    "scanpy[harmony]",
-    "scanpy[scanorama]",
-    "scanpy[scrublet]",
-]
-algorithms-full = [
-    "scanpy[algorithms]",
-    "scanpy[louvain]",
-    "scanpy[bbknn]",
-]
+paga = ["python-igraph"]
 louvain = ["python-igraph", "louvain>=0.6,!=0.6.2"]  # Louvain community detection
 leiden = ["python-igraph", "leidenalg"]  # Leiden community detection
 bbknn = ["bbknn"]  # Batch balanced KNN (batch correction)
 magic = ["magic-impute>=2.0"]  # MAGIC imputation method
-skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
+seurat = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
 harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
 # Acceleration
-speedups = ["scanpy[dask]", "scanpy[zappy]"]  # all CPU based speedups
-speedups-full = ["scanpy[speedups]", "scanpy[rapids]"]
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine
-zappy = ["zappy", "scanpy[zarr]"]  # Distributed array processing using Zarr
-# Optional I/O formats
-io = ["scanpy[zarr]"]  # all optional I/O formats
-zarr = ["zarr"]  # Support for the zarr data format
+zappy = ["zappy", "zarr"]  # Distributed array processing using Zarr
+# Backwards compat
+skmisc = ["scanpy[seurat]"]
 
 [tool.flit.sdist]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,8 +134,6 @@ scrublet = ["scrublet"]  # Doublet detection
 # Acceleration
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine
-# Backwards compat
-skmisc = ["scanpy[seurat]"]
 
 [tool.flit.sdist]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,10 +94,10 @@ test = [
     # Optional but important dependencies
     "scanpy[leiden]",
     "zarr",
+    "scanpy[dask]",
 ]
 test-full = [
     "scanpy[test]",
-    "scanpy[dask]",
     # tested algorithms
     "scanpy[leiden]",
     "scanpy[magic]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,7 +102,7 @@ test-full = [
     # tested algorithms
     "scanpy[leiden]",
     "scanpy[magic]",
-    "scanpy[skmisc]",
+    "scanpy[seurat]",
     "scanpy[harmony]",
     "scanpy[scanorama]",
     "scanpy[scrublet]",

--- a/scanpy/tests/external/test_scanorama_integrate.py
+++ b/scanpy/tests/external/test_scanorama_integrate.py
@@ -1,7 +1,12 @@
+from importlib.util import find_spec
+
+import pytest
+
 import scanpy as sc
 import scanpy.external as sce
 
 
+@pytest.mark.skipif(not find_spec("scanorama"), reason="needs module `scanorama`")
 def test_scanorama_integrate():
     """
     Test that Scanorama integration works.

--- a/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
+++ b/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
@@ -2,7 +2,7 @@
 # Hematopoiesis: trace myeloid and erythroid differentiation for data of [Paul *et al.* (2015)](http://doi.org/10.1016/j.cell.2015.11.013).
 #
 # This is the subsampled notebook for testing.
-
+from importlib.util import find_spec
 from pathlib import Path
 
 import numpy as np
@@ -19,6 +19,10 @@ ROOT = HERE / '_images_paga_paul15_subsampled'
 FIGS = HERE / 'figures'
 
 
+@pytest.mark.skipif(
+    not find_spec("igraph"),
+    reason="needs module `igraph` (`pip install python-igraph`)",
+)
 def test_paga_paul15_subsampled(image_comparer, plt):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=25)
 

--- a/scanpy/tests/notebooks/test_pbmc3k.py
+++ b/scanpy/tests/notebooks/test_pbmc3k.py
@@ -9,7 +9,7 @@
 # The data consists in *3k PBMCs from a Healthy Donor* and is freely available from 10x Genomics
 # ([here](http://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz)
 # from this [webpage](https://support.10xgenomics.com/single-cell-gene-expression/datasets/1.1.0/pbmc3k)).
-
+from importlib.util import find_spec
 from pathlib import Path
 
 import numpy as np
@@ -27,6 +27,7 @@ ROOT = HERE / 'pbmc3k_images'
 FIGS = HERE / 'figures'
 
 
+@pytest.mark.skipif(not find_spec("leidenalg"), reason="needs module `leidenalg`")
 def test_pbmc3k(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=20)
 

--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -53,9 +53,19 @@ def test_umap_init_dtype():
 
 
 needs_fa2 = pytest.mark.skipif(not find_spec("fa2"), reason="needs module `fa2`")
+needs_igraph = pytest.mark.skipif(
+    not find_spec("igraph"),
+    reason="needs module `igraph` (`pip install python-igraph`)",
+)
 
 
-@pytest.mark.parametrize("layout", [pytest.param("fa", marks=needs_fa2), "fr"])
+@pytest.mark.parametrize(
+    "layout",
+    [
+        pytest.param("fa", marks=needs_fa2),
+        pytest.param("fr", marks=needs_igraph),
+    ],
+)
 def test_umap_init_paga(layout):
     pbmc = pbmc68k_reduced()
     pbmc = pbmc[:100, :].copy()

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import pytest
 import pandas as pd
 import numpy as np
@@ -15,6 +17,10 @@ from scanpy.tests._data._cached_datasets import pbmc3k, pbmc68k_reduced
 FILE = Path(__file__).parent / Path('_scripts/seurat_hvg.csv')
 FILE_V3 = Path(__file__).parent / Path('_scripts/seurat_hvg_v3.csv.gz')
 FILE_V3_BATCH = Path(__file__).parent / Path('_scripts/seurat_hvg_v3_batch.csv')
+
+needs_skmisc = pytest.mark.skipif(
+    not find_spec('skmisc'), reason="needs module `skmisc`"
+)
 
 
 def test_highly_variable_genes_basic():
@@ -311,6 +317,7 @@ def test_higly_variable_genes_compare_to_seurat():
     )
 
 
+@needs_skmisc
 def test_higly_variable_genes_compare_to_seurat_v3():
     seurat_hvg_info = pd.read_csv(
         FILE_V3, sep=' ', dtype={"variances_norm": np.float64}
@@ -466,9 +473,7 @@ def test_highly_variable_genes_batches():
     assert np.all(np.isin(colnames, hvg1.columns))
 
 
-from scanpy.preprocessing._utils import _get_mean_var
-
-
+@needs_skmisc
 def test_seurat_v3_mean_var_output_with_batchkey():
     pbmc = pbmc3k()
     pbmc.var_names_make_unique()

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -1,3 +1,5 @@
+from importlib.util import find_spec
+
 import scanpy as sc
 import numpy as np
 import pytest
@@ -30,6 +32,10 @@ def test_neighbors_key_added(adata):
 
 
 # test functions with neighbors_key and obsp
+@pytest.mark.skipif(
+    not find_spec("igraph"),
+    reason="needs module `igraph` (`pip install python-igraph`)",
+)
 @pytest.mark.parametrize('field', ['neighbors_key', 'obsp'])
 def test_neighbors_key_obsp(adata, field):
     adata1 = adata.copy()

--- a/scanpy/tests/test_package_structure.py
+++ b/scanpy/tests/test_package_structure.py
@@ -1,6 +1,7 @@
 import email
 import inspect
 import os
+from importlib.util import find_spec
 from types import FunctionType
 from pathlib import Path
 
@@ -54,13 +55,3 @@ The displayed line is under-indented.
         _, lineno = inspect.getsourcelines(f)
         text = f">{lines[broken[0]]}<"
         raise SyntaxError(msg, (filename, lineno, 2, text))
-
-
-def test_metadata(tmp_path, in_project_dir):
-    import flit_core.buildapi
-
-    flit_core.buildapi.prepare_metadata_for_build_wheel(tmp_path)
-
-    metadata_path = next(tmp_path.glob('*.dist-info')) / 'METADATA'
-    metadata = email.message_from_bytes(metadata_path.read_bytes())
-    assert not metadata.defects

--- a/scanpy/tests/test_paga.py
+++ b/scanpy/tests/test_paga.py
@@ -1,4 +1,5 @@
 from functools import partial
+from importlib.util import find_spec
 from pathlib import Path
 
 from matplotlib import cm
@@ -13,6 +14,12 @@ ROOT = HERE / '_images'
 FIGS = HERE / 'figures'
 
 
+needs_igraph = pytest.mark.skipif(
+    not find_spec("igraph"),
+    reason="needs module `igraph` (`pip install python-igraph`)",
+)
+
+
 @pytest.fixture(scope="module")
 def pbmc():
     pbmc = pbmc68k_reduced()
@@ -21,6 +28,7 @@ def pbmc():
     return pbmc
 
 
+@needs_igraph
 @pytest.mark.parametrize(
     "test_id,func",
     [
@@ -50,6 +58,7 @@ def test_paga_plots(image_comparer, pbmc, test_id, func):
     save_and_compare_images(test_id)
 
 
+@needs_igraph
 def test_paga_pie(image_comparer, pbmc):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=30)
 
@@ -63,6 +72,7 @@ def test_paga_pie(image_comparer, pbmc):
     save_and_compare_images('master_paga_pie')
 
 
+@needs_igraph
 def test_paga_path(image_comparer, pbmc):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
 
@@ -77,6 +87,7 @@ def test_paga_path(image_comparer, pbmc):
     save_and_compare_images('master_paga_path')
 
 
+@needs_igraph
 def test_paga_compare(image_comparer):
     # Tests that https://github.com/scverse/scanpy/issues/1887 is fixed
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
@@ -89,6 +100,7 @@ def test_paga_compare(image_comparer):
     save_and_compare_images('master_paga_compare_pbmc3k')
 
 
+@needs_igraph
 def test_paga_positions_reproducible():
     """Check exact reproducibility and effect of random_state on paga positions"""
     # https://github.com/scverse/scanpy/issues/1859

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -1,6 +1,6 @@
 from functools import partial
+from importlib.util import find_spec
 from pathlib import Path
-import sys
 from itertools import repeat, chain, combinations
 
 import pytest
@@ -18,7 +18,6 @@ setup()
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import seaborn as sns
 import numpy as np
 import pandas as pd
@@ -40,6 +39,7 @@ sc.set_figure_params(dpi=40, color_map='viridis')
 # the ./figures folder to ./_images/
 
 
+@pytest.mark.skipif(not find_spec("leidenalg"), reason="needs module `leidenalg`")
 def test_heatmap(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
 
@@ -1531,6 +1531,7 @@ def test_filter_rank_genes_groups_plots(tmpdir, plot, check_same_image):
     check_same_image(pth_a, pth_b, tol=1)
 
 
+@pytest.mark.skipif(not find_spec("scrublet"), reason="needs module `scrublet`")
 def test_scrublet_plots(image_comparer, plt):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=30)
 

--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -83,8 +83,8 @@ class TestPreprocessingDistributed:
         npt.assert_allclose(result, adata.X)
 
     def test_write_zarr(self, adata, adata_dist):
-        import dask.array as da
-        import zarr
+        da = pytest.importorskip("dask.array")
+        zarr = pytest.importorskip("zarr")
 
         log1p(adata_dist)
         temp_store = zarr.TempStore()


### PR DESCRIPTION
Fixes #2211

I’ll first try with all removed. I expect the min_tests run to fail. Seeing what fails,

- If it’s not much, I’ll just refactor the fixtures a bit and so on
- Else I’ll move algorithms to the `test` extra. Then we can merge this PR and over time refactor our tests so more and more extras go from `tests` to `tests-full`

@ivirshup do you like the collection extras’ names (`io`, `speedups`, `algorithms`)? Should we add an extra named `all` that installs all the `-full` extras?