### PR TITLE
DensMAP support

### DIFF
--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -102,7 +102,13 @@ def umap(
     copy
         Return a copy instead of writing to adata.
     method
-        Use the original 'umap' implementation, or 'rapids' (experimental, GPU only)
+        Chosen implementation.
+        ``'umap'``
+            Umap’s simplical set embedding.
+        ``'rapids'``
+            GPU accelerated implementation.
+            .. deprecated:: 1.10.0
+                Use :func:`rapids_singlecell.tl.umap` instead.
     neighbors_key
         If not specified, umap looks .uns['neighbors'] for neighbors settings
         and .obsp['connectivities'] for connectivities
@@ -139,16 +145,15 @@ def umap(
             f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap'
         )
 
-    neigh_params = neighbors['params']
-
     if random_state != 0:
         adata.uns['umap']['params']['random_state'] = random_state
     random_state = check_random_state(random_state)
 
+    neigh_params = neighbors['params']
     X = _choose_representation(
         adata,
-        neigh_params.get('use_rep', None),
-        neigh_params.get('n_pcs', None),
+        use_rep=neigh_params.get('use_rep', None),
+        n_pcs=neigh_params.get('n_pcs', None),
         silent=True,
     )
 
@@ -223,6 +228,11 @@ def umap(
             verbose=settings.verbosity > 3,
         )
     elif method == 'rapids':
+        msg = (
+            "`method='rapids'` is deprecated. "
+            'Use `rapids_singlecell.tl.louvain` instead.'
+        )
+        warnings.warn(msg, FutureWarning)
         metric = neigh_params.get('metric', 'euclidean')
         if metric != 'euclidean':
             raise ValueError(

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -31,6 +31,8 @@ def umap(
     copy: bool = False,
     method: Literal['umap', 'rapids'] = 'umap',
     neighbors_key: Optional[str] = None,
+    densmap: Optional[bool] = False,
+    dens_lambda: Optional[float] = 0.2
 ) -> Optional[AnnData]:
     """\
     Embed the neighborhood graph using UMAP [McInnes18]_.
@@ -100,21 +102,17 @@ def umap(
     copy
         Return a copy instead of writing to adata.
     method
-        Chosen implementation.
-
-        ``'umap'``
-            Umap’s simplical set embedding.
-        ``'rapids'``
-            GPU accelerated implementation.
-
-            .. deprecated:: 1.10.0
-                Use :func:`rapids_singlecell.tl.umap` instead.
+        Use the original 'umap' implementation, or 'rapids' (experimental, GPU only)
     neighbors_key
         If not specified, umap looks .uns['neighbors'] for neighbors settings
         and .obsp['connectivities'] for connectivities
         (default storage places for pp.neighbors).
         If specified, umap looks .uns[neighbors_key] for neighbors settings and
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
+    densmap
+        Use DensMAP to compute the coordinates
+    dens_lambda
+        Specify a lambda value to be used by DensMAP
 
     Returns
     -------
@@ -141,6 +139,19 @@ def umap(
             f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap'
         )
 
+    neigh_params = neighbors['params']
+
+    if random_state != 0:
+        adata.uns['umap']['params']['random_state'] = random_state
+    random_state = check_random_state(random_state)
+
+    X = _choose_representation(
+        adata,
+        neigh_params.get('use_rep', None),
+        neigh_params.get('n_pcs', None),
+        silent=True,
+    )
+
     # Compat for umap 0.4 -> 0.5
     with warnings.catch_warnings():
         # umap 0.5.0
@@ -152,10 +163,18 @@ def umap(
         def simplicial_set_embedding(*args, **kwargs):
             from umap.umap_ import simplicial_set_embedding
 
+            kwds = {
+                "lambda": dens_lambda,
+                "frac": 0.3,
+                "var_shift": 0.1,
+                "n_neighbors": neigh_params.get('n_neighbors', 15),
+                "graph_dists": neighbors['distances'].tocoo().todok()
+            } if densmap else {}
+
             X_umap, _ = simplicial_set_embedding(
                 *args,
-                densmap=False,
-                densmap_kwds={},
+                densmap=densmap,
+                densmap_kwds=kwds,
                 output_dens=False,
                 **kwargs,
             )
@@ -182,17 +201,6 @@ def umap(
     if hasattr(init_coords, "dtype"):
         init_coords = check_array(init_coords, dtype=np.float32, accept_sparse=False)
 
-    if random_state != 0:
-        adata.uns['umap']['params']['random_state'] = random_state
-    random_state = check_random_state(random_state)
-
-    neigh_params = neighbors['params']
-    X = _choose_representation(
-        adata,
-        use_rep=neigh_params.get('use_rep', None),
-        n_pcs=neigh_params.get('n_pcs', None),
-        silent=True,
-    )
     if method == 'umap':
         # the data matrix X is really only used for determining the number of connected components
         # for the init condition in the UMAP embedding
@@ -215,11 +223,6 @@ def umap(
             verbose=settings.verbosity > 3,
         )
     elif method == 'rapids':
-        msg = (
-            "`method='rapids'` is deprecated. "
-            'Use `rapids_singlecell.tl.louvain` instead.'
-        )
-        warnings.warn(msg, FutureWarning)
         metric = neigh_params.get('metric', 'euclidean')
         if metric != 'euclidean':
             raise ValueError(


### PR DESCRIPTION
I added an optional boolean parameter to scanpy.tl.umap for DensMAP. Since umap 0.5, ``simplicial_set_embedding`` takes ``densmap`` and ``densmap_kwds`` parameters, and tools/_umap is using this function, so DensMAP support is easily implemented.