### PR TITLE
Fix generated path

### DIFF
--- a/docs/api/classes.md
+++ b/docs/api/classes.md
@@ -12,7 +12,7 @@ Represent data as a neighborhood structure, usually a knn graph.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    Neighbors
 

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -11,7 +11,7 @@
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    datasets.blobs
    datasets.ebi_expression_atlas

--- a/docs/api/deprecated.md
+++ b/docs/api/deprecated.md
@@ -7,7 +7,7 @@
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    pp.filter_genes_dispersion
    pp.normalize_per_cell

--- a/docs/api/experimental.md
+++ b/docs/api/experimental.md
@@ -18,7 +18,7 @@ integrated in Scanpy core.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    experimental.pp.normalize_pearson_residuals
    experimental.pp.normalize_pearson_residuals_pca

--- a/docs/api/get.md
+++ b/docs/api/get.md
@@ -14,7 +14,7 @@ useful formats.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    get.obs_df
    get.var_df

--- a/docs/api/metrics.md
+++ b/docs/api/metrics.md
@@ -13,7 +13,7 @@ Collections of useful measurements for evaluating results.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    metrics.confusion_matrix
    metrics.gearys_c

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -24,7 +24,7 @@ See the {ref}`settings` section for all important plotting configurations.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    pl.scatter
    pl.heatmap

--- a/docs/api/preprocessing.md
+++ b/docs/api/preprocessing.md
@@ -20,7 +20,7 @@ For visual quality control, see {func}`~scanpy.pl.highest_expr_genes` and
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    pp.calculate_qc_metrics
    pp.filter_cells

--- a/docs/api/queries.md
+++ b/docs/api/queries.md
@@ -13,7 +13,7 @@ This module provides useful queries for annotation and enrichment.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    queries.biomart_annotations
    queries.gene_coordinates

--- a/docs/api/reading.md
+++ b/docs/api/reading.md
@@ -15,7 +15,7 @@ Read common file formats using
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    read
 ```
@@ -25,7 +25,7 @@ Read 10x formatted hdf5 files and directories containing `.mtx` files using
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    read_10x_h5
    read_10x_mtx
@@ -37,7 +37,7 @@ Read other formats using functions borrowed from {mod}`anndata`
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    read_h5ad
    read_csv

--- a/docs/api/settings.md
+++ b/docs/api/settings.md
@@ -13,7 +13,7 @@ high-resolution jupyter display backend useful for use in notebooks.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    set_figure_params
 ```
@@ -23,7 +23,7 @@ An instance of the {class}`~scanpy._settings.ScanpyConfig` is available as `scan
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    _settings.ScanpyConfig
 ```
@@ -70,7 +70,7 @@ Print versions of packages that might influence numerical results.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    logging.print_header
    logging.print_versions

--- a/docs/api/tools.md
+++ b/docs/api/tools.md
@@ -15,7 +15,7 @@ Any transformation of the data matrix that is not *preprocessing*. In contrast t
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.pca
    tl.tsne
@@ -29,7 +29,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.embedding_density
 ```
@@ -39,7 +39,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.leiden
    tl.louvain
@@ -53,7 +53,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.ingest
 ```
@@ -63,7 +63,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.rank_genes_groups
    tl.filter_rank_genes_groups
@@ -75,7 +75,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.score_genes
    tl.score_genes_cell_cycle
@@ -86,7 +86,7 @@ Compute densities on embeddings.
 ```{eval-rst}
 .. autosummary::
    :nosignatures:
-   :toctree: generated/
+   :toctree: ../generated/
 
    tl.sim
 

--- a/docs/external/exporting.md
+++ b/docs/external/exporting.md
@@ -6,7 +6,7 @@
 
 ```{eval-rst}
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    exporting.spring_project
    exporting.cellbrowser

--- a/docs/external/plotting.md
+++ b/docs/external/plotting.md
@@ -7,7 +7,7 @@
 
 ```{eval-rst}
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    pl.phate
    pl.trimap

--- a/docs/external/preprocessing.md
+++ b/docs/external/preprocessing.md
@@ -8,7 +8,7 @@
 
 ```{eval-rst}
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    pp.bbknn
    pp.harmony_integrate
@@ -21,7 +21,7 @@
 
 ```{eval-rst}
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    pp.scrublet
    pp.scrublet_simulate_doublets
@@ -35,7 +35,7 @@ Note that the fundamental limitations of imputation are still under [debate](htt
 
 ```{eval-rst}
 .. autosummary::
-   :toctree: generated/
+   :toctree: ../generated/
 
    pp.dca
    pp.magic

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@
 .. role:: smaller
 ```
 
-::::{grid} 2
+::::{grid} 1 2 3 3
 :gutter: 2
 
 :::{grid-item-card} Installation {octicon}`plug;1em;`


### PR DESCRIPTION
The previous docs PRs moved the generated docs path, which breaks old urls. This fixes that.

This also adds responsive handling of the grid on the main index page.