### PR TITLE
Require matplotlib 3.6+ for colormaps

### DIFF
--- a/docs/release-notes/1.9.7.md
+++ b/docs/release-notes/1.9.7.md
@@ -3,3 +3,4 @@
 ```{rubric} Bug fixes
 ```
 - Fix handling of numpy array palettes (e.g. after write-read cycle) {pr}`2734` {smaller}`P Angerer`
+- Specify correct version of `matplotlib` dependency {pr}`2733` {smaller}`P Fisher`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
     "anndata>=0.7.4",
     # numpy needs a version due to #1320
     "numpy>=1.17.0",
-    "matplotlib>=3.4",
+    "matplotlib>=3.6",
     # pandas 2.1.2 has pandas/issues/52927
     "pandas >=1.1.1, !=2.1.2",
     "scipy>=1.4",


### PR DESCRIPTION
`matplotlib.colormaps` was introduced in v3.5.0, but scanpy currently specifies only v3.4+. Bump it and everything should be fine.

- [x] Tests included or not required because: trivial change
- [x] Release notes not necessary because: trivial change

(this is just my own evaluation of triviality; if you want a release notes entry I am happy to add one)