### PR TITLE
Follow all old http redirects to HTTPS version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Before filing an issue
   This allows contributors to spend less time responding to issues, and more time adding new features!
 * Please provide a minimal complete verifiable example for any bug.
   If you're not sure what this means, check out
-  [this blog post](http://matthewrocklin.com/blog/work/2018/02/28/minimal-bug-reports)
+  [this blog post](https://matthewrocklin.com/minimal-bug-reports)
   by Matthew Rocklin or [this definition](https://stackoverflow.com/help/mcve) from StackOverflow.
 * Let us know about your environment. Environment information is available via: `sc.logging.print_versions()`.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Build Status](https://dev.azure.com/scverse/scanpy/_apis/build/status/theislab.scanpy?branchName=master)](https://dev.azure.com/scverse/scanpy/_build)
 [![Discourse topics](https://img.shields.io/discourse/posts?color=yellow&logo=discourse&server=https%3A%2F%2Fdiscourse.scverse.org)](https://discourse.scverse.org/)
 [![Chat](https://img.shields.io/badge/zulip-join_chat-%2367b08f.svg)](https://scverse.zulipchat.com)
-[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](http://numfocus.org)
+[![Powered by NumFOCUS](https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A)](https://numfocus.org/)
 
 # Scanpy – Single-Cell Analysis in Python
 

--- a/docs/_static/img/Scanpy_Logo.svg
+++ b/docs/_static/img/Scanpy_Logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-	xmlns="http://www.w3.org/2000/svg"
-	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="https://www.w3.org/2000/svg"
+	xmlns:svg="https://www.w3.org/2000/svg"
 	version="1.1"
 	xml:space="preserve"
 	width="558.41333"

--- a/docs/_static/img/Scanpy_Logo_BrightFG.svg
+++ b/docs/_static/img/Scanpy_Logo_BrightFG.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-	xmlns="http://www.w3.org/2000/svg"
-	xmlns:svg="http://www.w3.org/2000/svg"
+	xmlns="https://www.w3.org/2000/svg"
+	xmlns:svg="https://www.w3.org/2000/svg"
 	version="1.1"
 	xml:space="preserve"
 	width="558.41333"

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -22,7 +22,7 @@ It can take a while to run the whole test suite. There are a few ways to cut dow
 ## Writing tests
 
 You can refer to the [existing test suite](https://github.com/scverse/scanpy/tree/master/scanpy/tests) for examples.
-If you haven't written tests before, Software Carpentry has an [in-depth guide](http://katyhuff.github.io/python-testing/) on the topic.
+If you haven't written tests before, Software Carpentry has an [in-depth guide](https://katyhuff.github.io/2016-07-11-scipy/testing/01-basics.html) on the topic.
 
 We highly recommend using [Test Driven Development](https://en.wikipedia.org/wiki/Test-driven_development) when contributing code.
 This not only ensures you have tests written, it often makes implementation easier since you start out with a specification for your function.

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -21,7 +21,7 @@ Interactive manifold viewers.
 - [cirrocumulus](https://cirrocumulus.readthedocs.io/) via direct reading of `.h5ad` {small}`Broad Inst.`
 - [cell browser](https://cells.ucsc.edu/) via exporing through {func}`~scanpy.external.exporting.cellbrowser` {small}`UCSC`
 - [SPRING](https://github.com/AllonKleinLab/SPRING) via exporting through {func}`~scanpy.external.exporting.spring_project` {small}`Harvard Med`
-- [vitessce](http://vitessce.io) for purely browser based viewing of zarr formatted AnnData files {smaller}`Harvard Med`
+- [vitessce](https://vitessce.io/) for purely browser based viewing of zarr formatted AnnData files {smaller}`Harvard Med`
 
 ## Portals
 

--- a/docs/ecosystem.md
+++ b/docs/ecosystem.md
@@ -21,7 +21,7 @@ Interactive manifold viewers.
 - [cirrocumulus](https://cirrocumulus.readthedocs.io/) via direct reading of `.h5ad` {small}`Broad Inst.`
 - [cell browser](https://cells.ucsc.edu/) via exporing through {func}`~scanpy.external.exporting.cellbrowser` {small}`UCSC`
 - [SPRING](https://github.com/AllonKleinLab/SPRING) via exporting through {func}`~scanpy.external.exporting.spring_project` {small}`Harvard Med`
-- [vitessce](https://vitessce.io/) for purely browser based viewing of zarr formatted AnnData files {smaller}`Harvard Med`
+- [vitessce](https://github.com/vitessce/vitessce#readme) for purely browser based viewing of zarr formatted AnnData files {smaller}`Harvard Med`
 
 ## Portals
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -123,7 +123,7 @@ The whole process takes just a couple of minutes.
 [from pypi]: https://pypi.org/project/scanpy
 [gcfntnu/scanpy]: https://hub.docker.com/r/gcfntnu/scanpy
 [leiden]: https://leidenalg.readthedocs.io
-[miniconda]: http://conda.pydata.org/miniconda.html
+[miniconda]: https://docs.conda.io/projects/miniconda/en/latest/
 [on github]: https://github.com/scverse/scanpy
 [igraph]: https://python.igraph.org/en/stable/
 [unofficial binaries]: https://www.lfd.uci.edu/~gohlke/pythonlibs/

--- a/docs/news.md
+++ b/docs/news.md
@@ -32,7 +32,7 @@ Two large toolkits extending our ecosystem to new modalities have had their manu
 
 ### scVelo on the cover of Nature Biotechnology {small}`2020-12-01`
 
-Scanpy's counterpart for RNA velocity, [scVelo](http://scvelo.org/), made it on the cover of [Nature Biotechnology](https://www.nature.com/nbt/volumes/38/issues/12) \[[tweet](https://twitter.com/NatureBiotech/status/1334647540030070792)\].
+Scanpy's counterpart for RNA velocity, [scVelo](https://scvelo.org/), made it on the cover of [Nature Biotechnology](https://www.nature.com/nbt/volumes/38/issues/12) \[[tweet](https://twitter.com/NatureBiotech/status/1334647540030070792)\].
 
 ### Scanpy selected among 20 papers for 20 years of Genome Biology {small}`2020-08-01`
 

--- a/docs/references.rst
+++ b/docs/references.rst
@@ -31,7 +31,7 @@ References
 
 .. [Csardi06] Csardi *et al.* (2006),
    *The igraph software package for complex network research*,
-   `InterJournal Complex Systems <http://igraph.org>`__.
+   `InterJournal Complex Systems <https://igraph.org/>`__.
 
 .. [Eraslan18] Eraslan and Simon *et al.* (2018),
    *Single cell RNA-seq denoising using a deep count autoencoder*,
@@ -40,7 +40,7 @@ References
 .. [Ester96] Ester *et al.* (1996),
    *A Density-Based Algorithm for Discovering Clusters in Large Spatial Databases with Noise*,
    `Proceedings of the 2nd International Conference on Knowledge Discovery and Data Mining,
-   Portland, OR <http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.121.9220>`__.
+   Portland, OR <https://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.121.9220>`__.
 
 .. [Eulenberg17] Eulenberg *et al.* (2017),
    *Reconstructing cell cycle and disease progression using deep learning*
@@ -52,7 +52,7 @@ References
 
 .. [Fruchterman91] Fruchterman & Reingold (1991),
    *Graph drawing by force-directed placement*,
-   `Software: Practice & Experience <http://doi.org:10.1002/spe.4380211102>`__.
+   `Software: Practice & Experience <https://doi.org/10.1002/spe.4380211102>`__.
 
 .. [Gardner00] Gardner *et al.*, (2000)
    *Construction of a genetic toggle switch in Escherichia coli*,
@@ -60,7 +60,7 @@ References
 
 .. [Hagberg08] Hagberg *et al.* (2008),
    *Exploring Network Structure, Dynamics, and Function using NetworkX*,
-   `Scipy Conference <http://conference.scipy.org/proceedings/SciPy2008/paper_2/>`__.
+   `Scipy Conference <https://conference.scipy.org/proceedings/SciPy2008/paper_2/>`__.
 
 .. [Hastie09]
    Hastie *et al.* (2009),
@@ -137,15 +137,15 @@ References
 
 .. [Maaten08] Maaten & Hinton (2008),
    *Visualizing data using t-SNE*,
-   `JMLR <http://www.jmlr.org/papers/v9/vandermaaten08a.html>`__.
+   `JMLR <https://www.jmlr.org/papers/v9/vandermaaten08a.html>`__.
 
 .. [McCarthy17] McCarthy *et al.* (2017),
    *scater: Single-cell analysis toolkit for gene expression data in R*,
    `Bioinformatics <https://doi.org/10.1093/bioinformatics/btw777>`__.
 
-.. [Moon17] Moon *et al.* (2017),
+.. [Moon17] Moon *et al.* (2019),
    *PHATE: A Dimensionality Reduction Method for Visualizing Trajectory Structures in High-Dimensional Biological Data*,
-   `BioRxiv <http://biorxiv.org/content/early/2017/03/24/120378>`__.
+   `Nature Biotechnology <https://doi.org/10.1038/s41587-019-0336-3>`__.
 
 .. [Satija15] Satija *et al.* (2015),
    *Spatial reconstruction of single-cell gene expression data*,
@@ -182,7 +182,7 @@ References
 
 .. [Pedregosa11] Pedregosa *et al.* (2011),
    *Scikit-learn: Machine Learning in Python*,
-   `JMLR <http://www.jmlr.org/papers/v12/pedregosa11a.html>`__.
+   `JMLR <https://www.jmlr.org/papers/v12/pedregosa11a.html>`__.
 
 .. [Polanski19] Polanski *et al.* (2019),
    *BBKNN: fast batch alignment of single cell transcriptomes*

--- a/docs/usage-principles.md
+++ b/docs/usage-principles.md
@@ -37,7 +37,7 @@ and leave the passed `adata` unchanged, pass `copy=True` or `inplace=False`.
 
 Scanpy is based on {mod}`anndata`, which provides the {class}`~anndata.AnnData` class.
 
-```{image} http://falexwolf.de/img/scanpy/anndata.svg
+```{image} https://falexwolf.de/img/scanpy/anndata.svg
 :width: 300px
 ```
 
@@ -75,7 +75,7 @@ adata.write_csvs(filename)
 adata.write_loom(filename)
 ```
 
-[blog post]: http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
-[matplotlib]: http://matplotlib.org/
-[out-of-memory pipelines]: http://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
-[seaborn]: http://seaborn.pydata.org/
+[blog post]: https://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
+[matplotlib]: https://matplotlib.org/
+[out-of-memory pipelines]: https://falexwolf.de/blog/171223_AnnData_indexing_views_HDF5-backing/
+[seaborn]: https://seaborn.pydata.org/

--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -595,7 +595,7 @@ def warn_with_traceback(message, category, filename, lineno, file=None, line=Non
 
     See also
     --------
-    http://stackoverflow.com/questions/22373927/get-traceback-of-warnings
+    https://stackoverflow.com/questions/22373927/get-traceback-of-warnings
     """
     import traceback
 

--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -171,7 +171,7 @@ def paul15() -> ad.AnnData:
 
     filename = settings.datasetdir / "paul15/paul15.h5"
     filename.parent.mkdir(exist_ok=True)
-    backup_url = "http://falexwolf.de/data/paul15.h5"
+    backup_url = "https://falexwolf.de/data/paul15.h5"
     _utils.check_presence_download(filename, backup_url)
     with h5py.File(filename, "r") as f:
         # Coercing to float32 for backwards compatibility
@@ -256,12 +256,12 @@ def pbmc3k() -> ad.AnnData:
 
     The data consists in 3k PBMCs from a Healthy Donor and is freely available
     from 10x Genomics (`here
-    <http://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz>`__
+    <https://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz>`__
     from this `webpage
     <https://support.10xgenomics.com/single-cell-gene-expression/datasets/1.1.0/pbmc3k>`__).
 
     The exact same data is also used in Seurat's
-    `basic clustering tutorial <https://satijalab.org/seurat/pbmc3k_tutorial.html>`__.
+    `basic clustering tutorial <https://satijalab.org/seurat/articles/pbmc3k_tutorial.html>`__.
 
     .. note::
 
@@ -287,7 +287,7 @@ def pbmc3k() -> ad.AnnData:
     -------
     Annotated data matrix.
     """
-    url = "http://falexwolf.de/data/pbmc3k_raw.h5ad"
+    url = "https://falexwolf.de/data/pbmc3k_raw.h5ad"
     adata = read(settings.datasetdir / "pbmc3k_raw.h5ad", backup_url=url)
     return adata
 

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -1124,7 +1124,7 @@ def circles(
     License
     --------
     This code is under [The BSD 3-Clause License]
-    (http://opensource.org/licenses/BSD-3-Clause)
+    (https://opensource.org/license/bsd-3-clause/)
     """
 
     # You can set `facecolor` with an array for each patch,

--- a/scanpy/plotting/palettes.py
+++ b/scanpy/plotting/palettes.py
@@ -36,7 +36,7 @@ default_20 = vega_20_scanpy
 
 # https://graphicdesign.stackexchange.com/questions/3682/where-can-i-find-a-large-palette-set-of-contrasting-colors-for-coloring-many-d
 # update 1
-# orig reference http://epub.wu.ac.at/1692/1/document.pdf
+# orig reference https://research.wu.ac.at/en/publications/escaping-rgbland-selecting-colors-for-statistical-graphics-26
 zeileis_28 = [
     "#023fa5",
     "#7d87b9",
@@ -71,7 +71,7 @@ zeileis_28 = [
 
 default_28 = zeileis_28
 
-# from http://godsnotwheregodsnot.blogspot.de/2012/09/color-distribution-methodology.html
+# from https://godsnotwheregodsnot.blogspot.com/2012/09/color-distribution-methodology.html
 godsnot_102 = [
     # "#000000",  # remove the black, as often, we have black colored annotation
     "#FFFF00",

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -648,9 +648,9 @@ def write(
         File extension from wich to infer file format. If `None`, defaults to
         `sc.settings.file_format_data`.
     compression
-        See http://docs.h5py.org/en/latest/high/dataset.html.
+        See https://docs.h5py.org/en/latest/high/dataset.html.
     compression_opts
-        See http://docs.h5py.org/en/latest/high/dataset.html.
+        See https://docs.h5py.org/en/latest/high/dataset.html.
     """
     filename = Path(filename)  # allow passing strings
     if is_valid_filename(filename):
@@ -852,12 +852,12 @@ def _read_softgz(filename: Union[str, bytes, Path, BinaryIO]) -> AnnData:
     Read a SOFT format data file.
 
     The SOFT format is documented here
-    http://www.ncbi.nlm.nih.gov/geo/info/soft2.html.
+    https://www.ncbi.nlm.nih.gov/geo/info/soft.html.
 
     Notes
     -----
     The function is based on a script by Kerby Shedden.
-    http://dept.stat.lsa.umich.edu/~kshedden/Python-Workshop/gene_expression_comparison.html
+    https://dept.stat.lsa.umich.edu/~kshedden/Python-Workshop/gene_expression_comparison.html
     """
     import gzip
 
@@ -915,7 +915,7 @@ def is_float(string: str) -> float:
 
     See also
     --------
-    http://stackoverflow.com/questions/736043/checking-if-a-string-can-be-converted-to-float-in-python
+    https://stackoverflow.com/questions/736043/checking-if-a-string-can-be-converted-to-float-in-python
     """
     try:
         float(string)

--- a/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
+++ b/scanpy/tests/notebooks/test_paga_paul15_subsampled.py
@@ -1,5 +1,5 @@
 # PAGA for hematopoiesis in mouse [(Paul *et al.*, 2015)](https://doi.org/10.1016/j.cell.2015.11.013)
-# Hematopoiesis: trace myeloid and erythroid differentiation for data of [Paul *et al.* (2015)](http://doi.org/10.1016/j.cell.2015.11.013).
+# Hematopoiesis: trace myeloid and erythroid differentiation for data of [Paul *et al.* (2015)](https://doi.org/10.1016/j.cell.2015.11.013).
 #
 # This is the subsampled notebook for testing.
 from functools import partial

--- a/scanpy/tests/notebooks/test_pbmc3k.py
+++ b/scanpy/tests/notebooks/test_pbmc3k.py
@@ -3,11 +3,11 @@
 #
 # This started out with a demonstration that Scanpy would allow to reproduce most of Seurat's
 # ([Satija *et al.*, 2015](https://doi.org/10.1038/nbt.3192)) clustering tutorial as described on
-# http://satijalab.org/seurat/pbmc3k_tutorial.html (July 26, 2017), which we gratefully acknowledge.
+# https://satijalab.org/seurat/articles/pbmc3k_tutorial.html (July 26, 2017), which we gratefully acknowledge.
 # In the meanwhile, we have added and removed several pieces.
 #
 # The data consists in *3k PBMCs from a Healthy Donor* and is freely available from 10x Genomics
-# ([here](http://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz)
+# ([here](https://cf.10xgenomics.com/samples/cell-exp/1.1.0/pbmc3k/pbmc3k_filtered_gene_bc_matrices.tar.gz)
 # from this [webpage](https://support.10xgenomics.com/single-cell-gene-expression/datasets/1.1.0/pbmc3k)).
 from functools import partial
 from pathlib import Path
@@ -31,7 +31,7 @@ def test_pbmc3k(image_comparer):
     save_and_compare_images = partial(image_comparer, ROOT, tol=20)
 
     adata = sc.read(
-        "./data/pbmc3k_raw.h5ad", backup_url="http://falexwolf.de/data/pbmc3k_raw.h5ad"
+        "./data/pbmc3k_raw.h5ad", backup_url="https://falexwolf.de/data/pbmc3k_raw.h5ad"
     )
 
     # Preprocessing

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -54,7 +54,7 @@ def draw_graph(
         Annotated data matrix.
     layout
         'fa' (`ForceAtlas2`) or any valid `igraph layout
-        <http://igraph.org/c/doc/igraph-Layout.html>`__. Of particular interest
+        <https://igraph.org/c/doc/igraph-Layout.html>`__. Of particular interest
         are 'fr' (Fruchterman Reingold), 'grid_fr' (Grid Fruchterman Reingold,
         faster than 'fr'), 'kk' (Kamadi Kawai', slower than 'fr'), 'lgl' (Large
         Graph, very fast), 'drl' (Distributed Recursive Layout, pretty fast) and

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -488,7 +488,7 @@ def rank_genes_groups(
         `'wilcoxon'` uses Wilcoxon rank-sum,
         `'logreg'` uses logistic regression. See [Ntranos18]_,
         `here <https://github.com/scverse/scanpy/issues/95>`__ and `here
-        <http://www.nxn.se/valent/2018/3/5/actionable-scrna-seq-clusters>`__,
+        <https://www.nxn.se/valent/2018/3/5/actionable-scrna-seq-clusters>`__,
         for why this is meaningful.
     corr_method
         p-value correction method.

--- a/scanpy/tools/_sim.py
+++ b/scanpy/tools/_sim.py
@@ -1,4 +1,4 @@
-# Author: Alex Wolf (http://falexwolf.de)
+# Author: Alex Wolf (https://falexwolf.de)
 """Simulate Data
 
 Simulate stochastic dynamic systems to model gene expression dynamics and


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes N/A
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: small change

And for broken links, I found the working location manually.

The only website that doesn’t have a working HTTPS version is http://vitessce.io (https://github.com/vitessce/vitessce/issues/1121), which is impressive given the late-90s-look of some of those journal websites.