### PR TITLE
Exclude matplotlib 3.7 due to incompatibility

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -50,7 +50,7 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pip install -v git+https://github.com/scverse/anndata
+      pip install -v "anndata[dev,test] @ git+https://github.com/scverse/anndata"
     displayName: 'Install development anndata'
     condition: eq(variables['ANNDATA_DEV'], 'yes')
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,8 @@ dependencies = [
     "anndata>=0.7.4",
     # numpy needs a version due to #1320
     "numpy>=1.17.0",
-    "matplotlib>=3.4",
+    # currently incompatible with matplotlib 3.7 due to #2411
+    "matplotlib>=3.4,<3.7",
     "pandas>=1.0",
     "scipy>=1.4",
     "seaborn",


### PR DESCRIPTION
matplotlib 3.7 introduces a metaclass incompatibility with scanpy:

      File ".../site-packages/scanpy/plotting/_utils.py", line 35, in <module>
        class _AxesSubplot(Axes, axes.SubplotBase, ABC):
    TypeError: metaclass conflict: the metaclass of a derived class
    must be a (non-strict) subclass of the metaclasses of all its bases

Excluding v3.7 works around this issue (#2411).