### PR TITLE
Stop ignoring batch_size in sc.external.pp.scanorama_integrate

### DIFF
--- a/scanpy/external/pp/_scanorama_integrate.py
+++ b/scanpy/external/pp/_scanorama_integrate.py
@@ -125,6 +125,7 @@ def scanorama_integrate(
         approx=approx,
         alpha=alpha,
         ds_names=batch_names,
+        batch_size=batch_size,
         **kwargs,
     )
 


### PR DESCRIPTION
This was giving out-of-memory errors since scanorama's default is batch_size=None, and setting batch_size to another value wasn't doing anything

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
