### PR TITLE
sc.tl.dendrogram 'var_names' -parameter bug fix

### DIFF
--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -124,10 +124,17 @@ def dendrogram(
         rep_df.set_index(categorical, inplace=True)
         categories = rep_df.index.categories
     else:
-        gene_names = adata.raw.var_names if use_raw else adata.var_names
         from ..plotting._anndata import _prepare_dataframe
 
-        categories, rep_df = _prepare_dataframe(adata, gene_names, groupby, use_raw)
+        categories, rep_df = _prepare_dataframe(
+            adata if not use_raw else adata.raw,
+            var_names, groupby, use_raw
+        )
+
+        # Correlation is not defined for rows where are values are equal
+        if rep_df.eq(rep_df.iloc[:, 0], axis=0).all(True).sum() > 0:
+            # Make sure correlation is defined
+            rep_df["dummy"] = -1
 
     # aggregate values within categories using 'mean'
     mean_df = rep_df.groupby(level=0).mean()


### PR DESCRIPTION
### Bug: `var_names` -parameter for `sc.tl.dendrogram` -function is not used properly.

**Currently:**
 - Hierarchical clustering is calculated on **all** of the var_names (genes) when `var_names is not None`

**Fix:**
- Subset of genes defined by `var_names` is now used

**In addition:**
 - When all of the values of some row of `rep_df` (or `mean_df`) are equal, `df.T.corr()` is not defined for that row resulting in `NaNs` in correlation matrix.
 - This is quite common with a subset of genes `var_names`, e.g. all `0` in all cells (these cells have already passed quality control/filtering at this point of downstream analysis).
 - This throws an error in `distance.squareform(1-corr_matrix)`: `ValueError: Distance matrix 'X' must be symmetric.`
 - Fix: In this case add 'dummy' feature `rep_df["dummy"] = -1` to make sure that at least one feature in a row is distinct.
 - Notice, this addition affects (increases) the correlation between the rows. However, it should affect all rows equally and hence the hierarchy stays as is. 