### PR TITLE
Fix paga tests

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -83,7 +83,7 @@ jobs:
     inputs:
       codeCoverageTool: Cobertura
       summaryFileLocation: '$(System.DefaultWorkingDirectory)/**/coverage.xml'
-      reportDirectory: '$(System.DefaultWorkingDirectory)/**/htmlcov'
+      failIfCoverageEmpty: true
     condition: eq(variables['RUN_COVERAGE'], 'yes')
 
   - task: PublishTestResults@2

--- a/scanpy/tests/test_paga.py
+++ b/scanpy/tests/test_paga.py
@@ -24,7 +24,7 @@ needs_igraph = pytest.mark.skipif(
 def pbmc():
     pbmc = pbmc68k_reduced()
     sc.tl.paga(pbmc, groups='bulk_labels')
-    pbmc.obs['cool_feature'] = pbmc[:, 'CST3'].X.squeeze()
+    pbmc.obs['cool_feature'] = pbmc[:, 'CST3'].X.squeeze().copy()
     return pbmc
 
 


### PR DESCRIPTION
In the sense that they no longer fail, not that they make sense. That’s what #2235 is for.