### PR TITLE
Corrected docstring in pl.ranking()

### DIFF
--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -519,7 +519,7 @@ def ranking(
     """\
     Plot rankings.
 
-    See, for example, how this is used in pl.pca_ranking.
+    See, for example, how this is used in pl.pca_loadings.
 
     Parameters
     ----------


### PR DESCRIPTION
Corrected: `See, for example, how this is used in pl.pca_loadings.` instead of  `pl.pca_ranking`.

