### PR TITLE
Add note to the groups arg in rank_genes_groups()

### DIFF
--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -462,7 +462,9 @@ def rank_genes_groups(
         Key from `adata.layers` whose value will be used to perform tests on.
     groups
         Subset of groups, e.g. [`'g1'`, `'g2'`, `'g3'`], to which comparison
-        shall be restricted, or `'all'` (default), for all groups.
+        shall be restricted, or `'all'` (default), for all groups. Note that if
+        `reference='rest'` all groups will still be used as the reference, not
+        just those specified in `groups`.
     reference
         If `'rest'`, compare each group to the union of the rest of the group.
         If a group identifier, compare with respect to this group.


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
It was unclear if the `groups` argument in `rank_genes_groups()` is equivalent to subsetting when `reference='rest'`(i.e. only the selected groups are tested against each other) or if only those groups are tested but all groups are still used as the reference.

This PR adds a note explaining the current behaviour (option 2).