### PR TITLE
changed  hvg with PR  to work with numba

### DIFF
--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -230,6 +230,7 @@ def _highly_variable_pearson_residuals(
             sums_cells = np.array(X_batch.sum(axis=1)).ravel()
             sum_total = np.sum(sums_genes).squeeze()
             X_batch = X_batch.tocsc()
+            X_batch.eliminate_zeros()
             residual_gene_var = calculate_res_sparse(
                 X_batch.indptr,
                 X_batch.indices,

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -33,15 +33,15 @@ def calculate_res_sparse(
     indptr,
     index,
     data,
+    *,
     sums_genes,
     sums_cells,
-    residuals,
     sum_total,
     clip,
     theta,
     n_genes,
     n_cells,
-):
+) -> NDArray[np.float64]:
     for gene in nb.prange(n_genes):
         start_idx = indptr[gene]
         stop_idx = indptr[gene + 1]

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -185,7 +185,7 @@ def _highly_variable_pearson_residuals(
             sums_genes = np.sum(X_batch, axis=0).ravel()
             sums_cells = np.sum(X_batch, axis=1).ravel()
             sum_total = np.sum(sums_genes)
-            X_batch = np.array(X_batch, order='F')
+            X_batch = np.array(X_batch, dtype=np.float64, order='F')
             calculate_res_dense(
                 X_batch,
                 sums_genes,

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -79,8 +79,8 @@ def calculate_res_sparse(
 
 @nb.njit(parallel=True)
 def calculate_res_dense(
-    matrix, sums_genes, sums_cells, residuals, sum_total, clip, theta, n_genes, n_cells
-):
+    matrix, *, sums_genes, sums_cells, sum_total, clip, theta, n_genes, n_cells
+) -> NDArray[np.float64]:
     for gene in nb.prange(n_genes):
         sum_clipped_res = np.float64(0.0)
         for cell in range(n_cells):

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -195,7 +195,7 @@ def _highly_variable_pearson_residuals(
 
         sums_genes = np.array(X_batch.sum(axis=0)).ravel()
         sums_cells = np.array(X_batch.sum(axis=1)).ravel()
-        sum_total = np.sum(sums_genes).squeeze()
+        sum_total = np.sum(sums_genes).ravel()
 
         residual_gene_var = calculate_res(
             sums_genes=sums_genes,

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -47,6 +47,10 @@ def clac_clipped_res_sparse(
 
 @nb.njit
 def get_value(cell, sparse_idx, index, stop_idx, data) -> np.float64:
+    """
+    This function navigates the sparsity of the CSC (Compressed Sparse Column) matrix,
+    returning the value at the specified cell location if it exists, or zero otherwise.
+    """
     if sparse_idx < stop_idx and index[sparse_idx] == cell:
         return data[sparse_idx]
     else:


### PR DESCRIPTION
The pearson residuals implementation for hvg is currently very slow and memory inefficient. I switched it to a numba kernel for csc and dense F-continous arrays.

It's based on the cuda-kernel in [rapids-singlecell](https://github.com/scverse/rapids_singlecell/blob/main/src/rapids_singlecell/cunnData_funcs/_hvg.py#L14-L258). For 90000 cells we go from 24 seconds to less than 5 with the new implementation. For smaller datasets we don't see a speedup.