### PR TITLE
Fix some typos in scanpy.tl.paga

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -83,7 +83,7 @@ def filter_cells(
         Boolean index mask that does filtering. `True` means that the
         cell is kept. `False` means the cell is removed.
     number_per_cell
-        Depending on what was tresholded (`counts` or `genes`),
+        Depending on what was thresholded (`counts` or `genes`),
         the array stores `n_counts` or `n_cells` per gene.
 
     Examples
@@ -218,7 +218,7 @@ def filter_genes(
         Boolean index mask that does filtering. `True` means that the
         gene is kept. `False` means the gene is removed.
     number_per_gene
-        Depending on what was tresholded (`counts` or `cells`), the array stores
+        Depending on what was thresholded (`counts` or `cells`), the array stores
         `n_counts` or `n_cells` per gene.
     """
     if copy:

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -27,13 +27,13 @@ def paga(
     By quantifying the connectivity of partitions (groups, clusters) of the
     single-cell graph, partition-based graph abstraction (PAGA) generates a much
     simpler abstracted graph (*PAGA graph*) of partitions, in which edge weights
-    represent confidence in the presence of connections. By tresholding this
+    represent confidence in the presence of connections. By thresholding this
     confidence in :func:`~scanpy.pl.paga`, a much simpler representation of the
     manifold data is obtained, which is nonetheless faithful to the topology of
     the manifold.
 
     The confidence should be interpreted as the ratio of the actual versus the
-    expected value of connetions under the null model of randomly connecting
+    expected value of connections under the null model of randomly connecting
     partitions. We do not provide a p-value as this null model does not
     precisely capture what one would consider "connected" in real data, hence it
     strongly overestimates the expected value. See an extensive discussion of


### PR DESCRIPTION
Found some typos in the docstring. Also searched them in other places.
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
