### PR TITLE
Speed up import again

### DIFF
--- a/scanpy/tests/test_performance.py
+++ b/scanpy/tests/test_performance.py
@@ -28,6 +28,7 @@ def test_deferred_imports(imported_modules):
         "umap",  # neighbors, tl.umap
         "seaborn",  # plotting
         "sklearn.metrics",  # neighbors
+        "pynndescent",  # neighbors
         "networkx",  # diffmap, paga, plotting._utils
         # TODO: 'matplotlib.pyplot',
         # TODO (maybe): 'numba',


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes N/A
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: improves an earlier unreleased change

For some reason, PyNNDescent takes >2s to import: https://github.com/lmcinnes/pynndescent/issues/111

This change makes e.g. test collection fast again