### PR TITLE
Loosen exact equality restriction

### DIFF
--- a/scanpy/_utils/compute/is_constant.py
+++ b/scanpy/_utils/compute/is_constant.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Literal, TypeVar, overload
 from functools import partial, wraps, singledispatch
 from numbers import Integral
 from collections.abc import Callable
@@ -12,7 +13,10 @@ from scipy import sparse
 from ..._compat import DaskArray
 
 
-def _check_axis_supported(wrapped: Callable) -> Callable:
+C = TypeVar("C", bound=Callable)
+
+
+def _check_axis_supported(wrapped: C) -> C:
     @wraps(wrapped)
     def func(a, axis=None):
         if axis is not None:
@@ -25,9 +29,21 @@ def _check_axis_supported(wrapped: Callable) -> Callable:
     return func
 
 
+@overload
+def is_constant(a: NDArray, axis: None = None) -> bool:
+    ...
+
+
+@overload
+def is_constant(a: NDArray, axis: Literal[0, 1]) -> NDArray[np.bool_]:
+    ...
+
+
 @_check_axis_supported
 @singledispatch
-def is_constant(a, axis: int | None = None) -> bool | NDArray[np.bool_]:
+def is_constant(
+    a: NDArray, axis: Literal[0, 1] | None = None
+) -> bool | NDArray[np.bool_]:
     """
     Check whether values in array are constant.
 
@@ -61,7 +77,7 @@ def is_constant(a, axis: int | None = None) -> bool | NDArray[np.bool_]:
 
 
 @is_constant.register(np.ndarray)
-def _(a: NDArray, axis: int | None = None) -> bool | NDArray[np.bool_]:
+def _(a: NDArray, axis: Literal[0, 1] | None = None) -> bool | NDArray[np.bool_]:
     # Should eventually support nd, not now.
     if axis is None:
         return np.array_equal(a, a.flat[0])
@@ -77,7 +93,9 @@ def _is_constant_rows(a: NDArray) -> NDArray[np.bool_]:
 
 
 @is_constant.register(sparse.csr_matrix)
-def _(a: sparse.csr_matrix, axis: int | None = None) -> bool | NDArray[np.bool_]:
+def _(
+    a: sparse.csr_matrix, axis: Literal[0, 1] | None = None
+) -> bool | NDArray[np.bool_]:
     if axis is None:
         if len(a.data) == np.multiply(*a.shape):
             return is_constant(a.data)
@@ -114,7 +132,9 @@ def _is_constant_csr_rows(
 
 
 @is_constant.register(sparse.csc_matrix)
-def _(a: sparse.csc_matrix, axis: int | None = None) -> bool | NDArray[np.bool_]:
+def _(
+    a: sparse.csc_matrix, axis: Literal[0, 1] | None = None
+) -> bool | NDArray[np.bool_]:
     if axis is None:
         if len(a.data) == np.multiply(*a.shape):
             return is_constant(a.data)
@@ -128,7 +148,7 @@ def _(a: sparse.csc_matrix, axis: int | None = None) -> bool | NDArray[np.bool_]
 
 
 @is_constant.register(DaskArray)
-def _(a: DaskArray, axis: int | None = None) -> bool | NDArray[np.bool_]:
+def _(a: DaskArray, axis: Literal[0, 1] | None = None) -> bool | NDArray[np.bool_]:
     if axis is None:
         v = a[tuple(0 for _ in range(a.ndim))].compute()
         return (a == v).all()

--- a/scanpy/metrics/_common.py
+++ b/scanpy/metrics/_common.py
@@ -1,17 +1,19 @@
 from __future__ import annotations
 
 from functools import singledispatch
+from typing import TypeVar
 import warnings
 
 import numpy as np
 import pandas as pd
+from numpy.typing import NDArray
 from scipy import sparse
 
 from .._compat import DaskArray
 
 
 @singledispatch
-def _resolve_vals(val):
+def _resolve_vals(val: NDArray | sparse.spmatrix) -> NDArray | sparse.csr_matrix:
     return np.asarray(val)
 
 
@@ -33,7 +35,12 @@ def _(val):
     return val.to_numpy()
 
 
-def _check_vals(vals):
+V = TypeVar("V", np.ndarray, sparse.csr_matrix)
+
+
+def _check_vals(
+    vals: V,
+) -> tuple[V, NDArray[np.bool_] | slice, NDArray[np.float64]]:
     """\
     Checks that values wont cause issues in computation.
 

--- a/scanpy/metrics/_gearys_c.py
+++ b/scanpy/metrics/_gearys_c.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from functools import singledispatch
 from typing import Optional, Union
 
@@ -7,7 +9,7 @@ import numpy as np
 from scipy import sparse
 
 from ..get import _get_obs_rep
-from .._compat import fullname, DaskArray
+from .._compat import fullname
 from ._common import _resolve_vals, _check_vals
 
 
@@ -254,7 +256,7 @@ def _gearys_c_mtx_csr(
 
 
 @gearys_c.register(sparse.csr_matrix)
-def _gearys_c(g, vals) -> np.ndarray:
+def _gearys_c(g: sparse.csr_matrix, vals: np.ndarray | sparse.spmatrix) -> np.ndarray:
     assert g.shape[0] == g.shape[1], "`g` should be a square adjacency matrix"
     vals = _resolve_vals(vals)
     g_data = g.data.astype(np.float_, copy=False)

--- a/scanpy/metrics/_morans_i.py
+++ b/scanpy/metrics/_morans_i.py
@@ -1,4 +1,6 @@
 """Moran's I global spatial autocorrelation."""
+from __future__ import annotations
+
 from functools import singledispatch
 from typing import Union, Optional
 
@@ -8,7 +10,7 @@ from scipy import sparse
 from numba import njit, prange
 
 from ..get import _get_obs_rep
-from .._compat import fullname, DaskArray
+from .._compat import fullname
 from ._common import _resolve_vals, _check_vals
 
 
@@ -186,10 +188,7 @@ def _morans_i_mtx(
     return out
 
 
-@njit(
-    cache=True,
-    parallel=True,
-)
+@njit(cache=True, parallel=True)
 def _morans_i_mtx_csr(
     g_data: np.ndarray,
     g_indices: np.ndarray,
@@ -223,7 +222,7 @@ def _morans_i_mtx_csr(
 
 
 @morans_i.register(sparse.csr_matrix)
-def _morans_i(g: sparse.csr_matrix, vals) -> np.ndarray:
+def _morans_i(g: sparse.csr_matrix, vals: np.ndarray | sparse.spmatrix) -> np.ndarray:
     assert g.shape[0] == g.shape[1], "`g` should be a square adjacency matrix"
     vals = _resolve_vals(vals)
     g_data = g.data.astype(np.float_, copy=False)

--- a/scanpy/tests/test_metrics.py
+++ b/scanpy/tests/test_metrics.py
@@ -1,8 +1,7 @@
+import warnings
 from functools import partial
 from operator import eq
 from string import ascii_letters
-import sys
-import warnings
 
 import numpy as np
 import pandas as pd
@@ -15,9 +14,9 @@ from scanpy._compat import DaskArray
 from scanpy.testing._helpers.data import pbmc68k_reduced
 
 
-mark_flaky = pytest.mark.skipif(
-    sys.version_info < (3, 10),
-    reason='This used to work reliably, but doesn’t anymore in old Python versions',
+mark_flaky = pytest.mark.xfail(
+    strict=False,
+    reason='This used to work reliably, but doesn’t anymore',
 )
 
 

--- a/scanpy/tests/test_metrics.py
+++ b/scanpy/tests/test_metrics.py
@@ -94,7 +94,7 @@ def test_correctness(metric, size, expected, assert_equal):
     assert metric(adata, vals=connected) == expected
 
 
-def test_graph_metrics_w_constant_values(metric, array_type):
+def test_graph_metrics_w_constant_values(metric, array_type, assert_equal):
     # https://github.com/scverse/scanpy/issues/1806
     pbmc = pbmc68k_reduced()
     XT = array_type(pbmc.raw.X.T.copy())
@@ -123,14 +123,12 @@ def test_graph_metrics_w_constant_values(metric, array_type):
         results_const_vals = metric(g, XT_const_vals)
 
     assert not np.isnan(results_full).any()
-    np.testing.assert_almost_equal(results_const_zeros, results_const_vals)
+    assert_equal(results_const_zeros, results_const_vals)
     np.testing.assert_array_equal(np.nan, results_const_zeros[const_inds])
     np.testing.assert_array_equal(np.nan, results_const_vals[const_inds])
 
     non_const_mask = ~np.isin(np.arange(XT.shape[0]), const_inds)
-    np.testing.assert_almost_equal(
-        results_full[non_const_mask], results_const_zeros[non_const_mask]
-    )
+    assert_equal(results_full[non_const_mask], results_const_zeros[non_const_mask])
 
 
 def test_confusion_matrix():


### PR DESCRIPTION
They kept failing. Something upstream (likely numba) or Azure’s testing machines seem to have become less consistent in calculating this. [This thread](https://github.com/scverse/scanpy/pull/1740#discussion_r596827747) came across that. @ivirshup’s final statement was

> This bug seems to be based on having nested parallelism and certain reductions. We can avoid it by just not having nested parallelism, which is what I've done for gearys_c.

I don’t think exact float equality is a reasonable assumption, but if we want to continue to test for it, we need to be able to force numba to be predictable or so.

Needs no release note.

Added https://github.com/scverse/scanpy/issues/2688 to track this regression