### PR TITLE
Compatibility with Palantir>=v1.3.0

### DIFF
--- a/scanpy/external/tl/_palantir.py
+++ b/scanpy/external/tl/_palantir.py
@@ -207,7 +207,7 @@ def palantir(
 
     # Diffusion maps
     dm_res = run_diffusion_maps(
-        data_df=df,
+        df,
         n_components=n_components,
         knn=knn,
         alpha=alpha,
@@ -292,7 +292,7 @@ def palantir_results(
 
     ms_data = pd.DataFrame(adata.obsm[ms_data], index=adata.obs_names)
     pr_res = run_palantir(
-        ms_data=ms_data,
+        ms_data,
         early_cell=early_cell,
         terminal_states=terminal_states,
         knn=knn,


### PR DESCRIPTION
This PR resolves [Issue #2608](https://github.com/scverse/scanpy/issues/2608) in Scanpy by ensuring compatibility with both [Palantir v1.3.0](https://github.com/dpeerlab/Palantir/releases/tag/v1.3.0) ([function signature](https://github.com/dpeerlab/Palantir/blob/870a9ba88b978a070fd0c29df4d1a3b94b0c9ad9/src/palantir/core.py#L34-L51)) and its [earlier versions](https://github.com/dpeerlab/Palantir/blob/4d4f9fcdbfebcf47b4ca1b7ac8a0fb1b8e5fc089/src/palantir/core.py#L31-L41). This is achieved by substituting the initial keyword argument (`data_df`) with a positional argument.

The change aligns with Palantir v1.3.0's new optionality to accept AnnData objects as the first argument, making the keyword `data_df` potentially misleading. Adopting a positional argument ensures compatibility with both new and prior versions of Palantir.