### PR TITLE
Fixed wrong order for groups with logreg

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -5,6 +5,7 @@
 
 * {func}`sc.pp.pca` and {func}`sc.pp.regress_out` now accept a layer argument {pr}`2588` {smaller}`S Dicks`
 
+
 ```{rubric} Docs
 ```
 
@@ -14,7 +15,7 @@
 * Updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
 * Fix {func}`~scanpy.pp.normalize_total` {pr}`2466` {smaller}`P Angerer`
 * Fix testing package build {pr}`2468` {smaller}`P Angerer`
-
+* {func}`tl.rank_genes_groups` now handles unsorted groups as intended {pr}`2589` {smaller}`S Dicks`
 
 ```{rubric} Ecosystem
 ```

--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -5,7 +5,6 @@
 
 * {func}`sc.pp.pca` and {func}`sc.pp.regress_out` now accept a layer argument {pr}`2588` {smaller}`S Dicks`
 
-
 ```{rubric} Docs
 ```
 
@@ -15,7 +14,6 @@
 * Updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
 * Fix {func}`~scanpy.pp.normalize_total` {pr}`2466` {smaller}`P Angerer`
 * Fix testing package build {pr}`2468` {smaller}`P Angerer`
-* {func}`~scanpy.tl.rank_genes_groups` now handles unsorted groups as intended {pr}`2589` {smaller}`S Dicks`
 
 ```{rubric} Ecosystem
 ```

--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -15,5 +15,6 @@
 * Fix {func}`~scanpy.pp.normalize_total` {pr}`2466` {smaller}`P Angerer`
 * Fix testing package build {pr}`2468` {smaller}`P Angerer`
 
+
 ```{rubric} Ecosystem
 ```

--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -15,7 +15,7 @@
 * Updated {func}`~scanpy.pp.read_visium` such that it can read spaceranger 2.0 files {smaller}`L Lehner`
 * Fix {func}`~scanpy.pp.normalize_total` {pr}`2466` {smaller}`P Angerer`
 * Fix testing package build {pr}`2468` {smaller}`P Angerer`
-* {func}`tl.rank_genes_groups` now handles unsorted groups as intended {pr}`2589` {smaller}`S Dicks`
+* {func}`~scanpy.tl.rank_genes_groups` now handles unsorted groups as intended {pr}`2589` {smaller}`S Dicks`
 
 ```{rubric} Ecosystem
 ```

--- a/docs/release-notes/1.9.4.md
+++ b/docs/release-notes/1.9.4.md
@@ -6,3 +6,4 @@
 * Support scikit-learn 1.3 {pr}`2515` {smaller}`P Angerer`
 * Deal with `None` value vanishing from things like `.uns['log1p']` {pr}`2546` {smaller}`SP Shen`
 * Depend on `igraph` instead of `python-igraph` {pr}`2566` {smaller}`P Angerer`
+* {func}`~scanpy.tl.rank_genes_groups` now handles unsorted groups as intended {pr}`2589` {smaller}`S Dicks`

--- a/scanpy/tests/test_rank_genes_groups_logreg.py
+++ b/scanpy/tests/test_rank_genes_groups_logreg.py
@@ -5,10 +5,7 @@ import scanpy as sc
 import pandas as pd
 
 
-@pytest.mark.parametrize(
-    "method",
-    ["t-test", "logreg"],
-)
+@pytest.mark.parametrize('method', ['t-test', 'logreg'])
 def test_rank_genes_groups_with_renamed_categories(method):
     adata = sc.datasets.blobs(n_variables=4, n_centers=3, n_observations=200)
     assert np.allclose(adata.X[1], [9.214668, -2.6487126, 4.2020774, 0.51076424])
@@ -31,34 +28,34 @@ def test_rank_genes_groups_with_renamed_categories_use_rep():
     adata = sc.datasets.blobs(n_variables=4, n_centers=3, n_observations=200)
     assert np.allclose(adata.X[1], [9.214668, -2.6487126, 4.2020774, 0.51076424])
 
-    adata.layers["to_test"] = adata.X.copy()
+    adata.layers['to_test'] = adata.X.copy()
     adata.X = adata.X[::-1, :]
 
     sc.tl.rank_genes_groups(
-        adata, 'blobs', method='logreg', layer="to_test", use_raw=False
+        adata, 'blobs', method='logreg', layer='to_test', use_raw=False
     )
     assert adata.uns['rank_genes_groups']['names'].dtype.names == ('0', '1', '2')
     assert adata.uns['rank_genes_groups']['names'][0].tolist() == ('1', '3', '0')
 
-    sc.tl.rank_genes_groups(adata, 'blobs', method="logreg")
+    sc.tl.rank_genes_groups(adata, 'blobs', method='logreg')
     assert not adata.uns['rank_genes_groups']['names'][0].tolist() == ('3', '1', '0')
 
 
 def test_rank_genes_groups_with_unsorted_groups():
     adata = sc.datasets.blobs(n_variables=10, n_centers=5, n_observations=200)
     adata._sanitize()
-    adata.rename_categories('blobs', ['Zero', 'One', 'Two', "Three", "Four"])
+    adata.rename_categories('blobs', ['Zero', 'One', 'Two', 'Three', 'Four'])
     bdata = adata.copy()
     sc.tl.rank_genes_groups(
-        adata, 'blobs', groups=['Zero', 'One', 'Three'], method="logreg"
+        adata, 'blobs', groups=['Zero', 'One', 'Three'], method='logreg'
     )
     sc.tl.rank_genes_groups(
-        bdata, 'blobs', groups=['One', 'Three', 'Zero'], method="logreg"
+        bdata, 'blobs', groups=['One', 'Three', 'Zero'], method='logreg'
     )
     array_ad = pd.DataFrame(
-        adata.uns["rank_genes_groups"]["scores"]['Three']
+        adata.uns['rank_genes_groups']['scores']['Three']
     ).to_numpy()
     array_bd = pd.DataFrame(
-        bdata.uns["rank_genes_groups"]["scores"]['Three']
+        bdata.uns['rank_genes_groups']['scores']['Three']
     ).to_numpy()
     np.testing.assert_equal(array_ad, array_bd)

--- a/scanpy/tests/test_rank_genes_groups_logreg.py
+++ b/scanpy/tests/test_rank_genes_groups_logreg.py
@@ -45,16 +45,20 @@ def test_rank_genes_groups_with_renamed_categories_use_rep():
 
 
 def test_rank_genes_groups_with_unsorted_groups():
-    adata = sc.datasets.blobs(n_variables=4, n_centers=3, n_observations=200)
+    adata = sc.datasets.blobs(n_variables=10, n_centers=5, n_observations=200)
     adata._sanitize()
-    adata.rename_categories('blobs', ['Zero', 'One', 'Two'])
+    adata.rename_categories('blobs', ['Zero', 'One', 'Two', "Three", "Four"])
     bdata = adata.copy()
     sc.tl.rank_genes_groups(
-        adata, 'blobs', groups=['Zero', 'One', 'Two'], method="logreg"
+        adata, 'blobs', groups=['Zero', 'One', 'Three'], method="logreg"
     )
     sc.tl.rank_genes_groups(
-        bdata, 'blobs', groups=['One', 'Two', 'Zero'], method="logreg"
+        bdata, 'blobs', groups=['One', 'Three', 'Zero'], method="logreg"
     )
-    array_ad = pd.DataFrame(adata.uns["rank_genes_groups"]["scores"]['One']).to_numpy()
-    array_bd = pd.DataFrame(bdata.uns["rank_genes_groups"]["scores"]['One']).to_numpy()
+    array_ad = pd.DataFrame(
+        adata.uns["rank_genes_groups"]["scores"]['Three']
+    ).to_numpy()
+    array_bd = pd.DataFrame(
+        bdata.uns["rank_genes_groups"]["scores"]['Three']
+    ).to_numpy()
     np.testing.assert_equal(array_ad, array_bd)

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -341,12 +341,14 @@ class _RankGenes:
         clf = LogisticRegression(**kwds)
         clf.fit(X, self.grouping.cat.codes)
         scores_all = clf.coef_
-        for igroup, _ in enumerate(self.groups_order):
+        unique_codes = np.unique(self.grouping.cat.codes)
+        for igroup, cat in enumerate(self.groups_order):
             if len(self.groups_order) <= 2:  # binary logistic regression
                 scores = scores_all[0]
             else:
-                scores = scores_all[igroup]
-
+                cat = np.where(self.grouping.cat.categories == cat)[0][0]
+                cat = np.where(unique_codes == cat)[0][0]
+                scores = scores_all[cat]
             yield igroup, scores, None
 
             if len(self.groups_order) <= 2:

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -349,9 +349,9 @@ class _RankGenes:
             else:
                 # cat code is index of cat value in .categories
                 cat_code: int = np.argmax(self.grouping.cat.categories == cat)
-                # index of scores array is index of cat code in array of existing codes
-                idx_scores: int = np.argmax(existing_codes == cat_code)
-                scores = scores_all[idx_scores]
+                # index of scores row is index of cat code in array of existing codes
+                scores_idx: int = np.argmax(existing_codes == cat_code)
+                scores = scores_all[scores_idx]
             yield igroup, scores, None
 
             if len(self.groups_order) <= 2:

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -341,12 +341,17 @@ class _RankGenes:
         clf = LogisticRegression(**kwds)
         clf.fit(X, self.grouping.cat.codes)
         scores_all = clf.coef_
+        # not all codes necessarily appear in data
+        existing_codes = np.unique(self.grouping.cat.codes)
         for igroup, cat in enumerate(self.groups_order):
             if len(self.groups_order) <= 2:  # binary logistic regression
                 scores = scores_all[0]
             else:
+                # cat code is index of cat value in .categories
                 cat_code: int = np.argmax(self.grouping.cat.categories == cat)
-                scores = scores_all[cat_code]
+                # index of scores array is index of cat code in array of existing codes
+                idx_scores: int = np.argmax(existing_codes == cat_code)
+                scores = scores_all[idx_scores]
             yield igroup, scores, None
 
             if len(self.groups_order) <= 2:

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -341,14 +341,12 @@ class _RankGenes:
         clf = LogisticRegression(**kwds)
         clf.fit(X, self.grouping.cat.codes)
         scores_all = clf.coef_
-        unique_codes = np.unique(self.grouping.cat.codes)
         for igroup, cat in enumerate(self.groups_order):
             if len(self.groups_order) <= 2:  # binary logistic regression
                 scores = scores_all[0]
             else:
-                cat = np.where(self.grouping.cat.categories == cat)[0][0]
-                cat = np.where(unique_codes == cat)[0][0]
-                scores = scores_all[cat]
+                cat_code: int = np.argmax(self.grouping.cat.categories == cat)
+                scores = scores_all[cat_code]
             yield igroup, scores, None
 
             if len(self.groups_order) <= 2:


### PR DESCRIPTION
Fixes a bug where the `groups` argument would return a wrongly sorted list for logreg in rank_gene_groups.
