### PR TITLE
Read visium v2

### DIFF
--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -369,7 +369,7 @@ def read_visium(
 
     adata.uns["spatial"][library_id] = dict()
 
-    # spaceranger count v1 uses "spatial_tissue_positions_list.csv" (no headers) 
+    # spaceranger count v1 uses "spatial_tissue_positions_list.csv" (no headers)
     # while v2 uses "tissue_positions.csv" (with headers)
     v1 = Path(path / 'spatial/tissue_positions_list.csv').is_file()
 

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -301,6 +301,7 @@ def read_visium(
     library_id: str = None,
     load_images: Optional[bool] = True,
     source_image_path: Optional[Union[str, Path]] = None,
+    spaceranger_version: Optional[str] = 'v1',
 ) -> AnnData:
     """\
     Read 10x-Genomics-formatted visum dataset.
@@ -370,12 +371,24 @@ def read_visium(
     adata.uns["spatial"][library_id] = dict()
 
     if load_images:
-        files = dict(
-            tissue_positions_file=path / 'spatial/tissue_positions_list.csv',
-            scalefactors_json_file=path / 'spatial/scalefactors_json.json',
-            hires_image=path / 'spatial/tissue_hires_image.png',
-            lowres_image=path / 'spatial/tissue_lowres_image.png',
-        )
+        if spaceranger_version == 'v1':
+            files = dict(
+                tissue_positions_file=path / 'spatial/tissue_positions_list.csv',
+                scalefactors_json_file=path / 'spatial/scalefactors_json.json',
+                hires_image=path / 'spatial/tissue_hires_image.png',
+                lowres_image=path / 'spatial/tissue_lowres_image.png',
+            )
+        elif spaceranger_version == 'v2':
+            files = dict(
+                tissue_positions_file=path / 'spatial/tissue_positions.csv',
+                scalefactors_json_file=path / 'spatial/scalefactors_json.json',
+                hires_image=path / 'spatial/tissue_hires_image.png',
+                lowres_image=path / 'spatial/tissue_lowres_image.png',
+            )
+        else:
+            raise ValueError(
+                f"Value passed for '{spaceranger_version}' is not valid. Only 'v1' and 'v2' are supported."
+            )
 
         # check if files exists, continue if images are missing
         for f in files.values():
@@ -409,15 +422,22 @@ def read_visium(
         }
 
         # read coordinates
-        positions = pd.read_csv(files['tissue_positions_file'], header=None)
-        positions.columns = [
-            'barcode',
-            'in_tissue',
-            'array_row',
-            'array_col',
-            'pxl_col_in_fullres',
-            'pxl_row_in_fullres',
-        ]
+        if spaceranger_version == 'v1":
+            positions = pd.read_csv(files['tissue_positions_file'], header=None)
+            positions.columns = [
+                'barcode',
+                'in_tissue',
+                'array_row',
+                'array_col',
+                'pxl_col_in_fullres',
+                'pxl_row_in_fullres',
+            ]
+        elif spaceranger_version == "v2":
+            positions = pd.read_csv(files['tissue_positions_file'])
+        else:
+            raise ValueError(
+                f"Value passed for '{spaceranger_version}' is not valid. Only 'v1' and 'v2' are supported."
+            )
         positions.index = positions['barcode']
 
         adata.obs = adata.obs.join(positions, how="left")


### PR DESCRIPTION
The "outs" from `spaceranger count` v2 differ from v1. Specifically, `tissue_positions_list.csv` has been renamed `tissue_positions.csv` and now has headers. Fortunately the column names exactly match those used by `scanpy`. See https://support.10xgenomics.com/spatial-gene-expression/software/pipelines/latest/output/spatial (search for `tissue_positions.csv`).

This PR adjusts `sc.read_visium()` so that it can load the outputs of `spaceranger count` v2.

The API / method signature is unchanged, so no changes to the documentation are required. The version is inferred from the presence or otherwise of the old `tissue_positions_list.csv` (implying v1) and then the files in `spatial/` are handled accordingly, including differential handling of headers / column names.

@linhuawang
@sopvdl
@TaopengWang