### PR TITLE
Make default for percent_top more permissive

### DIFF
--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -48,7 +48,7 @@ def describe_obs(
     expr_type: str = "counts",
     var_type: str = "genes",
     qc_vars: Collection[str] = (),
-    percent_top: Optional[Collection[int]] = (50, 100, 200, 500),
+    percent_top: Optional[Collection[int]] = None,
     layer: Optional[str] = None,
     use_raw: bool = False,
     log1p: Optional[str] = True,
@@ -85,6 +85,8 @@ def describe_obs(
 
     {doc_obs_qc_returns}
     """
+    if percent_top is None:
+        percent_top = tuple(x for x in (50, 100, 200, 500) if x <= adata.shape[1])
     if parallel is not None:
         warn(
             "Argument `parallel` is deprecated, and currently has no effect.",
@@ -229,7 +231,7 @@ def calculate_qc_metrics(
     expr_type: str = "counts",
     var_type: str = "genes",
     qc_vars: Collection[str] = (),
-    percent_top: Optional[Collection[int]] = (50, 100, 200, 500),
+    percent_top: Optional[Collection[int]] = None,
     layer: Optional[str] = None,
     use_raw: bool = False,
     inplace: bool = False,
@@ -291,6 +293,8 @@ def calculate_qc_metrics(
 
         sns.histplot(pbmc.obs["pct_counts_mito"])
     """
+    if percent_top is None:
+        percent_top = tuple(x for x in (50, 100, 200, 500) if x <= adata.shape[1])
     if parallel is not None:
         warn(
             "Argument `parallel` is deprecated, and currently has no effect.",


### PR DESCRIPTION
When running QC on a single-cell dataset with less than 500 features and leaving argument defaults, an index error is raised. This is because the default for `percent_top` assumes genomics data with 500+ genes. Such a number is not necessarily common for other OMICS, like metabolomics (typically 150-300).

```python
adata = anndata.AnnData(np.random.random(100**2).reshape((100, 100)))
sc.preprocessing._qc.describe_obs(adata)

Traceback (most recent call last):
  File "~/conda/lib/python3.8/site-packages/IPython/core/interactiveshell.py", line 3398, in run_code
    exec(code_obj, self.user_global_ns, self.user_ns)
  File "<ipython-input-61-7293f2baee95>", line 1, in <cell line: 1>
    sc.preprocessing._qc.describe_obs(adata)
  File "~/conda/lib/python3.8/site-packages/scanpy/preprocessing/_qc.py", line 116, in describe_obs
    proportions = top_segment_proportions(X, percent_top)
  File "~/conda/lib/python3.8/site-packages/scanpy/preprocessing/_qc.py", line 397, in top_segment_proportions
    raise IndexError("Positions outside range of features.")
IndexError: Positions outside range of features.
```
(scanpy==1.9.1)

In my case, I can not directly specify `percent_top`, because the ScanPy QC is called from a third-party library, which leaves all defaults. Ideally, defaults for unspecified arguments would be compatible with all inputs that the user specifies explicitly.

I have some questions:
- Now as the signature's default is None, is there a way to still make the signature in the documentation show the actual default? Or should I also change the docstring's Params section?
- I chose to have the `if` condition in argument order at the top (before `parallel`). Tell me if you prefer me to merge it with the percent_top condition in the middle (line 116), or to refactor the tuple out as a constant.