### PR TITLE
Faster filtering on sparse matrices

### DIFF
--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -148,10 +148,13 @@ def filter_cells(
     X = data  # proceed with processing the data matrix
     min_number = min_counts if min_genes is None else min_genes
     max_number = max_counts if max_genes is None else max_genes
-    number_per_cell = np.sum(
-        X if min_genes is None and max_genes is None else X > 0, axis=1
-    )
-    if issparse(X):
+    if min_genes is None and max_genes is None:
+        number_per_cell = np.sum(X, axis=1)
+    elif isspmatrix_csr(X):
+        number_per_cell = np.diff(X.indptr)
+    else:
+        number_per_cell = np.sum(X > 0, axis=1)
+    if issparse(X) and not isspmatrix_csr(X):
         number_per_cell = number_per_cell.A1
     if min_number is not None:
         cell_subset = number_per_cell >= min_number
@@ -260,10 +263,13 @@ def filter_genes(
     X = data  # proceed with processing the data matrix
     min_number = min_counts if min_cells is None else min_cells
     max_number = max_counts if max_cells is None else max_cells
-    number_per_gene = np.sum(
-        X if min_cells is None and max_cells is None else X > 0, axis=0
-    )
-    if issparse(X):
+    if min_cells is None and max_cells is None:
+        number_per_gene = np.sum(X, axis=0)
+    elif isspmatrix_csr(X):
+        number_per_gene = np.bincount(X.indices, minlength=X.shape[1])
+    else:
+        number_per_gene = np.sum(X > 0, axis=0)
+    if issparse(X) and not isspmatrix_csr(X):
         number_per_gene = number_per_gene.A1
     if min_number is not None:
         gene_subset = number_per_gene >= min_number

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -150,12 +150,14 @@ def filter_cells(
     max_number = max_counts if max_genes is None else max_genes
     if min_genes is None and max_genes is None:
         number_per_cell = np.sum(X, axis=1)
+        if issparse(X):
+            number_per_cell = number_per_cell.A1
     elif isspmatrix_csr(X):
         number_per_cell = np.diff(X.indptr)
     else:
         number_per_cell = np.sum(X > 0, axis=1)
-    if issparse(X) and not isspmatrix_csr(X):
-        number_per_cell = number_per_cell.A1
+        if issparse(X):
+            number_per_cell = number_per_cell.A1
     if min_number is not None:
         cell_subset = number_per_cell >= min_number
     if max_number is not None:
@@ -265,12 +267,14 @@ def filter_genes(
     max_number = max_counts if max_cells is None else max_cells
     if min_cells is None and max_cells is None:
         number_per_gene = np.sum(X, axis=0)
+        if issparse(X):
+            number_per_gene = number_per_gene.A1
     elif isspmatrix_csr(X):
         number_per_gene = np.bincount(X.indices, minlength=X.shape[1])
     else:
         number_per_gene = np.sum(X > 0, axis=0)
-    if issparse(X) and not isspmatrix_csr(X):
-        number_per_gene = number_per_gene.A1
+        if issparse(X):
+            number_per_gene = number_per_gene.A1
     if min_number is not None:
         gene_subset = number_per_gene >= min_number
     if max_number is not None:


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes # _no existing issue_
- [ ] Tests included or not required because: _No new tests_
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because: _I did not write release notes_


Hi :)

I am proposing a change that speeds up `filter_cells` (x1000 speedup) and  `filter_genes` (x2 speedup) for CSR sparse matrices. On my personal machine for 1M cells, `sc.pp.filter_cells(adata, min_genes=xx)` runs in 1ms instead of 10s currently. The speedup should be even stronger on sparser modalities like ATAC.

In spirit, this simply replaces `np.sum(X > 0, axis=axis)` with `X.getnnz(axis=axis)`, which is much more efficient. But the axis argument in `getnnz` in `csr_array` may be deprecated. I think it should still be fine with `csr_matrix`, but since I don't know for sure I manually implemented it for the CSR case as in https://github.com/scipy/scipy/issues/19405 .

What do you think?

Regarding `getnnz`: Of course it would be nicer to be able to write `.getnnz(axis=axis)`, which extends beyond CSR to other sparse matrices. Can we assume that we're getting sparse matrices and not sparse arrays ?

Pinging @dschult from the Scipy issue liked above, who mentioned: 

> I'm pretty sure that a reasonable and commonly occuring use-case would be enough to make the developers include this feature somehow.

(edited because I confused `csr_array` and `csr_matrix`)