### PR TITLE
(chore): run all python versions up to 3.11 in CI

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -18,7 +18,12 @@ jobs:
     matrix:
       Python38:
         python.version: '3.8'
-      Python39: {}
+      Python39:
+        python.version: '3.9'
+      Python310:
+        python.version: '3.10'
+      Python311:
+        python.version: '3.11'
       minimal_tests:
         TEST_EXTRA: 'test-min'
       anndata_dev:


### PR DESCRIPTION
@ivirshup mentioned that `scanpy` should work up to `3.11` so this PR adds it to the CI.
