### PR TITLE
n_components parameter for sc.tl.tsne

### DIFF
--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -42,6 +42,8 @@ def tsne(
         Annotated data matrix.
     {doc_n_pcs}
     {use_rep}
+    n_components
+        Dimension of the embedded space.
     perplexity
         The perplexity is related to the number of nearest neighbors that
         is used in other manifold learning algorithms. Larger datasets

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -13,6 +13,7 @@ from .. import logging as logg
 @_doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)
 def tsne(
     adata: AnnData,
+    n_components = 2,
     n_pcs: Optional[int] = None,
     use_rep: Optional[str] = None,
     perplexity: Union[float, int] = 30,
@@ -87,6 +88,7 @@ def tsne(
     # params for sklearn
     n_jobs = settings.n_jobs if n_jobs is None else n_jobs
     params_sklearn = dict(
+        n_components=n_components,
         perplexity=perplexity,
         random_state=random_state,
         verbose=settings.verbosity > 3,
@@ -149,6 +151,7 @@ def tsne(
         "params": {
             k: v
             for k, v in {
+                "n_components": n_components,
                 "perplexity": perplexity,
                 "early_exaggeration": early_exaggeration,
                 "learning_rate": learning_rate,


### PR DESCRIPTION
Dear scanpy-team,

thank you very much for this great package!

Similar to issues  [https://github.com/scverse/scanpy/issues/1435](url) and [https://github.com/scverse/scanpy/issues/460](url) I am interested in having an n_components parameter in the sc.tl.tsne function. 

Apparently, the commit was made but no pull request was opened back in 2019.

I added the necessary parameter to the arguments and passed them via the params_sklearn dict to the respective function. 

Documentation is also updated.

If you feel there is a need for a separate test, let me know, happy to include one.


Best,
Tarik
