### PR TITLE
Harmonization of Return Section in Documentation

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -15,6 +15,7 @@
 ```{rubric} Docs
 ```
 * Fixed a lot of broken usage examples {pr}`2605` {smaller}`P Angerer`
+* Improved harmonization of return field of `sc.pp` and `sc.tl` functions {pr}`2742` {smaller}`E Roellin`
 
 ```{rubric} Bug fixes
 ```

--- a/docs/release-notes/1.9.7.md
+++ b/docs/release-notes/1.9.7.md
@@ -4,5 +4,4 @@
 ```
 - Fix handling of numpy array palettes (e.g. after write-read cycle) {pr}`2734` {smaller}`P Angerer`
 - Specify correct version of `matplotlib` dependency {pr}`2733` {smaller}`P Fisher`
-- Improved harmonization of return field of `sc.pp` and `sc.tl` functions {pr}`2742` {smaller}`E Roellin`
 - Fix {func}`scanpy.pl.violin` usage of `seaborn.catplot` {pr}`2739` {smaller}`E Roellin`

--- a/docs/release-notes/1.9.7.md
+++ b/docs/release-notes/1.9.7.md
@@ -4,3 +4,4 @@
 ```
 - Fix handling of numpy array palettes (e.g. after write-read cycle) {pr}`2734` {smaller}`P Angerer`
 - Specify correct version of `matplotlib` dependency {pr}`2733` {smaller}`P Fisher`
+- Improved harmonization of return field of `sc.pp` and `sc.tl` functions {pr}`2742` {smaller}`E Roellin`

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -148,9 +148,9 @@ def neighbors(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obsp['distances' | key_added+'_distances']` : :class:`~scipy.sparse.csr_matrix` (dtype `float`)
+    `adata.obsp['distances' | key_added+'_distances']` : :class:`scipy.sparse.csr_matrix` (dtype `float`)
         Distance matrix of the nearest neighbors search. Each row (cell) has `n_neighbors`-1 non-zero entries. These are the distances to their `n_neighbors`-1 nearest neighbors (excluding the cell itself).
-    `adata.obsp['connectivities' | key_added+'_connectivities']` : :class:`~scipy.sparse._csr.csr_matrix` (dtype `float`)
+    `adata.obsp['connectivities' | key_added+'_connectivities']` : :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
         Weighted adjacency matrix of the neighborhood graph of data
         points. Weights should be interpreted as connectivities.
     `adata.uns['neighbors' | key_added]` : :class:`dict`

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -146,16 +146,15 @@ def neighbors(
 
     Returns
     -------
-    Depending on `copy`, updates or returns `adata` with the following:
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    See `key_added` parameter description for the storage path of
-    connectivities and distances.
-
-    **connectivities** : sparse matrix of dtype `float32`.
+    `adata.obsp['distances' | key_added+'_distances']` : :class:`~scipy.sparse.csr_matrix` (dtype `float`)
+        Distance matrix of the nearest neighbors search. Each row (cell) has `n_neighbors`-1 non-zero entries. These are the distances to their `n_neighbors`-1 nearest neighbors (excluding the cell itself).
+    `adata.obsp['connectivities' | key_added+'_connectivities']` : :class:`~scipy.sparse._csr.csr_matrix` (dtype `float`)
         Weighted adjacency matrix of the neighborhood graph of data
         points. Weights should be interpreted as connectivities.
-    **distances** : sparse matrix of dtype `float64`.
-        Stores the distance matrix of the nearest neighbors search.
+    `adata.uns['neighbors' | key_added]` : :class:`dict`
+        neighbors parameters.
 
     Examples
     --------

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -163,8 +163,10 @@ def combat(
 
     Returns
     -------
-    Depending on the value of `inplace`, either returns the corrected matrix or
-    or modifies `adata.X`.
+    Returns :class:`numpy.ndarray` if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+
+    `adata.X` (:class:`numpy.ndarray`, dtype `float`)
+        Corrected data matrix.
     """
 
     # check the input

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -133,7 +133,7 @@ def combat(
     key: str = "batch",
     covariates: Optional[Collection[str]] = None,
     inplace: bool = True,
-) -> Union[AnnData, np.ndarray, None]:
+) -> Union[np.ndarray, None]:
     """\
     ComBat function for batch effect correction [Johnson07]_ [Leek12]_
     [Pedersen12]_.
@@ -163,7 +163,7 @@ def combat(
 
     Returns
     -------
-    Returns :class:`numpy.ndarray` if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+    Returns :class:`numpy.ndarray` if `inplace=True`, else returns `None` and sets the following field in the `adata` object:
 
     `adata.X` : :class:`numpy.ndarray` (dtype `float`)
         Corrected data matrix.

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -165,7 +165,7 @@ def combat(
     -------
     Returns :class:`numpy.ndarray` if `inplace=True`, else returns an `AnnData` object where it sets the following field:
 
-    `adata.X` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.X` : :class:`numpy.ndarray` (dtype `float`)
         Corrected data matrix.
     """
 

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -394,25 +394,25 @@ def highly_variable_genes(
 
     Returns :class:`~pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
 
-    `adata.var['highly_variable']` (:class:`pandas.Series, dtype `bool`)
+    `adata.var['highly_variable']` : :class:`pandas.Series` (dtype `bool`)
         boolean indicator of highly-variable genes
-    `adata.var['means']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['means']` : :class:`pandas.Series` (dtype `float`)
         means per gene
-    `adata.var['dispersions']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['dispersions']` : :class:`pandas.Series` (dtype `float`)
         For dispersion-based flavors, dispersions per gene
-    `adata.var['dispersions_norm']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['dispersions_norm']` : :class:`pandas.Series` (dtype `float`)
         For dispersion-based flavors, normalized dispersions per gene
-    `adata.var['variances']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['variances']` : :class:`pandas.Series` (dtype `float`)
         For `flavor='seurat_v3'`, variance per gene
-    `adata.var['variances_norm']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['variances_norm']` : :class:`pandas.Series` (dtype `float`)
         For `flavor='seurat_v3'`, normalized variance per gene, averaged in
         the case of multiple batches
-    `adata.var['highly_variable_rank']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['highly_variable_rank']` : :class:`pandas.Series` (dtype `float`)
         For `flavor='seurat_v3'`, rank of the gene according to normalized
         variance, median rank in the case of multiple batches
-    `adata.var['highly_variable_nbatches']` (:class:`pandas.Series`, dtype `int`)
+    `adata.var['highly_variable_nbatches']` : :class:`pandas.Series` (dtype `int`)
         If batch_key is given, this denotes in how many batches genes are detected as HVG
-    `adata.var['highly_variable_intersection']` (:class:`pandas.Series`, dtype `bool`)
+    `adata.var['highly_variable_intersection']` : :class:`pandas.Series` (dtype `bool`)
         If batch_key is given, this denotes the genes that are highly variable in all batches
 
     Notes

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -390,27 +390,29 @@ def highly_variable_genes(
     Returns
     -------
     Depending on `inplace` returns calculated metrics (:class:`~pandas.DataFrame`) or
-    updates `.var` with the following fields
+    updates `.var` with the following fields:
 
-    highly_variable : bool
+    Returns :class:`~pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+
+    `adata.var['highly_variable']` (:class:`pandas.Series, dtype `bool`)
         boolean indicator of highly-variable genes
-    **means**
+    `adata.var['means']` (:class:`pandas.Series`, dtype `float`)
         means per gene
-    **dispersions**
+    `adata.var['dispersions']` (:class:`pandas.Series`, dtype `float`)
         For dispersion-based flavors, dispersions per gene
-    **dispersions_norm**
+    `adata.var['dispersions_norm']` (:class:`pandas.Series`, dtype `float`)
         For dispersion-based flavors, normalized dispersions per gene
-    **variances**
+    `adata.var['variances']` (:class:`pandas.Series`, dtype `float`)
         For `flavor='seurat_v3'`, variance per gene
-    **variances_norm**
+    `adata.var['variances_norm']` (:class:`pandas.Series`, dtype `float`)
         For `flavor='seurat_v3'`, normalized variance per gene, averaged in
         the case of multiple batches
-    highly_variable_rank : float
+    `adata.var['highly_variable_rank']` (:class:`pandas.Series`, dtype `float`)
         For `flavor='seurat_v3'`, rank of the gene according to normalized
         variance, median rank in the case of multiple batches
-    highly_variable_nbatches : int
+    `adata.var['highly_variable_nbatches']` (:class:`pandas.Series`, dtype `int`)
         If batch_key is given, this denotes in how many batches genes are detected as HVG
-    highly_variable_intersection : bool
+    `adata.var['highly_variable_intersection']` (:class:`pandas.Series`, dtype `bool`)
         If batch_key is given, this denotes the genes that are highly variable in all batches
 
     Notes

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -389,7 +389,7 @@ def highly_variable_genes(
 
     Returns
     -------
-    Returns a :class:`~pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+    Returns a :class:`pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
 
     `adata.var['highly_variable']` : :class:`pandas.Series` (dtype `bool`)
         boolean indicator of highly-variable genes

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -389,10 +389,7 @@ def highly_variable_genes(
 
     Returns
     -------
-    Depending on `inplace` returns calculated metrics (:class:`~pandas.DataFrame`) or
-    updates `.var` with the following fields:
-
-    Returns :class:`~pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+    Returns a :class:`~pandas.DataFrame` with calculated metrics if `inplace=True`, else returns an `AnnData` object where it sets the following field:
 
     `adata.var['highly_variable']` : :class:`pandas.Series` (dtype `bool`)
         boolean indicator of highly-variable genes

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -483,8 +483,10 @@ def normalize_per_cell(
 
     Returns
     -------
-    Returns or updates `adata` with normalized version of the original
-    `adata.X`, depending on `copy`.
+    Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
+
+    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+        Normalized count data matrix.
 
     Examples
     --------
@@ -595,7 +597,10 @@ def regress_out(
 
     Returns
     -------
-    Depending on `copy` returns or updates `adata` with the corrected data matrix.
+    Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
+
+    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+        Normalized count data matrix.
     """
     start = logg.info(f"regressing out {keys}")
     adata = adata.copy() if copy else adata
@@ -747,8 +752,16 @@ def scale(
 
     Returns
     -------
-    Depending on `copy` returns or updates `adata` with a scaled `adata.X`,
-    annotated with `'mean'` and `'std'` in `adata.var`.
+    Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
+
+    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+        Scaled count data matrix.
+    `adata.var['mean']` (:class:`pandas.Series`, dtype `float`)
+        Means per gene before scaling.
+    `adata.var['std']` (:class:`pandas.Series`, dtype `float`)
+        Standard deviations per gene before scaling.
+    `adata.var['var']` (:class:`pandas.Series`, dtype `float`)
+        Variances per gene before scaling.
     """
     _check_array_function_arguments(layer=layer, obsm=obsm)
     if layer is not None:

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -969,7 +969,7 @@ def downsample_counts(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.X` : :class:`numpy.ndarray` | :class:`~scipy.sparse.spmatrix` (dtype `float`)
+    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse.spmatrix` (dtype `float`)
         Downsampled counts matrix.
     """
     # This logic is all dispatch

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -599,8 +599,8 @@ def regress_out(
     -------
     Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
 
-    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
-        Normalized count data matrix.
+    `adata.X` | `adata.layers[layer]` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
+        Corrected count data matrix.
     """
     start = logg.info(f"regressing out {keys}")
     adata = adata.copy() if copy else adata
@@ -754,7 +754,7 @@ def scale(
     -------
     Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
 
-    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
+    `adata.X` | `adata.layers[layer]` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
         Scaled count data matrix.
     `adata.var['mean']` : :class:`pandas.Series` (dtype `float`)
         Means per gene before scaling.
@@ -967,7 +967,10 @@ def downsample_counts(
 
     Returns
     -------
-    Depending on `copy` returns or updates an `adata` with downsampled `.X`.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
+
+    `adata.X` : :class:`numpy.ndarray` | :class:`~scipy.sparse.spmatrix` (dtype `float`)
+        Downsampled counts matrix.
     """
     # This logic is all dispatch
     total_counts_call = total_counts is not None

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -485,7 +485,7 @@ def normalize_per_cell(
     -------
     Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
 
-    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
         Normalized count data matrix.
 
     Examples
@@ -599,7 +599,7 @@ def regress_out(
     -------
     Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
 
-    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
         Normalized count data matrix.
     """
     start = logg.info(f"regressing out {keys}")
@@ -754,13 +754,13 @@ def scale(
     -------
     Returns `None` if `copy=False`, else returns an updated `AnnData` object. Sets the following fields:
 
-    `adata.X` (:class:`numpy.ndarray` or :class:`scipy.sparse._csr.csr_matrix`, dtype `float`)
+    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse._csr.csr_matrix` (dtype `float`)
         Scaled count data matrix.
-    `adata.var['mean']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['mean']` : :class:`pandas.Series` (dtype `float`)
         Means per gene before scaling.
-    `adata.var['std']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['std']` : :class:`pandas.Series` (dtype `float`)
         Standard deviations per gene before scaling.
-    `adata.var['var']` (:class:`pandas.Series`, dtype `float`)
+    `adata.var['var']` : :class:`pandas.Series` (dtype `float`)
         Variances per gene before scaling.
     """
     _check_array_function_arguments(layer=layer, obsm=obsm)

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -83,8 +83,10 @@ def dendrogram(
 
     Returns
     -------
-    If `inplace=False`, returns dendrogram information,
-    else `adata.uns[key_added]` is updated with it.
+    Returns `None` if `inplace=True`, else returns a `dict` with dendrogram information. Sets the following field if `inplace=True`:
+
+    `adata.uns[key_added]` (:class:`dict`)
+        Dendrogram information.
 
     Examples
     --------

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -85,7 +85,7 @@ def dendrogram(
     -------
     Returns `None` if `inplace=True`, else returns a `dict` with dendrogram information. Sets the following field if `inplace=True`:
 
-    `adata.uns[key_added]` (:class:`dict`)
+    `adata.uns[key_added]` : :class:`dict`
         Dendrogram information.
 
     Examples

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -85,7 +85,7 @@ def dendrogram(
     -------
     Returns `None` if `inplace=True`, else returns a `dict` with dendrogram information. Sets the following field if `inplace=True`:
 
-    `adata.uns[key_added]` : :class:`dict`
+    `adata.uns[f'dendrogram_{{group_by}}' | key_added]` : :class:`dict`
         Dendrogram information.
 
     Examples

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -50,11 +50,11 @@ def diffmap(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obsm['X_diffmap']` : :class:`numpy.ndarray`
+    `adata.obsm['X_diffmap']` : :class:`numpy.ndarray` (dtype `float`)
         Diffusion map representation of data, which is the right eigen basis of
         the transition matrix with eigenvectors as columns.
 
-    `adata.uns['diffmap_evals']` : :class:`numpy.ndarray`
+    `adata.uns['diffmap_evals']` : :class:`numpy.ndarray` (dtype `float`)
         Array of size (number of eigen vectors).
         Eigenvalues of transition matrix.
 

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -48,12 +48,13 @@ def diffmap(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following fields.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `X_diffmap` : :class:`numpy.ndarray` (`adata.obsm`)
+    `adata.obsm['X_diffmap']` (:class:`numpy.ndarray`)
         Diffusion map representation of data, which is the right eigen basis of
         the transition matrix with eigenvectors as columns.
-    `diffmap_evals` : :class:`numpy.ndarray` (`adata.uns`)
+
+    `adata.uns['diffmap_evals']` (:class:`numpy.ndarray`)
         Array of size (number of eigen vectors).
         Eigenvalues of transition matrix.
 

--- a/scanpy/tools/_diffmap.py
+++ b/scanpy/tools/_diffmap.py
@@ -50,11 +50,11 @@ def diffmap(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obsm['X_diffmap']` (:class:`numpy.ndarray`)
+    `adata.obsm['X_diffmap']` : :class:`numpy.ndarray`
         Diffusion map representation of data, which is the right eigen basis of
         the transition matrix with eigenvectors as columns.
 
-    `adata.uns['diffmap_evals']` (:class:`numpy.ndarray`)
+    `adata.uns['diffmap_evals']` : :class:`numpy.ndarray`
         Array of size (number of eigen vectors).
         Eigenvalues of transition matrix.
 

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -98,14 +98,12 @@ def dpt(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following fields.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields (If `n_branchings==0`, no field `adata.obs['dpt_groups']` will be written):
 
-    If `n_branchings==0`, no field `dpt_groups` will be written.
-
-    `dpt_pseudotime` : :class:`pandas.Series` (`adata.obs`, dtype `float`)
+    `adata.obs['dpt_pseudotime']` (:class:`pandas.Series`, dtype `float`)
         Array of dim (number of samples) that stores the pseudotime of each
         cell, that is, the DPT distance with respect to the root cell.
-    `dpt_groups` : :class:`pandas.Series` (`adata.obs`, dtype `category`)
+    `adata.obs['dpt_groups']` (:class:`pandas.Series`, dtype `category`)
         Array of dim (number of samples) that stores the subgroup id ('0',
         '1', ...) for each cell. The groups  typically correspond to
         'progenitor cells', 'undecided cells' or 'branches' of a process.

--- a/scanpy/tools/_dpt.py
+++ b/scanpy/tools/_dpt.py
@@ -100,10 +100,10 @@ def dpt(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields (If `n_branchings==0`, no field `adata.obs['dpt_groups']` will be written):
 
-    `adata.obs['dpt_pseudotime']` (:class:`pandas.Series`, dtype `float`)
+    `adata.obs['dpt_pseudotime']` : :class:`pandas.Series` (dtype `float`)
         Array of dim (number of samples) that stores the pseudotime of each
         cell, that is, the DPT distance with respect to the root cell.
-    `adata.obs['dpt_groups']` (:class:`pandas.Series`, dtype `category`)
+    `adata.obs['dpt_groups']` : :class:`pandas.Series` (dtype `category`)
         Array of dim (number of samples) that stores the subgroup id ('0',
         '1', ...) for each cell. The groups  typically correspond to
         'progenitor cells', 'undecided cells' or 'branches' of a process.

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -91,11 +91,12 @@ def draw_graph(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following field.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    **X_draw_graph_layout** : `adata.obsm`
-        Coordinates of graph layout. E.g. for layout='fa' (the default),
-        the field is called 'X_draw_graph_fa'
+    `adata.obsm['X_draw_graph_[layout]']` (:class:`numpy.ndarray`, dtype `float`)
+        Coordinates of graph layout. E.g. for `layout='fa'` (the default),
+        the field is called `'X_draw_graph_fa'`.
+
     """
     start = logg.info(f"drawing single-cell graph using layout {layout!r}")
     if layout not in _LAYOUTS:

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -91,7 +91,7 @@ def draw_graph(
 
     Returns
     -------
-    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
     `adata.obsm['X_draw_graph_[layout | key_added_ext]']` : :class:`numpy.ndarray` (dtype `float`)
         Coordinates of graph layout. E.g. for `layout='fa'` (the default),

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -93,10 +93,11 @@ def draw_graph(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obsm['X_draw_graph_[layout]']` : :class:`numpy.ndarray` (dtype `float`)
+    `adata.obsm['X_draw_graph_[layout | key_added_ext]']` : :class:`numpy.ndarray` (dtype `float`)
         Coordinates of graph layout. E.g. for `layout='fa'` (the default),
-        the field is called `'X_draw_graph_fa'`.
-
+        the field is called `'X_draw_graph_fa'`. `key_added_ext` overwrites `layout`.
+    `adata.uns['draw_graph']`: :class:`dict`
+        `draw_graph` parameters.
     """
     start = logg.info(f"drawing single-cell graph using layout {layout!r}")
     if layout not in _LAYOUTS:

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -93,7 +93,7 @@ def draw_graph(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obsm['X_draw_graph_[layout]']` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.obsm['X_draw_graph_[layout]']` : :class:`numpy.ndarray` (dtype `float`)
         Coordinates of graph layout. E.g. for `layout='fa'` (the default),
         the field is called `'X_draw_graph_fa'`.
 

--- a/scanpy/tools/_embedding_density.py
+++ b/scanpy/tools/_embedding_density.py
@@ -76,9 +76,9 @@ def embedding_density(
     -------
     Sets the following fields (`key_added` defaults to `[basis]_density_[groupby]`, where `[basis]` is one of `umap`, `diffmap`, `pca`, `tsne`, or `draw_graph_fa` and `[groupby]` denotes the parameter input):
 
-    `adata.obs[key_added]` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.obs[key_added]` : :class:`numpy.ndarray` (dtype `float`)
         Embedding density values for each cell.
-    `adata.uns['[key_added]_params']` (:class:`dict`)
+    `adata.uns['[key_added]_params']` : :class:`dict`
         A dict with the values for the parameters `covariate` (for the `groupby` parameter) and `components`.
 
     Examples

--- a/scanpy/tools/_embedding_density.py
+++ b/scanpy/tools/_embedding_density.py
@@ -74,11 +74,12 @@ def embedding_density(
 
     Returns
     -------
-    Updates `adata.obs` with an additional field specified by the `key_added`
-    parameter. This parameter defaults to `[basis]_density_[groupby]`, where
-    `[basis]` is one of `umap`, `diffmap`, `pca`, `tsne`, or `draw_graph_fa`
-    and `[groupby]` denotes the parameter input.
-    Updates `adata.uns` with an additional field `[key_added]_params`.
+    Sets the following fields (`key_added` defaults to `[basis]_density_[groupby]`, where `[basis]` is one of `umap`, `diffmap`, `pca`, `tsne`, or `draw_graph_fa` and `[groupby]` denotes the parameter input):
+
+    `adata.obs[key_added]` (:class:`numpy.ndarray`, dtype `float`)
+        Embedding density values for each cell.
+    `adata.uns['[key_added]_params']` (:class:`dict`)
+        A dict with the values for the parameters `covariate` (for the `groupby` parameter) and `components`.
 
     Examples
     --------

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -95,7 +95,7 @@ def ingest(
 
     `adata.obs[obs]` : :class:`pandas.Series` (dtype ``category``)
         Mapped labels.
-    `adata.obsm['X_umap' | 'X_pca']` : :class:`np.ndarray` (dtype ``float``)
+    `adata.obsm['X_umap' | 'X_pca']` : :class:`numpy.ndarray` (dtype ``float``)
         Mapped embeddings. `'X_umap'` if `embedding_method` is `'umap'`, `'X_pca'` if `embedding_method` is `'pca'`.
 
     Example

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -91,10 +91,12 @@ def ingest(
 
     Returns
     -------
-    * if `inplace=False` returns a copy of `adata`
-      with mapped embeddings and labels in `obsm` and `obs` correspondingly
-    * if `inplace=True` returns `None` and updates `adata.obsm` and `adata.obs`
-      with mapped embeddings and labels
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
+
+    `adata.obs[obs]` : :class:`pandas.Series` (dtype ``category``)
+        Mapped labels.
+    `adata.obsm['X_umap' | 'X_pca']` : :class:`np.ndarray` (dtype ``float``)
+        Mapped embeddings. `'X_umap'` if `embedding_method` is `'umap'`, `'X_pca'` if `embedding_method` is `'pca'`.
 
     Example
     -------

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -99,7 +99,7 @@ def leiden(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obs[key_added]` : :class:`pandas.Series` (dtype ``category``)
+    `adata.obs['leiden' | key_added]` : :class:`pandas.Series` (dtype ``category``)
         Array of dim (number of samples) that stores the subgroup id
         (``'0'``, ``'1'``, ...) for each cell.
 

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -97,10 +97,13 @@ def leiden(
 
     Returns
     -------
-    `adata.obs[key_added]`
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
+
+    `adata.obs[key_added]` (:class:`pandas.Series`, dtype ``category``)
         Array of dim (number of samples) that stores the subgroup id
-        (`'0'`, `'1'`, ...) for each cell.
-    `adata.uns['leiden']['params']`
+        (``'0'``, ``'1'``, ...) for each cell.
+
+    `adata.uns['leiden']['params']` (:class:`dict`)
         A dict with the values for the parameters `resolution`, `random_state`,
         and `n_iterations`.
     """

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -99,11 +99,11 @@ def leiden(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obs[key_added]` (:class:`pandas.Series`, dtype ``category``)
+    `adata.obs[key_added]` : :class:`pandas.Series` (dtype ``category``)
         Array of dim (number of samples) that stores the subgroup id
         (``'0'``, ``'1'``, ...) for each cell.
 
-    `adata.uns['leiden']['params']` (:class:`dict`)
+    `adata.uns['leiden']['params']` : :class:`dict`
         A dict with the values for the parameters `resolution`, `random_state`,
         and `n_iterations`.
     """

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -104,15 +104,15 @@ def louvain(
 
     Returns
     -------
-    :obj:`None`
-        By default (``copy=False``), updates ``adata`` with the following fields:
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-        ``adata.obs['louvain']`` (:class:`pandas.Series`, dtype ``category``)
-            Array of dim (number of samples) that stores the subgroup id
-            (``'0'``, ``'1'``, ...) for each cell.
+    `adata.obs[key_added]` (:class:`pandas.Series`, dtype ``category``)
+        Array of dim (number of samples) that stores the subgroup id
+        (``'0'``, ``'1'``, ...) for each cell.
 
-    :class:`~anndata.AnnData`
-        When ``copy=True`` is set, a copy of ``adata`` with those fields is returned.
+    `adata.uns['louvain']['params']` (:class:`dict`)
+        A dict with the values for the parameters `resolution`, `random_state`,
+        and `n_iterations`.
     """
     partition_kwargs = dict(partition_kwargs)
     start = logg.info("running Louvain clustering")

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -106,11 +106,11 @@ def louvain(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obs[key_added]` (:class:`pandas.Series`, dtype ``category``)
+    `adata.obs[key_added]` : :class:`pandas.Series` (dtype ``category``)
         Array of dim (number of samples) that stores the subgroup id
         (``'0'``, ``'1'``, ...) for each cell.
 
-    `adata.uns['louvain']['params']` (:class:`dict`)
+    `adata.uns['louvain']['params']` : :class:`dict`
         A dict with the values for the parameters `resolution`, `random_state`,
         and `n_iterations`.
     """

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -106,7 +106,7 @@ def louvain(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obs[key_added]` : :class:`pandas.Series` (dtype ``category``)
+    `adata.obs['louvain' | key_added]` : :class:`pandas.Series` (dtype ``category``)
         Array of dim (number of samples) that stores the subgroup id
         (``'0'``, ``'1'``, ...) for each cell.
 

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -132,9 +132,10 @@ def marker_gene_overlap(
 
     Returns
     -------
-    A pandas dataframe with the marker gene overlap scores if `inplace=False`.
-    For `inplace=True` `adata.uns` is updated with an additional field
-    specified by the `key_added` parameter (default = 'marker_gene_overlap').
+    Returns :class:`pandas.DataFrame` if `inplace=True`, else returns an `AnnData` object where it sets the following field:
+
+    `adata.uns[key_added]` (:class:`pandas.DataFrame`, dtype `float`)
+        Marker gene overlap scores. Default for `key_added` is `'marker_gene_overlap'`.
 
     Examples
     --------

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -134,7 +134,7 @@ def marker_gene_overlap(
     -------
     Returns :class:`pandas.DataFrame` if `inplace=True`, else returns an `AnnData` object where it sets the following field:
 
-    `adata.uns[key_added]` (:class:`pandas.DataFrame`, dtype `float`)
+    `adata.uns[key_added]` : :class:`pandas.DataFrame` (dtype `float`)
         Marker gene overlap scores. Default for `key_added` is `'marker_gene_overlap'`.
 
     Examples

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -78,7 +78,6 @@ def paga(
     `adata.uns['connectivities']` : :class:`numpy.ndarray` (dtype `float`)
         The full adjacency matrix of the abstracted graph, weights correspond to
         confidence in the connectivities of partitions.
-
     `adata.uns['connectivities_tree']` : :class:`scipy.sparse.csr_matrix` (dtype `float`)
         The adjacency matrix of the tree-like subgraph that best explains
         the topology.

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -75,11 +75,11 @@ def paga(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.uns['connectivities']` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.uns['connectivities']` : :class:`numpy.ndarray` (dtype `float`)
         The full adjacency matrix of the abstracted graph, weights correspond to
         confidence in the connectivities of partitions.
 
-    `adata.uns['connectivities_tree']` (:class:`scipy.sparse.csr_matrix`, dtype `float`)
+    `adata.uns['connectivities_tree']` : :class:`scipy.sparse.csr_matrix` (dtype `float`)
         The adjacency matrix of the tree-like subgraph that best explains
         the topology.
 

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -73,10 +73,13 @@ def paga(
 
     Returns
     -------
-    **connectivities** : :class:`numpy.ndarray` (adata.uns['connectivities'])
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
+
+    `adata.uns['connectivities']` (:class:`numpy.ndarray`, dtype `float`)
         The full adjacency matrix of the abstracted graph, weights correspond to
         confidence in the connectivities of partitions.
-    **connectivities_tree** : :class:`scipy.sparse.csr_matrix` (adata.uns['connectivities_tree'])
+
+    `adata.uns['connectivities_tree']` (:class:`scipy.sparse.csr_matrix`, dtype `float`)
         The adjacency matrix of the tree-like subgraph that best explains
         the topology.
 

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -503,6 +503,8 @@ def rank_genes_groups(
         Compute the fraction of cells expressing the genes.
     key_added
         The key in `adata.uns` information is saved to.
+    copy
+        Whether to copy `adata` or modify it inplace.
     kwds
         Are passed to test methods. Currently this affects only parameters that
         are passed to :class:`sklearn.linear_model.LogisticRegression`.
@@ -512,25 +514,27 @@ def rank_genes_groups(
 
     Returns
     -------
-    names : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
+
+    `adata.uns['rank_genes_groups']['names']` (structured :class:`numpy.ndarray`, dtype `object`)
         Structured array to be indexed by group id storing the gene
         names. Ordered according to scores.
-    scores : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['scores']` (structured :class:`numpy.ndarray`, dtype `object`)
         Structured array to be indexed by group id storing the z-score
         underlying the computation of a p-value for each gene for each
         group. Ordered according to scores.
-    logfoldchanges : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['logfoldchanges']` (structured :class:`numpy.ndarray`, dtype `object`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
         scores. Only provided if method is 't-test' like.
         Note: this is an approximation calculated from mean-log values.
-    pvals : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['pvals']` (structured :class:`numpy.ndarray`, dtype `float`)
         p-values.
-    pvals_adj : structured `np.ndarray` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['pvals_adj']` (structured :class:`numpy.ndarray`, dtype `float`)
         Corrected p-values.
-    pts : `pandas.DataFrame` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['pts']` (:class:`pandas.DataFrame`, dtype `float`)
         Fraction of cells expressing the genes for each group.
-    pts_rest : `pandas.DataFrame` (`.uns['rank_genes_groups']`)
+    `adata.uns['rank_genes_groups']['pts_rest']` (:class:`pandas.DataFrame`, dtype `float`)
         Only if `reference` is set to `'rest'`.
         Fraction of cells from the union of the rest of each group
         expressing the genes.

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -516,25 +516,25 @@ def rank_genes_groups(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.uns['rank_genes_groups']['names']` (structured :class:`numpy.ndarray`, dtype `object`)
+    `adata.uns['rank_genes_groups']['names']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the gene
         names. Ordered according to scores.
-    `adata.uns['rank_genes_groups']['scores']` (structured :class:`numpy.ndarray`, dtype `object`)
+    `adata.uns['rank_genes_groups']['scores']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the z-score
         underlying the computation of a p-value for each gene for each
         group. Ordered according to scores.
-    `adata.uns['rank_genes_groups']['logfoldchanges']` (structured :class:`numpy.ndarray`, dtype `object`)
+    `adata.uns['rank_genes_groups']['logfoldchanges']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
         scores. Only provided if method is 't-test' like.
         Note: this is an approximation calculated from mean-log values.
-    `adata.uns['rank_genes_groups']['pvals']` (structured :class:`numpy.ndarray`, dtype `float`)
+    `adata.uns['rank_genes_groups']['pvals']` : structured :class:`numpy.ndarray` (dtype `float`)
         p-values.
-    `adata.uns['rank_genes_groups']['pvals_adj']` (structured :class:`numpy.ndarray`, dtype `float`)
+    `adata.uns['rank_genes_groups']['pvals_adj']` : structured :class:`numpy.ndarray` (dtype `float`)
         Corrected p-values.
-    `adata.uns['rank_genes_groups']['pts']` (:class:`pandas.DataFrame`, dtype `float`)
+    `adata.uns['rank_genes_groups']['pts']` : :class:`pandas.DataFrame` (dtype `float`)
         Fraction of cells expressing the genes for each group.
-    `adata.uns['rank_genes_groups']['pts_rest']` (:class:`pandas.DataFrame`, dtype `float`)
+    `adata.uns['rank_genes_groups']['pts_rest']` : :class:`pandas.DataFrame` (dtype `float`)
         Only if `reference` is set to `'rest'`.
         Fraction of cells from the union of the rest of each group
         expressing the genes.

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -516,25 +516,25 @@ def rank_genes_groups(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.uns['rank_genes_groups']['names']` : structured :class:`numpy.ndarray` (dtype `object`)
+    `adata.uns['rank_genes_groups' | key_added]['names']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the gene
         names. Ordered according to scores.
-    `adata.uns['rank_genes_groups']['scores']` : structured :class:`numpy.ndarray` (dtype `object`)
+    `adata.uns['rank_genes_groups' | key_added]['scores']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the z-score
         underlying the computation of a p-value for each gene for each
         group. Ordered according to scores.
-    `adata.uns['rank_genes_groups']['logfoldchanges']` : structured :class:`numpy.ndarray` (dtype `object`)
+    `adata.uns['rank_genes_groups' | key_added]['logfoldchanges']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
         scores. Only provided if method is 't-test' like.
         Note: this is an approximation calculated from mean-log values.
-    `adata.uns['rank_genes_groups']['pvals']` : structured :class:`numpy.ndarray` (dtype `float`)
+    `adata.uns['rank_genes_groups' | key_added]['pvals']` : structured :class:`numpy.ndarray` (dtype `float`)
         p-values.
-    `adata.uns['rank_genes_groups']['pvals_adj']` : structured :class:`numpy.ndarray` (dtype `float`)
+    `adata.uns['rank_genes_groups' | key_added]['pvals_adj']` : structured :class:`numpy.ndarray` (dtype `float`)
         Corrected p-values.
-    `adata.uns['rank_genes_groups']['pts']` : :class:`pandas.DataFrame` (dtype `float`)
+    `adata.uns['rank_genes_groups' | key_added]['pts']` : :class:`pandas.DataFrame` (dtype `float`)
         Fraction of cells expressing the genes for each group.
-    `adata.uns['rank_genes_groups']['pts_rest']` : :class:`pandas.DataFrame` (dtype `float`)
+    `adata.uns['rank_genes_groups' | key_added]['pts_rest']` : :class:`pandas.DataFrame` (dtype `float`)
         Only if `reference` is set to `'rest'`.
         Fraction of cells from the union of the rest of each group
         expressing the genes.

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -87,7 +87,7 @@ def score_genes(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obs[score_name]` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.obs[score_name]` : :class:`numpy.ndarray` (dtype `float`)
         Scores of each cell.
 
     Examples
@@ -222,11 +222,11 @@ def score_genes_cell_cycle(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obs['S_score']` (:class:`pandas.Series`, dtype `object`)
+    `adata.obs['S_score']` : :class:`pandas.Series` (dtype `object`)
         The score for S phase for each cell.
-    `adata.obs['G2M_score']` (:class:`pandas.Series`, dtype `object`)
+    `adata.obs['G2M_score']` : :class:`pandas.Series` (dtype `object`)
         The score for G2M phase for each cell.
-    `adata.obs['phase']` (:class:`pandas.Series`, dtype `object`)
+    `adata.obs['phase']` : :class:`pandas.Series` (dtype `object`)
         The cell cycle phase (`S`, `G2M` or `G1`) for each cell.
 
     See also

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -85,8 +85,10 @@ def score_genes(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with an additional field
-    `score_name`.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
+
+    `adata.obs[score_name]` (:class:`numpy.ndarray`, dtype `float`)
+        Scores of each cell.
 
     Examples
     --------
@@ -218,13 +220,13 @@ def score_genes_cell_cycle(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following fields.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    **S_score** : `adata.obs`, dtype `object`
+    `adata.obs['S_score']` (:class:`pandas.Series`, dtype `object`)
         The score for S phase for each cell.
-    **G2M_score** : `adata.obs`, dtype `object`
+    `adata.obs['G2M_score']` (:class:`pandas.Series`, dtype `object`)
         The score for G2M phase for each cell.
-    **phase** : `adata.obs`, dtype `object`
+    `adata.obs['phase']` (:class:`pandas.Series`, dtype `object`)
         The cell cycle phase (`S`, `G2M` or `G1`) for each cell.
 
     See also

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -76,7 +76,7 @@ def tsne(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obsm['X_tsne']` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.obsm['X_tsne']` : :class:`numpy.ndarray` (dtype `float`)
         tSNE coordinates of data.
     """
     import sklearn

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -74,9 +74,9 @@ def tsne(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following fields.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    **X_tsne** : `np.ndarray` (`adata.obsm`, dtype `float`)
+    `adata.obsm['X_tsne']` (:class:`numpy.ndarray`, dtype `float`)
         tSNE coordinates of data.
     """
     import sklearn

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -76,8 +76,11 @@ def tsne(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obsm['X_tsne']` : :class:`numpy.ndarray` (dtype `float`)
+    `adata.obsm['X_tsne']` : :class:`numpy.ndarray` | :class: `` (dtype `float`)
         tSNE coordinates of data.
+    `adata.uns['tsne']` : :class:`dict`
+        tSNE parameters.
+
     """
     import sklearn
 

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -74,9 +74,9 @@ def tsne(
 
     Returns
     -------
-    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.obsm['X_tsne']` : :class:`numpy.ndarray` | :class: `` (dtype `float`)
+    `adata.obsm['X_tsne']` : :class:`numpy.ndarray` (dtype `float`)
         tSNE coordinates of data.
     `adata.uns['tsne']` : :class:`dict`
         tSNE parameters.

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -118,10 +118,10 @@ def umap(
 
     Returns
     -------
-    Depending on `copy`, returns or updates `adata` with the following fields.
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    **X_umap** : `adata.obsm` field
-        UMAP coordinates of data.
+    `adata.obsm['X_umap']` (:class:`numpy.ndarray`, dtype `float`)
+        tSNE coordinates of data.
     """
     adata = adata.copy() if copy else adata
 

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -120,7 +120,7 @@ def umap(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
-    `adata.obsm['X_umap']` (:class:`numpy.ndarray`, dtype `float`)
+    `adata.obsm['X_umap']` : :class:`numpy.ndarray` (dtype `float`)
         tSNE coordinates of data.
     """
     adata = adata.copy() if copy else adata

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -118,7 +118,7 @@ def umap(
 
     Returns
     -------
-    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
+    Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
     `adata.obsm['X_umap']` : :class:`numpy.ndarray` (dtype `float`)
         UMAP coordinates of data.

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -121,7 +121,10 @@ def umap(
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following field:
 
     `adata.obsm['X_umap']` : :class:`numpy.ndarray` (dtype `float`)
-        tSNE coordinates of data.
+        UMAP coordinates of data.
+    `adata.uns['umap']` : :class:`dict`
+        UMAP parameters.
+
     """
     adata = adata.copy() if copy else adata
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2741, Closes #2276
- [x] Tests included or not required because: Only docstring changes
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because: Added

**Notes**

- [x]  How does `sc.pp.combat` return `None`? A: when `inplace=True`: it never returns an `AnnData` object though. Hence removed `AnnData` from the return type list.

- `sc.pp.normalize` has both `inplace` and `copy` so did not force to harmonize with others
- `sc.pp.pca` allows adata and array/sparsematrix input, so did not force to harmonize with others
- `sc.pp.filter_cells`,  `sc.pp.filter_genes` , `sc.pp.subsample` acts on data in different manner (changing dims), so did not force to harmonize with others
- `sc.pp.log1p` , `sc.pp.sqrt` seem to be understandable enough without bloating this up

