### PR TITLE
allow sc.pp.subsample in backed mode when returning a copy

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -4,6 +4,7 @@
 ```
 
 * {func}`scanpy.pp.pca` and {func}`scanpy.pp.regress_out` now accept a layer argument {pr}`2588` {smaller}`S Dicks`
+* {func}`scanpy.pp.subsample` with `copy=True` can now be called in backed mode {pr}`2624` {smaller}`E Roellin`
 
 ```{rubric} Docs
 ```

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -899,7 +899,10 @@ def subsample(
     obs_indices = np.random.choice(old_n_obs, size=new_n_obs, replace=False)
     if isinstance(data, AnnData):
         if copy:
-            return data[obs_indices].copy()
+            if data.isbacked:
+                return data[obs_indices].to_memory().copy()
+            else:
+                return data[obs_indices].copy()
         else:
             data._inplace_subset_obs(obs_indices)
     else:

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -904,7 +904,12 @@ def subsample(
             else:
                 return data[obs_indices].copy()
         else:
-            data._inplace_subset_obs(obs_indices)
+            if data.isbacked:
+                raise NotImplementedError(
+                    "Inplace subsampling is not implemented for backed objects."
+                )
+            else:
+                data._inplace_subset_obs(obs_indices)
     else:
         X = data
         return X[obs_indices], obs_indices

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -898,16 +898,16 @@ def subsample(
         raise ValueError('Either pass `n_obs` or `fraction`.')
     obs_indices = np.random.choice(old_n_obs, size=new_n_obs, replace=False)
     if isinstance(data, AnnData):
-        if copy:
-            if data.isbacked:
+        if data.isbacked:
+            if copy:
                 return data[obs_indices].to_memory()
             else:
-                return data[obs_indices].copy()
-        else:
-            if data.isbacked:
                 raise NotImplementedError(
                     "Inplace subsampling is not implemented for backed objects."
                 )
+        else:
+            if copy:
+                return data[obs_indices].copy()
             else:
                 data._inplace_subset_obs(obs_indices)
     else:

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -900,7 +900,7 @@ def subsample(
     if isinstance(data, AnnData):
         if copy:
             if data.isbacked:
-                return data[obs_indices].to_memory().copy()
+                return data[obs_indices].to_memory()
             else:
                 return data[obs_indices].copy()
         else:

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -123,7 +123,7 @@ def test_subsample_copy_backed(tmp_path):
     adata_d.filename = filename
     # This should not throw an error
     assert sc.pp.subsample(adata_d, n_obs=40, copy=True).shape == (40, 10)
-    assert np.allclose(
+    np.testing.assert_array_equal(
         sc.pp.subsample(adata_m, n_obs=40, copy=True).X,
         sc.pp.subsample(adata_d, n_obs=40, copy=True).X,
     )

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -127,6 +127,8 @@ def test_subsample_copy_backed(tmp_path):
         sc.pp.subsample(adata_m, n_obs=40, copy=True).X,
         sc.pp.subsample(adata_d, n_obs=40, copy=True).X,
     )
+    with pytest.raises(NotImplementedError):
+        sc.pp.subsample(adata_d, n_obs=40, copy=False)
 
 
 def test_scale():

--- a/scanpy/tests/test_preprocessing.py
+++ b/scanpy/tests/test_preprocessing.py
@@ -115,6 +115,20 @@ def test_subsample_copy():
     assert sc.pp.subsample(adata, fraction=0.1, copy=True).shape == (20, 10)
 
 
+def test_subsample_copy_backed(tmp_path):
+    A = np.random.rand(200, 10).astype(np.float32)
+    adata_m = AnnData(A.copy())
+    adata_d = AnnData(A.copy())
+    filename = tmp_path / 'test.h5ad'
+    adata_d.filename = filename
+    # This should not throw an error
+    assert sc.pp.subsample(adata_d, n_obs=40, copy=True).shape == (40, 10)
+    assert np.allclose(
+        sc.pp.subsample(adata_m, n_obs=40, copy=True).X,
+        sc.pp.subsample(adata_d, n_obs=40, copy=True).X,
+    )
+
+
 def test_scale():
     adata = pbmc68k_reduced()
     adata.X = adata.raw.X


### PR DESCRIPTION
Adresses issue #2495.

Suggested change to allow `sc.pp.subsample` in backed mode of AnnData, when `copy=True` in `sc.pp.subsample`

```
import scanpy as sc

adata = sc.read_h5ad("matrix/scatlas.h5ad", backed="r")
adata_sample = sc.pp.subsample(adata, fraction=0.01, copy=True)
```

Tagging @ivirshup.

