### PR TITLE
Add deprecated_func decorator

### DIFF
--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -122,6 +122,14 @@ def deprecated_arg_names(arg_mapping: Mapping[str, str]):
     return decorator
 
 
+def deprecated_func(func: Calling[..., Optional[any]]) -> None:
+    """
+    Decorator that marks function as deprecated. It will raise FutureWarning for user.
+    """
+    @wraps(func)
+    raise FutureWarning(f"{func.__name__} is deprecated! ")
+
+
 def _one_of_ours(obj, root: str):
     return (
         hasattr(obj, "__name__")


### PR DESCRIPTION
Can you give a dict of deprecated functions and there new analogues?
Then we can add f"Use {new_func[deprecated_func]} instead." for raise FutureWarning.


<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2505 
- [x] Tests included or not required because:
Didn't add decorator to any function(don't know which are deprecated)
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because:
Too small issue