### PR TITLE
XML namespaces are “opaque identifiers”, not URLs

### DIFF
--- a/docs/_static/img/Scanpy_Logo.svg
+++ b/docs/_static/img/Scanpy_Logo.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-	xmlns="https://www.w3.org/2000/svg"
-	xmlns:svg="https://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:svg="http://www.w3.org/2000/svg"
 	version="1.1"
 	xml:space="preserve"
 	width="558.41333"

--- a/docs/_static/img/Scanpy_Logo_BrightFG.svg
+++ b/docs/_static/img/Scanpy_Logo_BrightFG.svg
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-	xmlns="https://www.w3.org/2000/svg"
-	xmlns:svg="https://www.w3.org/2000/svg"
+	xmlns="http://www.w3.org/2000/svg"
+	xmlns:svg="http://www.w3.org/2000/svg"
 	version="1.1"
 	xml:space="preserve"
 	width="558.41333"


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes N/A
- [x] Tests included or not required because: manual test: check if logo displays in rendered docs
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: unreleased bug

Seems like GitHub renders .svgs even if the namespace isn’t there, but browsers don’t.