### PR TITLE
Add missing link targets

### DIFF
--- a/docs/external/exporting.md
+++ b/docs/external/exporting.md
@@ -1,6 +1,7 @@
 ## Exporting
 
 ```{eval-rst}
+.. module:: scanpy.external.exporting
 .. currentmodule:: scanpy.external
 ```
 

--- a/docs/external/plotting.md
+++ b/docs/external/plotting.md
@@ -2,6 +2,7 @@
 
 
 ```{eval-rst}
+.. module:: scanpy.external.pl
 .. currentmodule:: scanpy.external
 ```
 

--- a/docs/external/preprocessing.md
+++ b/docs/external/preprocessing.md
@@ -1,6 +1,7 @@
 ## Preprocessing: PP
 
 ```{eval-rst}
+.. module:: scanpy.external.pp
 .. currentmodule:: scanpy.external
 ```
 

--- a/docs/external/tools.md
+++ b/docs/external/tools.md
@@ -1,6 +1,7 @@
 ## Tools: TL
 
 ```{eval-rst}
+.. module:: scanpy.external.tl
 .. currentmodule:: scanpy.external
 ```
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes N/A (infra change for other PRs touching `external`)
- [x] Tests included or not required because: works if docs build
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: see above

Adds link targets for `scanpy.external.{pp,tl,pl,…}` like they exist for `scanpy.{pp,tl,pl,…}`