### PR TITLE
Restore numpydoc-like parameter lists

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -65,8 +65,9 @@ extensions = [
     'matplotlib.sphinxext.plot_directive',
     'sphinx_autodoc_typehints',  # needs to be after napoleon
     'scanpydoc.autosummary_generate_imported',
-    "sphinx_design",
-    "sphinxext.opengraph",
+    'scanpydoc.definition_list_typed_field',
+    'sphinx_design',
+    'sphinxext.opengraph',
     *[p.stem for p in (HERE / 'extensions').glob('*.py')],
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test-full = [
 ]
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
-    "scanpydoc>=0.7.9",
+    "scanpydoc>=0.7.10",
     "sphinx-autodoc-typehints",
     "myst-parser",
     "myst-nb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test-full = [
 ]
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
-    "scanpydoc>=0.7.7",
+    "scanpydoc>=0.7.9",
     "sphinx-autodoc-typehints",
     "myst-parser",
     "myst-nb",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ test-full = [
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
     "scanpydoc>=0.7.7",
+    "sphinx-autodoc-typehints",
     "myst-parser",
     "myst-nb",
     "sphinx-book-theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test-full = [
 ]
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
-    "scanpydoc[typehints]>=0.7.7",
+    "scanpydoc>=0.7.7",
     "myst-parser",
     "myst-nb",
     "sphinx-book-theme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ test-full = [
 ]
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
-    "scanpydoc>=0.7.10",
+    "scanpydoc>=0.7.11",
     "sphinx-autodoc-typehints",
     "myst-parser",
     "myst-nb",


### PR DESCRIPTION
I just saw that @adamgayoso accidentally removed something we want to keep from the docs in  #2220

This restores it.

before | after
--- | ---
![grafik](https://github.com/scverse/scanpy/assets/291575/8a941ac6-f822-45b7-91fd-fa3201873b64) | ![grafik](https://github.com/scverse/scanpy/assets/291575/c7188bad-a5db-445c-b5e5-ed72f6e3f0a6)
