### PR TITLE
add reader for 10x Xenium output

### DIFF
--- a/scanpy/__init__.py
+++ b/scanpy/__init__.py
@@ -27,7 +27,14 @@ if not within_flit():  # see function docstring on why this is there
         read_text,
         read_umi_tools,
     )
-    from .readwrite import read, read_10x_h5, read_10x_mtx, write, read_visium
+    from .readwrite import (
+        read,
+        read_10x_h5,
+        read_10x_mtx,
+        write,
+        read_visium,
+        read_xenium,
+    )
     from .neighbors import Neighbors
 
     set_figure_params = settings.set_figure_params


### PR DESCRIPTION
I tried to keep the resulting AnnData as compatible as possible with the Visium output, but it is still going to break sc.pl.spatial due to the lack of scale factors. In theory, we could calculate the scale factors ourselves, but that's probably not useful for plotting anyway, since the current spatial plotting function also requires spot sizes, which we don't have.

I tested it on the example Xenium data set from the 10x web site. The images in this data set are JPEG2000-compressed, which is not supported by Pillow. Manually creating an image with zlib compression and passing that to the reader works. I don't know if the 10x Xenium software can only output this type of image file or if it can also produce TIFFs with another compression.