### PR TITLE
Fix for sklearn 1.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dependencies = [
     "seaborn",
     "h5py>=3",
     "tqdm",
-    "scikit-learn>=0.22",
+    "scikit-learn>=0.24",
     "statsmodels>=0.10.0rc2",
     "patsy",
     "networkx>=2.3",

--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -31,16 +31,6 @@ def test_tsne():
     assert cosine.uns["tsne"]["params"]["metric"] == "cosine"
 
 
-def test_tsne_metric_warning():
-    pbmc = pbmc68k_reduced()
-    import sklearn
-
-    with patch.object(sklearn, "__version__", "0.23.0"), pytest.warns(
-        UserWarning, match="Results for non-euclidean metrics changed"
-    ):
-        sc.tl.tsne(pbmc, metric="cosine")
-
-
 def test_umap_init_dtype():
     pbmc = pbmc68k_reduced()
     pbmc = pbmc[:100, :].copy()

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -95,11 +95,11 @@ def tsne(
         n_jobs=n_jobs,
         metric=metric,
     )
-    # square_distances will default to true in the future, we'll get ahead of the
-    # warning for now
     if metric != "euclidean":
         sklearn_version = version.parse(sklearn.__version__)
-        if sklearn_version >= version.parse("0.24.0"):
+        if sklearn_version >= version.parse("1.3.0"):
+            pass  # square_distances are always True
+        elif sklearn_version >= version.parse("0.24.0"):
             params_sklearn["square_distances"] = True
         else:
             warnings.warn(

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -97,7 +97,7 @@ def tsne(
     )
     if metric != "euclidean":
         sklearn_version = version.parse(sklearn.__version__)
-        if sklearn_version >= version.parse("1.3.0"):
+        if sklearn_version >= version.parse("1.3.0rc1"):
             pass  # square_distances are always True
         elif sklearn_version >= version.parse("0.24.0"):
             params_sklearn["square_distances"] = True

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -95,18 +95,10 @@ def tsne(
         n_jobs=n_jobs,
         metric=metric,
     )
-    if metric != "euclidean":
-        sklearn_version = version.parse(sklearn.__version__)
-        if sklearn_version >= version.parse("1.3.0rc1"):
-            pass  # square_distances are always True
-        elif sklearn_version >= version.parse("0.24.0"):
-            params_sklearn["square_distances"] = True
-        else:
-            warnings.warn(
-                "Results for non-euclidean metrics changed in sklearn 0.24.0, while "
-                f"you are using {sklearn.__version__}.",
-                UserWarning,
-            )
+    if metric != "euclidean" and (
+        version.parse(sklearn.__version__) < version.parse("1.3.0rc1")
+    ):
+        params_sklearn["square_distances"] = True
 
     # Backwards compat handling: Remove in scanpy 1.9.0
     if n_jobs != 1 and not use_fast_tsne:


### PR DESCRIPTION
Fix the dev tests. `square_distances` are not longer an argument in sklearn 1.3