### PR TITLE
Fix pytest norecursedirs option

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ addopts = [
     "-pscanpy.testing._pytest",
 ]
 testpaths = ["scanpy"]
-ignore = ["scanpy/tests/_images"]
+norecursedirs = ["scanpy/tests/_images"]
 xfail_strict = true
 nunit_attach_on = "fail"
 markers = [


### PR DESCRIPTION
The CLI option is different from the config option …

no review necessary, simple fix