### PR TITLE
Mellon

### DIFF
--- a/docs/external/tools.md
+++ b/docs/external/tools.md
@@ -39,3 +39,12 @@
    tl.cyclone
 
 ```
+
+### Cell statistics
+
+```{eval-rst}
+.. autosummary::
+   :toctree: generated/
+
+   tl.mellon
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ test-full = [
     "scanpy[harmony]",
     "scanpy[scanorama]",
     "scanpy[scrublet]",
+    "scanpy[mellon]",
 ]
 doc = [
     "sphinx>=4.4,<5", # remove upper bound when theme supports dark mode
@@ -140,6 +141,7 @@ skmisc = ["scikit-misc>=0.1.3"]  # highly_variable_genes method 'seurat_v3'
 harmony = ["harmonypy"]  # Harmony dataset integration
 scanorama = ["scanorama"]  # Scanorama dataset integration
 scrublet = ["scrublet"]  # Doublet detection
+mellon = ["mellon"]  # Cell-state density
 # Acceleration
 rapids = ["cudf>=0.9", "cuml>=0.9", "cugraph>=0.9"]  # GPU accelerated calculation of neighbors
 dask = ["dask[array]!=2.17.0"]  # Use the Dask parallelization engine

--- a/scanpy/external/tl/__init__.py
+++ b/scanpy/external/tl/__init__.py
@@ -2,6 +2,7 @@ from ._pypairs import cyclone, sandbag
 from ._phate import phate
 from ._phenograph import phenograph
 from ._palantir import palantir, palantir_results
+from ._mellon import mellon
 from ._trimap import trimap
 from ._harmony_timeseries import harmony_timeseries
 from ._sam import sam

--- a/scanpy/external/tl/_mellon.py
+++ b/scanpy/external/tl/_mellon.py
@@ -1,0 +1,95 @@
+"""\
+Cell-state density computation using Mellon
+"""
+
+from typing import Optional
+from anndata import AnnData
+import numpy as np
+
+from ... import logging as logg
+
+
+def mellon(
+    adata: AnnData,
+    repr_key: str = 'X_palantir_diff_comp',
+    density_key: str = 'mellon_log_density',
+    copy: bool = False,
+    **kwargs,
+) -> Optional[AnnData]:
+    """\
+    Compute cell-state density with Mellon.
+
+    This function uses Mellon to compute the density of cell states,
+    which is stored in the obs attribute of the AnnData object. The function returns
+    the computed density. If `repr_key` is not found in the AnnData object,
+    an error is raised suggesting the user to run the function `scanpy.external.tl.palantir(adata)`.
+
+    Additionally, the density prediction model is serialized and stored in the `.uns` attribute
+    of the AnnData object under the key `'{density_key}_predictor'`. This can be deserialized
+    and used for prediction by using the `palantir.utils.run_density_evaluation` method.
+
+    Parameters
+    ----------
+    adata
+        The annotated data matrix of shape `n_obs` × `n_vars`. Rows correspond
+        to cells and columns to genes.
+    repr_key
+        Key to retrieve cell-state representation from the AnnData object.
+        Default is 'X_palantir_diff_comp'.
+    density_key
+        Key under which the computed density values are stored in the obs
+        of the AnnData object. Default is 'mellon_log_density'.
+    copy
+        If `True`, return a copy of `adata` instead of writing to it.
+    **kwargs
+        Additional keyword arguments to be passed to mellon.
+
+    Returns
+    -------
+    Depending on `copy`, returns or updates `adata` with the following fields:
+
+    adata.obs[density_key]
+        Array of log density values computed for each cell.
+    adata.obs[density_key + "_clipped"]
+        Array of log density values clipped between the 1st and 100th percentiles.
+    adata.uns[density_key + "_predictor"]
+        Serialized density prediction model.
+    """
+    _check_import()
+    from mellon import DensityEstimator
+
+    adata = adata.copy() if copy else adata
+
+    logg.info('Mellon Density Maps in progress ...')
+
+    # Check if 'X_palantir_diff_comp' key is in the adata object
+    if repr_key not in adata.obsm.keys():
+        raise ValueError(
+            f"{repr_key} not found in adata.obsm. "
+            "Please run `scanpy.external.tl.palantir(adata)` first."
+        )
+
+    X = adata.obsm[repr_key]
+
+    # Set the default arguments for mellon.DensityEstimator
+    mellon_args = dict()
+    mellon_args.update(kwargs)
+
+    dest = DensityEstimator(**mellon_args)
+    log_density = np.asarray(dest.fit_predict(X))
+
+    # Save the density values and predictor to adata
+    adata.obs[density_key] = log_density
+    adata.obs[density_key + "_clipped"] = np.clip(
+        log_density, *np.quantile(log_density, [0.01, 1])
+    )
+    adata.uns[density_key + "_predictor"] = dest.predict.to_dict()
+
+    return adata if copy else None
+
+
+def _check_import():
+    try:
+        import mellon
+    except ImportError:
+        raise ImportError('\nplease install mellon:\n\tpip install mellon')

--- a/scanpy/external/tl/_palantir.py
+++ b/scanpy/external/tl/_palantir.py
@@ -207,7 +207,7 @@ def palantir(
 
     # Diffusion maps
     dm_res = run_diffusion_maps(
-        data=df,
+        df,
         n_components=n_components,
         knn=knn,
         alpha=alpha,

--- a/scanpy/external/tl/_palantir.py
+++ b/scanpy/external/tl/_palantir.py
@@ -207,7 +207,7 @@ def palantir(
 
     # Diffusion maps
     dm_res = run_diffusion_maps(
-        data_df=df,
+        data=df,
         n_components=n_components,
         knn=knn,
         alpha=alpha,

--- a/scanpy/testing/_pytest/marks.py
+++ b/scanpy/testing/_pytest/marks.py
@@ -20,6 +20,7 @@ KNOWN = dict(
     harmony="harmonyTS",
     harmonypy="harmonypy",
     magic="magic-impute",
+    mellon="mellon",
     palantir="palantir",
     phenograph="PhenoGraph",
     samalg="sam-algorithm",

--- a/scanpy/tests/external/test_mellon.py
+++ b/scanpy/tests/external/test_mellon.py
@@ -1,0 +1,14 @@
+import pytest
+
+import scanpy as sc
+import scanpy.external as sce
+from scanpy.testing._helpers.data import pbmc3k_processed
+from scanpy.testing._pytest.marks import needs
+
+
+@needs("mellon")
+def test_mellon_core():
+    adata = pbmc3k_processed()
+
+    sce.tl.mellon(adata=adata, repr_key="X_pca")
+    assert adata.obs['mellon_log_density'].shape[0], "mellon cell-state density Error!"


### PR DESCRIPTION
This implements `scanpy.external.tl.mellon` using [Mellon](https://github.com/settylab/mellon) to compute cell-state density.