### PR TITLE
Fix for highly_variable_genes flavor=seurat modifying layer

### DIFF
--- a/docs/release-notes/1.9.6.md
+++ b/docs/release-notes/1.9.6.md
@@ -6,5 +6,5 @@
 - Allow {func}`scanpy.pl.scatter` to accept a {class}`str` palette name {pr}`2571` {smaller}`P Angerer`
 - Make {func}`scanpy.external.tl.palantir` compatible with palantir >=1.3 {pr}`2672` {smaller}`DJ Otto`
 - Fix {func}`scanpy.pl.pca` when `return_fig=True` and `annotate_var_explained=True` {pr}`2682` {smaller}`J Wagner`
-- Temp fix `seaborn!=0.13.0` for {pr}`2661` {smaller}`P Angerer`
+- Temp fix for {issue}`2680` by skipping `seaborn` version 0.13.0 {pr}`2661` {smaller}`P Angerer`
 - Fix {func}`scanpy.pp.highly_variable_genes` to not modify the used layer when `flavor=seurat` {pr}`2698` {smaller}`E Roellin`

--- a/docs/release-notes/1.9.6.md
+++ b/docs/release-notes/1.9.6.md
@@ -5,4 +5,6 @@
 
 - Allow {func}`scanpy.pl.scatter` to accept a {class}`str` palette name {pr}`2571` {smaller}`P Angerer`
 - Make {func}`scanpy.external.tl.palantir` compatible with palantir >=1.3 {pr}`2672` {smaller}`DJ Otto`
-- Fix {func}`scanpy.pl.pca` when when `return_fig=True` and `annotate_var_explained=True` {pr}`2682` {smaller}`J Wagner`
+- Fix {func}`scanpy.pl.pca` when `return_fig=True` and `annotate_var_explained=True` {pr}`2682` {smaller}`J Wagner`
+- Temp fix `seaborn!=0.13.0` for {pr}`2661` {smaller}`P Angerer`
+- Fix {func}`scanpy.pp.highly_variable_genes` to not modify the used layer when `flavor=seurat` {pr}`2698` {smaller}`E Roellin`

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -194,9 +194,14 @@ def _highly_variable_genes_single_batch(
     """
     X = adata.layers[layer] if layer is not None else adata.X
     if flavor == 'seurat':
+        X = X.copy()
         if 'log1p' in adata.uns_keys() and adata.uns['log1p'].get('base') is not None:
             X *= np.log(adata.uns['log1p']['base'])
-        X = np.expm1(X)
+        # use out if possible. only possible since we copy X
+        if isinstance(X, np.ndarray):
+            np.expm1(X, out=X)
+        else:
+            X = np.expm1(X)
 
     mean, var = materialize_as_ndarray(_get_mean_var(X))
     # now actually compute the dispersion

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -73,7 +73,7 @@ def test_highly_variable_genes_basic():
 
 
 @pytest.mark.parametrize('base', [None, 10])
-@pytest.mark.parametrize('flavor', ['seurat', 'cell_ranger', 'seurat_v3'])
+@pytest.mark.parametrize('flavor', ['seurat', 'cell_ranger'])
 def test_highly_variable_genes_keep_layer(base, flavor):
     adata = pbmc3k()
     # cell_ranger flavor can raise error if many 0 genes

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -79,14 +79,15 @@ def test_highly_variable_genes_keep_layer(base, flavor):
     # cell_ranger flavor can raise error if many 0 genes
     sc.pp.filter_genes(adata, min_counts=1)
 
-    if flavor != 'seurat_v3':
-        sc.pp.log1p(adata, base=base)
+    sc.pp.log1p(adata, base=base)
     X_orig = adata.X.copy()
 
-    if flavor == 'seurat_v3':
+    if flavor == 'seurat':
         sc.pp.highly_variable_genes(adata, n_top_genes=50, flavor=flavor)
-    else:
+    elif flavor == 'cell_ranger':
         sc.pp.highly_variable_genes(adata, flavor=flavor)
+    else:
+        assert False
 
     assert np.allclose(X_orig.A, adata.X.A)
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
Fixes #2668.

`sc.pp.highly_variable_genes(adata, flavor='seurat')` modified the used `layer` in some cases, as described in #2668.

This PR fixes this behaviour, and adds additional tests.