### PR TITLE
add scalex[Xiong22 Nature Communications] to scanpy.external.pp

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -102,6 +102,7 @@ intersphinx_mapping = dict(
     seaborn=('https://seaborn.pydata.org/', None),
     sklearn=('https://scikit-learn.org/stable/', None),
     scanpy_tutorials=(scanpy_tutorials_url, None),
+    scalex=('https://scalex.readthedocs.io/en/latest/', None),
 )
 
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -94,6 +94,7 @@ Interactive manifold viewers.
 ### Data integration
 
 - [scanaroma](https://github.com/brianhie/scanorama) {small}`MIT`
+- [scalex](https://github.com/jsxlei/SCALEX) {small}`Tsinghua`
 
 ### Modeling perturbations
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -47,6 +47,14 @@ Interactive manifold viewers.
 
   > PASTE is a computational method to align and integrate spatial transcriptomics data across adjacent tissue slices by leveraging both gene expression similarity and spatial distances between spots.
 
+
+### Single-cell ATAC-seq
+
+- [SCALE](https://github.com/jsxlei/SCALE) {small}`Tsinghua`
+
+  > single-cell ATAC clustering
+  > single-cell imputation
+
 ### Multimodal integration
 
 - [MUON](https://muon.readthedocs.io/en/latest/) and [MuData](https://mudata.readthedocs.io/en/latest/) {small}`EMBL/ DKFZ`

--- a/docs/external.md
+++ b/docs/external.md
@@ -59,6 +59,18 @@ Note that the fundamental limitations of imputation are still under [debate](htt
 
    pp.dca
    pp.magic
+   pp.scale
+
+```
+
+
+### scATAC-seq
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   pp.scale
 
 ```
 

--- a/docs/external.md
+++ b/docs/external.md
@@ -33,6 +33,7 @@ If the tool already uses `scanpy` or `anndata`, it may fit better in the {doc}`e
    pp.harmony_integrate
    pp.mnn_correct
    pp.scanorama_integrate
+   pp.scalex_integrate
 
 ```
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,7 +1,7 @@
 References
 ----------
-.. [Xiong22] Xiong *et al.* (2022)
-   Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space
+.. [Xiong22] Xiong *et al.* (2022),
+   *Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space*,
    `Nature Communications <https://www.nature.com/articles/s41467-022-33758-z>`__.
 
 .. [Amid19] Amid & Warmuth (2019),

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,5 +1,10 @@
 References
 ----------
+.. [Xiong19] Xiong *et al.* (2019),
+   *SCALE method for single-cell ATAC-seq analysis via latent feature extraction*,
+   `Nature Communications <https://www.nature.com/articles/s41467-019-12630-7>`__.
+
+
 .. [Xiong22] Xiong *et al.* (2022),
    *Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space*,
    `Nature Communications <https://www.nature.com/articles/s41467-022-33758-z>`__.

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -1,5 +1,8 @@
 References
 ----------
+.. [Xiong22] Xiong *et al.* (2022)
+   Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space
+   `Nature Communications <https://www.nature.com/articles/s41467-022-33758-z>`__.
 
 .. [Amid19] Amid & Warmuth (2019),
    *TriMap: Large-scale Dimensionality Reduction Using Triplets*,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ test-full = [
     "scanpy[harmony]",
     "scanpy[scanorama]",
     "scanpy[scrublet]",
+    "scanpy[scalex]",
 ]
 doc = [
     "sphinx>=4.4",
@@ -132,6 +133,7 @@ skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
 harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
+scalex = ["scalex"] # SCALEX online integration
 # Acceleration
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ test-full = [
     "scanpy[scanorama]",
     "scanpy[scrublet]",
     "scanpy[scalex]",
+    "scanpy[scale]",
 ]
 doc = [
     "sphinx>=4.4",
@@ -134,6 +135,8 @@ harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
 scalex = ["scalex"] # SCALEX online integration
+scale = ["scale"] # single-cell ATAC-seq clustering and imputation
+
 # Acceleration
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine

--- a/scanpy/external/pp/__init__.py
+++ b/scanpy/external/pp/__init__.py
@@ -6,3 +6,4 @@ from ._magic import magic
 from ._scanorama_integrate import scanorama_integrate
 from ._hashsolo import hashsolo
 from ._scrublet import scrublet, scrublet_simulate_doublets
+from ._scalex_integrate import scalex_integrate

--- a/scanpy/external/pp/__init__.py
+++ b/scanpy/external/pp/__init__.py
@@ -7,3 +7,4 @@ from ._scanorama_integrate import scanorama_integrate
 from ._hashsolo import hashsolo
 from ._scrublet import scrublet, scrublet_simulate_doublets
 from ._scalex_integrate import scalex_integrate
+from ._scale import scale

--- a/scanpy/external/pp/_scale.py
+++ b/scanpy/external/pp/_scale.py
@@ -1,0 +1,136 @@
+from typing import Optional, Union, List
+from anndata import AnnData
+
+
+def scale(
+    data_list: Union[str, List],
+    n_centroids: int = 30,
+    outdir: bool = None,
+    verbose: bool = False,
+    pretrain: str = None,
+    lr: float = 0.0002,
+    batch_size: int = 64,
+    gpu: int = 0,
+    seed: int = 18,
+    encode_dim: List = [1024, 128],
+    decode_dim: List = [],
+    latent: int = 10,
+    min_peaks: int = 100,
+    min_cells: Union[float, int] = 3,
+    n_feature: int = 50000,
+    log_transform: bool = False,
+    max_iter: int = 30000,
+    weight_decay: float = 5e-4,
+    impute: bool = False,
+    binary: bool = False,
+    embed: str = 'UMAP',
+    reference: str = 'cell_type',
+    cluster_method: str = 'leiden',
+) -> AnnData:
+    """
+    Use SCALE [Xiong19]_ to cluster and impute on scATAC-seq
+
+    SCALE [Xiong19]_ is a deeplearning tool combining GMM with VAE for single-cell ATAC-seq analysis (visualization, clustering, imputation, downstream analysis for celltype-specific TFs
+
+    Parameters
+    ----------
+    data_list
+        A path of input data, could be AnnData, or file in format of h5ad, txt, csv or dir containing mtx file
+    n_centroids
+        Initial n_centroids, default is 30
+    outdir
+        output of dir where results will be saved, if None, will return an AnnData object
+    verbose
+        Verbosity, default is False
+    pretrain
+        Use the pretrained model to project on new data or repeat results
+    lr
+        learning rate for training model
+    batch_size
+        batch_size of one iteration for training model
+    gpu
+        Use id of gpu device
+    seed
+        Random seed
+    encode_dim
+        encode architecture
+    decode_dim
+        decode architecture
+    latent
+        dimensions of latent
+    min_peaks
+        min peaks for filtering cells
+    min_cells
+        min cells for filtering peaks, will be ratio if small than 1, default is 3
+    n_feature
+        number of the most highly variable peaks will be used for training model
+    log_transform
+        log transform the data, recommended for scRNA-seq data
+    max_iter
+        Max iteration for training model
+    weight_decay
+        weight decay for training model
+    impute
+        output the imputed data in adata if true
+    binary
+        Change the imputed data to binary format
+    embed
+        Embedding method, UMAP or tSNE, default is UMAP
+    reference
+        reference annotations for evaluation, default is cell_type
+    cluster_method
+        cluster method, default is Leiden
+    )->AnnData:
+
+
+    Returns
+    -------
+    adata
+        An AnnData object
+
+
+    Example
+    -------
+    >>> import scanpy as sc
+    >>> import scanpy.external as sce
+    >>> adata = sc.read('Your/scATAC/Data')
+    >>> adata = sce.pp.scale(adata)
+
+    if want imputed data
+
+    >>> adata = sce.pp.scale(adata, impute=True)
+
+    imputed data will be saved in adata.obsm['impute']
+    binary version of imputed data will be saved in adata.obsm['binary']
+    """
+
+    try:
+        import scale
+    except ImportError:
+        raise ImportError("\nplease install scale: \n\n\tpip install scale")
+
+    return scale.SCALE_function(
+        data_list,
+        n_centroids=n_centroids,
+        outdir=outdir,
+        verbose=verbose,
+        pretrain=pretrain,
+        lr=lr,
+        batch_size=batch_size,
+        gpu=gpu,
+        seed=seed,
+        encode_dim=encode_dim,
+        decode_dim=decode_dim,
+        latent=latent,
+        min_peaks=min_peaks,
+        min_cells=min_cells,
+        n_feature=n_feature,
+        log_transform=log_transform,
+        max_iter=max_iter,
+        weight_decay=weight_decay,
+        impute=impute,
+        binary=binary,
+        embed=embed,
+        reference=reference,
+        cluster_method=cluster_method,
+    )

--- a/scanpy/external/pp/_scalex_integrate.py
+++ b/scanpy/external/pp/_scalex_integrate.py
@@ -97,7 +97,7 @@ def scalex_integrate(
     Example
     -------
     >>> import scanpy as sc
-    >>> import scapy.external as sce
+    >>> import scanpy.external as sce
     >>> adata = sc.datasets.pbmc3k()
 
     We now arbitrarily assign a batch metadata variable to each cell
@@ -117,7 +117,7 @@ def scalex_integrate(
 
     if use other meta information as ``batch``, e.g. sample_id
 
-    >>> sce.pp.scalex_integrate(adata, batch_name = 'sample_id')
+    >>> adata = sce.pp.scalex_integrate(adata, batch_name = 'sample_id')
     """
 
     try:

--- a/scanpy/external/pp/_scalex_integrate.py
+++ b/scanpy/external/pp/_scalex_integrate.py
@@ -1,0 +1,72 @@
+from typing import Optional
+
+def scalex_integrate(
+    adata, 
+    batch_categories=None,
+    batch_name='batch',
+    outdir='scalex_output/',
+    **kwargs
+    ):
+    """\
+    Use scalex to integrate [Xiong22]_ to online integrate different experiments.
+
+    SCALEX [Xiong22]_ is an online integration algorithm for integrating single-cell data from multiple experiments 
+    and projecting new incoming datasets onto the existing cell-embedding space. This function uses the SCALEX from 
+    ``scalex`` python package. The input to SCALEX can be filename or AnnData object, or list, or mixed of them. 
+    SCALEX will do the preprocess if given the raw data, otherwise should set the ``processsed=True``
+    
+    Parameters
+    ----------
+    adata
+        A path list of AnnData matrices to concatenate with. Each matrix is referred to as a 'batch'.
+    batch_categories
+        Categories for the batch annotation. By default, use increasing numbers.
+    batch_name
+        Use this annotation in obs as batches for training model. Default: 'batch'.
+    outdir
+        output AnnData will be saved as ``adata.h5ad`` in outdir if outdir is not None, default is None
+
+
+    
+    Returns
+    -------
+    The output folder contains:
+    adata.h5ad
+        The AnnData matrice after batch effects removal. The low-dimensional representation of the data is stored at adata.obsm['latent'].
+    checkpoint
+        model.pt contains the variables of the model and config.pt contains the parameters of the model.
+    log.txt
+        Records raw data information, filter conditions, model parameters etc.
+    umap.pdf 
+        UMAP plot for visualization.
+
+
+    Example
+    -------
+    >>> import scanpy as sc
+    >>> import scapy.external as sce
+    >>> adata = sc.datasets.pbmc3k()
+
+    We now arbitrarily assign a batch metadata variable to each cell
+    for the sake of example, but during real usage there would already
+    be a column in ``adata.obs`` giving the experiment each cell came
+    from.
+
+    >>> adata.obs['batch] = 1350*['a'] + 1350*['b']
+    >>> sce.pp.scalex_integrate(adata)
+
+    >>> 'X_scalex_umap' as well as 'X_umap' will in adata.obsm
+
+    if adata has been preprocessed, please set the ``processed = True``
+    >>> sce.pp.scalex_integrate(adata, processed=True)
+
+    if use other meta information as ``batch``, e.g. sample_id
+    >>> sce.pp.scalex_integrate(adata, batch_name = 'sample_id') 
+    """
+    try:
+        import scalex
+    except ImportError:
+        raise ImportError("\nplease install scalex: \n\n\tpip install scalex")
+
+    scalex.SCALEX(adata, batch_categories, batch_name=batch_name, outdir=outdir, **kwargs)
+

--- a/scanpy/external/pp/_scalex_integrate.py
+++ b/scanpy/external/pp/_scalex_integrate.py
@@ -1,44 +1,97 @@
-from typing import Optional
+from typing import Optional, Union, List
+from anndata import AnnData
+
 
 def scalex_integrate(
-    adata, 
-    batch_categories=None,
-    batch_name='batch',
-    outdir='scalex_output/',
-    **kwargs
-    ):
-    """\
-    Use scalex to integrate [Xiong22]_ to online integrate different experiments.
+    data_list: Union[str, AnnData, List] = None,
+    batch_categories: List = None,
+    profile: str = 'RNA',
+    batch_name: str = 'batch',
+    min_features: int = 600,
+    min_cells: int = 3,
+    target_sum: int = None,
+    n_top_features: int = None,
+    join: str = 'inner',
+    batch_key: str = 'batch',
+    processed: bool = False,
+    batch_size: int = 64,
+    lr: float = 2e-4,
+    max_iteration: int = 30000,
+    seed: int = 124,
+    gpu: int = 0,
+    outdir: str = None,
+    projection: str = None,
+    repeat: bool = False,
+    impute: str = None,
+    chunk_size: int = 20000,
+    ignore_umap: bool = False,
+    verbose: bool = False,
+    assess: bool = False,
+    show: bool = True,
+    eval: bool = False,
+) -> AnnData:
+    """
+    Use scalex [Xiong22]_ to online integrate different experiments.
 
-    SCALEX [Xiong22]_ is an online integration algorithm for integrating single-cell data from multiple experiments 
-    and projecting new incoming datasets onto the existing cell-embedding space. This function uses the SCALEX from 
-    ``scalex`` python package. The input to SCALEX can be filename or AnnData object, or list, or mixed of them. 
-    SCALEX will do the preprocess if given the raw data, otherwise should set the ``processsed=True``
-    
+    SCALEX [Xiong22]_ is an algorithm for online integrating single-cell
+    data from multiple experiments. This function uses the ``scalex.SCALEX``, to integrate single-cell data
+    stored in an AnnData object, or list of file paths. SCALEX prefer to take the raw input data without any preprocessing.
+    If the data has already been preprocessed, should set `processed=True`.
+    Online single-cell data integration through projecting heterogeneous datasets into a common cell-embedding space
+
     Parameters
     ----------
-    adata
+    data_list
         A path list of AnnData matrices to concatenate with. Each matrix is referred to as a 'batch'.
     batch_categories
         Categories for the batch annotation. By default, use increasing numbers.
+    profile
+        Specify the single-cell profile, RNA or ATAC. Default: RNA.
     batch_name
         Use this annotation in obs as batches for training model. Default: 'batch'.
+    min_features
+        Filtered out cells that are detected in less than min_features. Default: 600.
+    min_cells
+        Filtered out genes that are detected in less than min_cells. Default: 3.
+    n_top_features
+        Number of highly-variable genes to keep. Default: 2000.
+    join
+        Use intersection ('inner') or union ('outer') of variables of different batches.
+    batch_key
+        Add the batch annotation to obs using this key. By default, batch_key='batch'.
+    batch_size
+        Number of samples per batch to load. Default: 64.
+    lr
+        Learning rate. Default: 2e-4.
+    max_iteration
+        Max iterations for training. Training one batch_size samples is one iteration. Default: 30000.
+    seed
+        Random seed for torch and numpy. Default: 124.
+    gpu
+        Index of GPU to use if GPU is available. Default: 0.
     outdir
-        output AnnData will be saved as ``adata.h5ad`` in outdir if outdir is not None, default is None
+        Output directory. Default: 'output/'.
+    projection
+        Use for new dataset projection. Input the folder containing the pre-trained model. If None, don't do projection. Default: None.
+    repeat
+        Use with projection. If False, concatenate the reference and projection datasets for downstream analysis. If True, only use projection datasets. Default: False.
+    impute
+        If True, calculate the imputed gene expression and store it at adata.layers['impute']. Default: False.
+    chunk_size
+        Number of samples from the same batch to transform. Default: 20000.
+    ignore_umap
+        If True, do not perform UMAP for visualization and leiden for clustering. Default: False.
+    verbose
+        Verbosity, True or False. Default: False.
+    assess
+        If True, calculate the entropy_batch_mixing score and silhouette score to evaluate integration results. Default: False.
 
 
-    
+
     Returns
     -------
-    The output folder contains:
-    adata.h5ad
-        The AnnData matrice after batch effects removal. The low-dimensional representation of the data is stored at adata.obsm['latent'].
-    checkpoint
-        model.pt contains the variables of the model and config.pt contains the parameters of the model.
-    log.txt
-        Records raw data information, filter conditions, model parameters etc.
-    umap.pdf 
-        UMAP plot for visualization.
+    adata
+        An AnnData object
 
 
     Example
@@ -55,18 +108,48 @@ def scalex_integrate(
     >>> adata.obs['batch] = 1350*['a'] + 1350*['b']
     >>> sce.pp.scalex_integrate(adata)
 
-    >>> 'X_scalex_umap' as well as 'X_umap' will in adata.obsm
+    'X_scalex_umap' as well as 'X_umap' will in adata.obsm
 
+    SCALEX will do the preprocssing internally, like sc.pp.filter_cells, sc.pp.filter_genes, sc.pp.normalize_total, sc.pp.log1p, sc.pp.highly_variable_genes
     if adata has been preprocessed, please set the ``processed = True``
+
     >>> sce.pp.scalex_integrate(adata, processed=True)
 
     if use other meta information as ``batch``, e.g. sample_id
-    >>> sce.pp.scalex_integrate(adata, batch_name = 'sample_id') 
+
+    >>> sce.pp.scalex_integrate(adata, batch_name = 'sample_id')
     """
+
     try:
         import scalex
     except ImportError:
         raise ImportError("\nplease install scalex: \n\n\tpip install scalex")
 
-    scalex.SCALEX(adata, batch_categories, batch_name=batch_name, outdir=outdir, **kwargs)
-
+    return scalex.SCALEX(
+        data_list=data_list,
+        batch_categories=batch_categories,
+        profile=profile,
+        batch_name=batch_name,
+        min_features=min_features,
+        min_cells=min_cells,
+        target_sum=target_sum,
+        n_top_features=n_top_features,
+        join=join,
+        batch_key=batch_key,
+        processed=processed,
+        batch_size=batch_size,
+        lr=lr,
+        max_iteration=max_iteration,
+        seed=seed,
+        gpu=gpu,
+        outdir=outdir,
+        projection=projection,
+        repeat=repeat,
+        impute=impute,
+        chunk_size=chunk_size,
+        ignore_umap=ignore_umap,
+        verbose=verbose,
+        assess=assess,
+        show=show,
+        eval=eval,
+    )

--- a/scanpy/external/pp/_scalex_integrate.py
+++ b/scanpy/external/pp/_scalex_integrate.py
@@ -106,14 +106,14 @@ def scalex_integrate(
     from.
 
     >>> adata.obs['batch] = 1350*['a'] + 1350*['b']
-    >>> sce.pp.scalex_integrate(adata)
+    >>> adata = sce.pp.scalex_integrate(adata)
 
     'X_scalex_umap' as well as 'X_umap' will in adata.obsm
 
     SCALEX will do the preprocssing internally, like sc.pp.filter_cells, sc.pp.filter_genes, sc.pp.normalize_total, sc.pp.log1p, sc.pp.highly_variable_genes
     if adata has been preprocessed, please set the ``processed = True``
 
-    >>> sce.pp.scalex_integrate(adata, processed=True)
+    >>> adata = sce.pp.scalex_integrate(adata, processed=True)
 
     if use other meta information as ``batch``, e.g. sample_id
 

--- a/scanpy/tests/external/test_scalex_integrate.py
+++ b/scanpy/tests/external/test_scalex_integrate.py
@@ -16,5 +16,9 @@ def test_scalex_integrate():
     adata = sc.datasets.pbmc3k()
 
     adata.obs['batch'] = 1350 * ['a'] + 1350 * ['b']
-    sce.pp.scalex_integrate(adata)
+    adata = sce.pp.scalex_integrate(adata, show=False, max_iteration=1)
     assert adata.obsm['X_scalex_umap'].shape[0] == adata.shape[0]
+
+
+if __name__ == '__main__':
+    test_scalex_integrate()

--- a/scanpy/tests/external/test_scalex_integrate.py
+++ b/scanpy/tests/external/test_scalex_integrate.py
@@ -1,0 +1,20 @@
+import pytest
+
+import scanpy as sc
+import scanpy.external as sce
+
+pytest.importorskip("scalex")
+
+
+def test_scalex_integrate():
+    """
+    Test that SCALEX integrate works.
+
+    This is a very simple test that just checks to see if the SCALEX
+    integrate wrapper succesfully added a new field to ``adata.obsm``
+    """
+    adata = sc.datasets.pbmc3k()
+
+    adata.obs['batch'] = 1350 * ['a'] + 1350 * ['b']
+    sce.pp.scalex_integrate(adata)
+    assert adata.obsm['X_scalex_umap'].shape[0] == adata.shape[0]


### PR DESCRIPTION
Hi,
we want to add SCALEX, an online integration method that integrate different single-cell experiments including scRNA-seq and scATAC-seq, which also enable accurate projecting new incoming datasets onto the existing cell space. This method is published on Nature Communications. SCALEX is developed based-on scanpy. We appreciate and will be honored to contribute to the scanpy community.

Thank you!
