### PR TITLE
Unify needs() syntax

### DIFF
--- a/scanpy/tests/external/test_palantir.py
+++ b/scanpy/tests/external/test_palantir.py
@@ -6,7 +6,9 @@ from scanpy.testing._helpers.data import pbmc3k_processed
 from scanpy.testing._pytest.marks import needs
 
 
-@needs("palantir")
+pytestmark = [needs('palantir')]
+
+
 def test_palantir_core():
     adata = pbmc3k_processed()
 

--- a/scanpy/tests/external/test_phenograph.py
+++ b/scanpy/tests/external/test_phenograph.py
@@ -9,7 +9,9 @@ import scanpy.external as sce
 from scanpy.testing._pytest.marks import needs
 
 
-@needs("phenograph")
+pytestmark = [needs('phenograph')]
+
+
 def test_phenograph():
     df = np.random.rand(1000, 40)
     dframe = pd.DataFrame(df)

--- a/scanpy/tests/external/test_wishbone.py
+++ b/scanpy/tests/external/test_wishbone.py
@@ -6,7 +6,9 @@ from scanpy.testing._helpers.data import pbmc3k
 from scanpy.testing._pytest.marks import needs
 
 
-@needs("wishbone")
+pytestmark = [needs('wishbone')]
+
+
 def test_run_wishbone():
     adata = pbmc3k()
     sc.pp.normalize_per_cell(adata)

--- a/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
+++ b/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
@@ -20,8 +20,8 @@ ROOT = HERE / '_images_paga_paul15_subsampled'
 FIGS = HERE / 'figures'
 
 
-@needs("igraph")
-@needs("louvain")
+@needs('igraph')
+@needs('louvain')
 def test_paga_paul15_subsampled(image_comparer, plt):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=25)
 

--- a/scanpy/tests/notebooks/test_pbmc3k.py
+++ b/scanpy/tests/notebooks/test_pbmc3k.py
@@ -26,7 +26,7 @@ ROOT = HERE / 'pbmc3k_images'
 FIGS = HERE / 'figures'
 
 
-@needs("leidenalg")
+@needs('leidenalg')
 def test_pbmc3k(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=20)
 

--- a/scanpy/tests/test_clustering.py
+++ b/scanpy/tests/test_clustering.py
@@ -9,7 +9,7 @@ def adata_neighbors():
     return pbmc68k_reduced()
 
 
-@needs("leidenalg")
+@needs('leidenalg')
 def test_leiden_basic(adata_neighbors):
     sc.tl.leiden(adata_neighbors)
 
@@ -17,8 +17,8 @@ def test_leiden_basic(adata_neighbors):
 @pytest.mark.parametrize(
     'clustering,key',
     [
-        pytest.param(sc.tl.louvain, 'louvain', marks=needs("louvain")),
-        pytest.param(sc.tl.leiden, 'leiden', marks=needs("leidenalg")),
+        pytest.param(sc.tl.louvain, 'louvain', marks=needs('louvain')),
+        pytest.param(sc.tl.leiden, 'leiden', marks=needs('leidenalg')),
     ],
 )
 def test_clustering_subset(adata_neighbors, clustering, key):
@@ -48,7 +48,7 @@ def test_clustering_subset(adata_neighbors, clustering, key):
         assert len(common_cat) == 0
 
 
-@needs("louvain")
+@needs('louvain')
 def test_louvain_basic(adata_neighbors):
     sc.tl.louvain(adata_neighbors)
     sc.tl.louvain(adata_neighbors, use_weights=True)
@@ -56,7 +56,7 @@ def test_louvain_basic(adata_neighbors):
     sc.tl.louvain(adata_neighbors, flavor="igraph")
 
 
-@needs("louvain")
+@needs('louvain')
 def test_partition_type(adata_neighbors):
     import louvain
 

--- a/scanpy/tests/test_embedding.py
+++ b/scanpy/tests/test_embedding.py
@@ -41,10 +41,10 @@ def test_umap_init_dtype():
 
 
 @pytest.mark.parametrize(
-    "layout",
+    'layout',
     [
-        pytest.param("fa", marks=needs("fa2")),
-        pytest.param("fr", marks=needs("igraph")),
+        pytest.param('fa', marks=needs('fa2')),
+        pytest.param('fr', marks=needs('igraph')),
     ],
 )
 def test_umap_init_paga(layout):

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -305,7 +305,7 @@ def test_higly_variable_genes_compare_to_seurat():
     )
 
 
-@needs("skmisc")
+@needs('skmisc')
 def test_higly_variable_genes_compare_to_seurat_v3():
     seurat_hvg_info = pd.read_csv(
         FILE_V3, sep=' ', dtype={"variances_norm": np.float64}
@@ -461,7 +461,7 @@ def test_highly_variable_genes_batches():
     assert np.all(np.isin(colnames, hvg1.columns))
 
 
-@needs("skmisc")
+@needs('skmisc')
 def test_seurat_v3_mean_var_output_with_batchkey():
     pbmc = pbmc3k()
     pbmc.var_names_make_unique()

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -31,8 +31,8 @@ def test_neighbors_key_added(adata):
 
 
 # test functions with neighbors_key and obsp
-@needs("igraph")
-@needs("leidenalg")
+@needs('igraph')
+@needs('leidenalg')
 @pytest.mark.parametrize('field', ['neighbors_key', 'obsp'])
 def test_neighbors_key_obsp(adata, field):
     adata1 = adata.copy()
@@ -78,7 +78,7 @@ def test_neighbors_key_obsp(adata, field):
         )
 
 
-@needs("louvain")
+@needs('louvain')
 @pytest.mark.parametrize('field', ['neighbors_key', 'obsp'])
 def test_neighbors_key_obsp_louvain(adata, field):
     adata1 = adata.copy()

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -32,9 +32,9 @@ X_frac = [[1, 0, 1], [3, 0, 1], [5, 6, 1]]
     params=[
         lambda: np.array,
         lambda: csr_matrix,
-        pytest.param(lambda: da.from_array, marks=[needs("dask")]),
+        pytest.param(lambda: da.from_array, marks=[needs('dask')]),
     ],
-    ids=["numpy-array", "sparse-csr", "dask-array"],
+    ids=['numpy-array', 'sparse-csr', 'dask-array'],
 )
 def typ(request) -> Callable[[], type]:
     return request.param()

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -43,7 +43,7 @@ sc.set_figure_params(dpi=40, color_map='viridis')
 # the ./figures folder to ./_images/
 
 
-@needs("leidenalg")
+@needs('leidenalg')
 def test_heatmap(image_comparer):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=15)
 
@@ -1587,7 +1587,7 @@ def test_filter_rank_genes_groups_plots(tmp_path, plot, check_same_image):
     check_same_image(pth_a, pth_b, tol=1)
 
 
-@needs("scrublet")
+@needs('scrublet')
 def test_scrublet_plots(image_comparer, plt):
     save_and_compare_images = image_comparer(ROOT, FIGS, tol=30)
 

--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -14,7 +14,7 @@ HERE = Path(__file__).parent / Path('_data/')
 input_file = str(Path(HERE, "10x-10k-subset.zarr"))
 
 
-pytestmark = [needs("zarr")]
+pytestmark = [needs('zarr')]
 
 
 @pytest.fixture()
@@ -26,8 +26,8 @@ def adata():
 
 @pytest.fixture(
     params=[
-        pytest.param("direct", marks=[needs("zappy")]),
-        pytest.param("dask", marks=[needs("dask")]),
+        pytest.param('direct', marks=[needs('zappy')]),
+        pytest.param('dask', marks=[needs('dask')]),
     ]
 )
 def adata_dist(request):


### PR DESCRIPTION
Follow-up to #2593: make `needs('thing` more greppable