### PR TITLE
add scalex[Xiong22 Nature Communications] to scanpy.external.pp

### DIFF
--- a/docs/external.md
+++ b/docs/external.md
@@ -33,6 +33,7 @@ If the tool already uses `scanpy` or `anndata`, it may fit better in the {doc}`e
    pp.harmony_integrate
    pp.mnn_correct
    pp.scanorama_integrate
+   pp.scalex_integrate
 
 ```
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,5 +1,8 @@
 References
 ----------
+.. [Xiong22] Xiong *et al.* (2022)
+   Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space
+   `Nature Communications <https://www.nature.com/articles/s41467-022-33758-z>`__.
 
 .. [Amid19] Amid & Warmuth (2019),
    *TriMap: Large-scale Dimensionality Reduction Using Triplets*,

--- a/scanpy/external/pp/__init__.py
+++ b/scanpy/external/pp/__init__.py
@@ -6,3 +6,4 @@ from ._magic import magic
 from ._scanorama_integrate import scanorama_integrate
 from ._hashsolo import hashsolo
 from ._scrublet import scrublet, scrublet_simulate_doublets
+from ._scalex_integrate import scalex_integrate

--- a/scanpy/external/pp/_scalex_integrate.py
+++ b/scanpy/external/pp/_scalex_integrate.py
@@ -1,0 +1,72 @@
+from typing import Optional
+
+def scalex_integrate(
+    adata, 
+    batch_categories=None,
+    batch_name='batch',
+    outdir='scalex_output/',
+    **kwargs
+    ):
+    """\
+    Use scalex to integrate [Xiong22]_ to online integrate different experiments.
+
+    SCALEX [Xiong22]_ is an online integration algorithm for integrating single-cell data from multiple experiments 
+    and projecting new incoming datasets onto the existing cell-embedding space. This function uses the SCALEX from 
+    ``scalex`` python package. The input to SCALEX can be filename or AnnData object, or list, or mixed of them. 
+    SCALEX will do the preprocess if given the raw data, otherwise should set the ``processsed=True``
+    
+    Parameters
+    ----------
+    adata
+        A path list of AnnData matrices to concatenate with. Each matrix is referred to as a 'batch'.
+    batch_categories
+        Categories for the batch annotation. By default, use increasing numbers.
+    batch_name
+        Use this annotation in obs as batches for training model. Default: 'batch'.
+    outdir
+        output AnnData will be saved as ``adata.h5ad`` in outdir if outdir is not None, default is None
+
+
+    
+    Returns
+    -------
+    The output folder contains:
+    adata.h5ad
+        The AnnData matrice after batch effects removal. The low-dimensional representation of the data is stored at adata.obsm['latent'].
+    checkpoint
+        model.pt contains the variables of the model and config.pt contains the parameters of the model.
+    log.txt
+        Records raw data information, filter conditions, model parameters etc.
+    umap.pdf 
+        UMAP plot for visualization.
+
+
+    Example
+    -------
+    >>> import scanpy as sc
+    >>> import scapy.external as sce
+    >>> adata = sc.datasets.pbmc3k()
+
+    We now arbitrarily assign a batch metadata variable to each cell
+    for the sake of example, but during real usage there would already
+    be a column in ``adata.obs`` giving the experiment each cell came
+    from.
+
+    >>> adata.obs['batch] = 1350*['a'] + 1350*['b']
+    >>> sce.pp.scalex_integrate(adata)
+
+    >>> 'X_scalex_umap' as well as 'X_umap' will in adata.obsm
+
+    if adata has been preprocessed, please set the ``processed = True``
+    >>> sce.pp.scalex_integrate(adata, processed=True)
+
+    if use other meta information as ``batch``, e.g. sample_id
+    >>> sce.pp.scalex_integrate(adata, batch_name = 'sample_id') 
+    """
+    try:
+        import scalex
+    except ImportError:
+        raise ImportError("\nplease install scalex: \n\n\tpip install scalex")
+
+    scalex.SCALEX(adata, batch_categories, batch_name=batch_name, outdir=outdir, **kwargs)
+


### PR DESCRIPTION
Hi, 
we want to add SCALEX, an online integration method that integrate different single-cell experiments including scRNA-seq and scATAC-seq, which also enable accurate projecting new incoming datasets onto the existing cell space. This method is published on Nature Communications. SCALEX is developed based-on scanpy. We appreciate and will be honored to contribute to the scanpy community.

Thank you!
Lei 

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
