### PR TITLE
Prepare 1.9.4 release

### DIFF
--- a/docs/release-notes/1.9.4.md
+++ b/docs/release-notes/1.9.4.md
@@ -1,4 +1,4 @@
-### 1.9.4 {small}`the future`
+### 1.9.4 {small}`2023-08-24`
 
 ```{rubric} Bug fixes
 ```

--- a/docs/release-notes/1.9.5.md
+++ b/docs/release-notes/1.9.5.md
@@ -1,0 +1,4 @@
+### 1.9.5 {small}`the future`
+
+```{rubric} Bug fixes
+```

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -8,6 +8,9 @@
 ```
 ## Version 1.9
 
+```{include} /release-notes/1.9.5.md
+```
+
 ```{include} /release-notes/1.9.4.md
 ```
 


### PR DESCRIPTION
I went through the PRs and we actually did a good job (at least for the backported ones): Nothing missing!

Regarding the new 1.9.5.md: Even if 1.9.5 will probably not happen, we should just keep the file and fill it as expected, and if we release 1.10 first, we just migrate the by-then-merged changes over and delete the 1.9.5.md.

Better to stick to a clean process than improvising and making things confusing.