### PR TITLE
updated read_visium() to read in spaceranger 2.0 files

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -9,7 +9,7 @@
 ```{rubric} Bug fixes
 ```
 
-* updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
+* Updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
 
 
 ```{rubric} Ecosystem

--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -9,5 +9,8 @@
 ```{rubric} Bug fixes
 ```
 
+* updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
+
+
 ```{rubric} Ecosystem
 ```

--- a/docs/release-notes/1.9.3.md
+++ b/docs/release-notes/1.9.3.md
@@ -4,3 +4,4 @@
 ```
 
 * Variety of fixes against pandas 2.0.0rc0 {pr}`2434` {smaller}`I Virshup`
+* updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`

--- a/docs/release-notes/1.9.3.md
+++ b/docs/release-notes/1.9.3.md
@@ -4,4 +4,3 @@
 ```
 
 * Variety of fixes against pandas 2.0.0rc0 {pr}`2434` {smaller}`I Virshup`
-* updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -372,9 +372,9 @@ def read_visium(
 
     if load_images:
         tissue_positions_file = (
-        path / "spatial/tissue_positions.csv"
-        if (path / "spatial/tissue_positions.csv").exists()
-        else path / "spatial/tissue_positions_list.csv"
+            path / "spatial/tissue_positions.csv"
+            if (path / "spatial/tissue_positions.csv").exists()
+            else path / "spatial/tissue_positions_list.csv"
         )
         files = dict(
             tissue_positions_file=tissue_positions_file,
@@ -415,9 +415,11 @@ def read_visium(
         }
 
         # read coordinates
-        positions = pd.read_csv(files['tissue_positions_file'], 
-        header=1 if tissue_positions_file.name == "tissue_positions.csv" else None,
-        index_col=0)
+        positions = pd.read_csv(
+            files['tissue_positions_file'],
+            header=1 if tissue_positions_file.name == "tissue_positions.csv" else None,
+            index_col=0,
+        )
         positions.columns = [
             'in_tissue',
             'array_row',

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -371,8 +371,13 @@ def read_visium(
     adata.uns["spatial"][library_id] = dict()
 
     if load_images:
+        tissue_positions_file = (
+        path / "spatial/tissue_positions.csv"
+        if (path / "spatial/tissue_positions.csv").exists()
+        else path / "spatial/tissue_positions_list.csv"
+        )
         files = dict(
-            tissue_positions_file=path / 'spatial/tissue_positions_list.csv',
+            tissue_positions_file=tissue_positions_file,
             scalefactors_json_file=path / 'spatial/scalefactors_json.json',
             hires_image=path / 'spatial/tissue_hires_image.png',
             lowres_image=path / 'spatial/tissue_lowres_image.png',
@@ -410,16 +415,16 @@ def read_visium(
         }
 
         # read coordinates
-        positions = pd.read_csv(files['tissue_positions_file'], header=None)
+        positions = pd.read_csv(files['tissue_positions_file'], 
+        header=1 if tissue_positions_file.name == "tissue_positions.csv" else None,
+        index_col=0)
         positions.columns = [
-            'barcode',
             'in_tissue',
             'array_row',
             'array_col',
             'pxl_col_in_fullres',
             'pxl_row_in_fullres',
         ]
-        positions.index = positions['barcode']
 
         adata.obs = adata.obs.join(positions, how="left")
 
@@ -427,7 +432,7 @@ def read_visium(
             ['pxl_row_in_fullres', 'pxl_col_in_fullres']
         ].to_numpy()
         adata.obs.drop(
-            columns=['barcode', 'pxl_row_in_fullres', 'pxl_col_in_fullres'],
+            columns=['pxl_row_in_fullres', 'pxl_col_in_fullres'],
             inplace=True,
         )
 


### PR DESCRIPTION
Can now read in spaceranger 2.0 files where the tissue position file name is different and a header is included. Code adapated from squidpy's [read.visium()](https://github.com/scverse/squidpy/blob/main/squidpy/read/_read.py#L25) in response to [scverse/squidpy#599](https://github.com/scverse/squidpy/issues/599) and [scverse/scanpy#2296](https://github.com/scverse/scanpy/pull/2296#issuecomment-1273309536).