### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,21 @@
+name: Publish Python Package
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write # to authenticate as Trusted Publisher to pypi.org
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.x"
+          cache: "pip"
+      - run: pip install build
+      - run: python -m build
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/docs/dev/index.md
+++ b/docs/dev/index.md
@@ -11,8 +11,8 @@ getting-set-up
 testing
 documentation
 ci
-release
 versioning
+release
 ```
 
 Parts of the guidelines have been adapted from the [pandas](https://pandas.pydata.org/pandas-docs/stable/development/index.html) and [MDAnalysis](https://userguide.mdanalysis.org/stable/contributing.html) guides.

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -1,10 +1,15 @@
 # Making a release
 
+First, check out {doc}`versioning` to see which kind of release you want to make.
+That page also explains concepts like *pre-releases* and applications thereof.
+
+## Actually making the release
+
 1. Go to GitHub’s [releases][] page
 2. Click “Draft a new release”
 3. Click “Choose a tag” and type the version of the tag you want to release, such as `1.9.6`
 4. Click “**+ Create new tag: 1.\<minor>.\<patch>** on publish”
-5. If the version is a pre-release version, such as `1.7.0rc1` or `1.10.0a1`, tick the “Set as a pre-release” checkbox
+5. If the version is a *pre-release* version, such as `1.7.0rc1` or `1.10.0a1`, tick the “Set as a pre-release” checkbox
 
 [releases]: https://github.com/scverse/scanpy/releases
 
@@ -27,3 +32,33 @@ After a *major* or *minor* release has been made:
 - Create a new branch for this release series, like `1.7.x`. This should get a new release notes file.
 
 [meeseeksdev]: https://meeseeksbox.github.io
+
+## Debugging the build process
+
+If you changed something about the build process (e.g. [Hatchling’s build configuration][hatch-build]),
+or something about the package’s structure,
+you might want to manually check if the build and upload process behaves as expected:
+
+```shell
+# Clear out old distributions
+rm -r dist
+
+# Build source distribution and wheel both
+python -m build
+
+# Now check those build artifacts
+twine check dist/*
+
+# List the wheel archive’s contents
+bsdtar -tf dist/*.whl
+
+# Upload to TestPyPI
+twine upload --repository testpypi dist/*
+```
+
+The above approximates what the [publish workflow][] does automatically for us.
+If you want to replicate the process more exactly, make sure you are careful,
+and create a version tag before building (make sure you delete it after uploading to TestPyPI!).
+
+[hatch-build]: https://hatch.pypa.io/latest/config/build/
+[publish workflow]: https://github.com/scverse/scanpy/tree/master/.github/workflows/publish.yml

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -2,9 +2,9 @@
 
 1. Go to GitHub’s [releases][] page
 2. Click “Draft a new release”
-3. Click “Choose a tag” and type the version of the tag you want to release, such as “1.9.6”
+3. Click “Choose a tag” and type the version of the tag you want to release, such as `1.9.6`
 4. Click “**+ Create new tag: 1.\<minor>.\<patch>** on publish”
-5. If the version is a pre-release version, such as “1.10.0a1”, tick the “Set as a pre-release” checkbox
+5. If the version is a pre-release version, such as `1.7.0rc1` or `1.10.0a1`, tick the “Set as a pre-release” checkbox
 
 [releases]: https://github.com/scverse/scanpy/releases
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -3,27 +3,27 @@
 1. Go to GitHub’s [releases][] page
 2. Click “Draft a new release”
 3. Click “Choose a tag” and type the version of the tag you want to release, such as “1.9.6”
-4. Click “**+ Create new tag: 1.x.x** on publish”
+4. Click “**+ Create new tag: 1.\<minor>.\<patch>** on publish”
 5. If the version is a pre-release version, such as “1.10.0a1”, tick the “Set as a pre-release” checkbox
 
 [releases]: https://github.com/scverse/scanpy/releases
 
 ## After making a release
 
-After a major or minor release has been made:
+After *any* release has been made:
+
+- Create a new release notes file for the next bugfix release.
+  This should be included in both dev and stable branches.
+- Create a milestone for the next release (in case you made a bugfix release) or releases (in case of a major/minor release).
+  For bugfix releases, this should have `on-merge: backport to 0.<minor>.x`,
+  so the [meeseeksdev][] bot will create a backport PR. See {doc}`versioning` for more info.
+- Clear out and close the milestone you just made a release for.
+
+After a *major* or *minor* release has been made:
 
 - Tweet about it! Announce it on Zulip! Announce it on Discourse! Think about making a bot for this! Maybe actually do that?
 - Create a new release notes file for the next minor release. This should only be added to the dev branch.
 - Tag the development branch. If you just released `1.7.0`, this would be `1.8.0.dev0`.
 - Create a new branch for this release series, like `1.7.x`. This should get a new release notes file.
-
-After any release has been made:
-
-- Create a new release notes file for the next bugfix release.
-  This should be included in both dev and stable branches.
-- Create a milestone for the next release(s).
-  For bugfix releases, this should have `on-merge: backport to 0.8.x`,
-  so the [meeseeksdev][] bot will create a backport PR. See {doc}`versioning` for more info.
-- Clear out and close the milestone you just made a release for.
 
 [meeseeksdev]: https://meeseeksbox.github.io

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -52,7 +52,13 @@ twine check dist/*
 # List the wheel archive’s contents
 bsdtar -tf dist/*.whl
 
-# Upload to TestPyPI
+```
+
+You can also upload the package to <test.pypi.org> ([tutorial][testpypi tutorial])
+
+[testpypi tutorial]: https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives
+
+```
 twine upload --repository testpypi dist/*
 ```
 

--- a/docs/dev/release.md
+++ b/docs/dev/release.md
@@ -1,51 +1,12 @@
 # Making a release
 
-This is a guide on how to make a release of scanpy for maintainers.
+1. Go to GitHub’s [releases][] page
+2. Click “Draft a new release”
+3. Click “Choose a tag” and type the version of the tag you want to release, such as “1.9.6”
+4. Click “**+ Create new tag: 1.x.x** on publish”
+5. If the version is a pre-release version, such as “1.10.0a1”, tick the “Set as a pre-release” checkbox
 
-## Checking that PyPI will accept it
-
-Sometimes PyPI will reject a build.
-You can locally check whether the build is acceptable with `twine check`.
-
-```shell
-# First, make a build
-python -m build
-
-# Now check that build
-twine check dist/*  # Assuming dist is otherwise empty
-```
-
-## Actually making release
-
-First, make sure you're working repository is clean and is on the commit you'd like to release from.
-Then follow these steps:
-
-```shell
-# Tag the commit with version info
-git tag {version}  # where version is a version number like "1.7.0"
-
-# Clear out old distributions
-rm -r dist
-
-# Build distributions and wheel
-python -m build
-# you can check that the previous step worked by installing from it's results
-# e.g. pip install dist/scanpy-{version}-py3-none-any.whl
-
-# Once you're confident the build looks good, push the tag to github
-git push upstream {version}
-
-# Upload wheel and code distribution to pypi
-twine upload dist/scanpy-{version}
-```
-
-### Checking the distributions
-
-If you're feeling cautious, you can:
-
-- List the contents of a wheel with: `unzip -l dist/*.whl`
-- Make a release candidate. Tag these with `{version}rc1` (e.g. `1.7.0rc1`)
-- Upload them to <test.pypi.org> ([tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects/#uploading-the-distribution-archives))
+[releases]: https://github.com/scverse/scanpy/releases
 
 ## After making a release
 
@@ -58,5 +19,11 @@ After a major or minor release has been made:
 
 After any release has been made:
 
-- Create a new release notes file for the next bugfix release. This should be included in both dev and stable branches `release-latest.md`
-- Create a milestone for the next release(s). For bugfix releases, this should have `on-merge: backport to 0.8.x` so [meeseeksdev](https://meeseeksbox.github.io) bot will create a backport PR. See {doc}`versioning` for more info.
+- Create a new release notes file for the next bugfix release.
+  This should be included in both dev and stable branches.
+- Create a milestone for the next release(s).
+  For bugfix releases, this should have `on-merge: backport to 0.8.x`,
+  so the [meeseeksdev][] bot will create a backport PR. See {doc}`versioning` for more info.
+- Clear out and close the milestone you just made a release for.
+
+[meeseeksdev]: https://meeseeksbox.github.io

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -18,7 +18,7 @@ At a `point` release, there should be no changes beyond bug fixes.
 Valid version numbers are described in [PEP 440](https://peps.python.org/pep-0440/).
 
 [Pre-releases](https://peps.python.org/pep-0440/#pre-releases)
-:   should have versions like `1.7.0a1`, `1.7.0b1`, or `1.7.0rc2`.
+:   should have versions like `1.7.0rc1` or `1.7.0rc2`.
 [Development versions](https://peps.python.org/pep-0440/#developmental-releases)
 :   should look like `1.8.0.dev0`, with a commit hash optionally appended as a local version identifier (e.g. `1.8.0.dev2+g00ad77b`).
 

--- a/docs/dev/versioning.md
+++ b/docs/dev/versioning.md
@@ -17,8 +17,10 @@ At a `point` release, there should be no changes beyond bug fixes.
 
 Valid version numbers are described in [PEP 440](https://peps.python.org/pep-0440/).
 
-[Release candidates](https://peps.python.org/pep-0440/#pre-releases) should have versions like `1.7.0rc1`, `1.7.0rc2`.
-[Development versions](https://peps.python.org/pep-0440/#developmental-releases) should look like `1.8.0.dev0`, with a commit hash optionally appended as a local version identifier (e.g. `1.8.0.dev2+g00ad77b`).
+[Pre-releases](https://peps.python.org/pep-0440/#pre-releases)
+:   should have versions like `1.7.0a1`, `1.7.0b1`, or `1.7.0rc2`.
+[Development versions](https://peps.python.org/pep-0440/#developmental-releases)
+:   should look like `1.8.0.dev0`, with a commit hash optionally appended as a local version identifier (e.g. `1.8.0.dev2+g00ad77b`).
 
 ## Tooling
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2644
- [x] Tests included or not required because: dev workflow
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: dev workflow

Very simple, following https://docs.pypi.org/trusted-publishers/adding-a-publisher/

The change removes most of the technical parts of making a release including `twine check` which is just done by default by the GH action.

The only parts I’m not 100% sure about removing are
- “When to make a pre-release” – I feel like “if UR unsure, make one of these” wasn’t helping here either, so maybe that should just be fleshed out as a section now we’re down a few sections
- “Check the file contents of the wheel” should probably go into “how to code review a PR that touches the build process”, and we don’t have any other guides on how to do code reviews, so …