### PR TITLE
Add tSNE components parameter

### DIFF
--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -24,12 +24,13 @@ if TYPE_CHECKING:
     "random_state",
     "use_fast_tsne",
     "n_jobs",
-    "copy",
+    "copy"
 )
 @_doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)
 def tsne(
     adata: AnnData,
     n_pcs: int | None = None,
+    n_components: int = 2,
     *,
     use_rep: str | None = None,
     perplexity: float | int = 30,
@@ -57,6 +58,8 @@ def tsne(
         Annotated data matrix.
     {doc_n_pcs}
     {use_rep}
+    n_components
+        The number of dimensions of the embedding.
     perplexity
         The perplexity is related to the number of nearest neighbors that
         is used in other manifold learning algorithms. Larger datasets
@@ -113,6 +116,7 @@ def tsne(
         learning_rate=learning_rate,
         n_jobs=n_jobs,
         metric=metric,
+        n_components=n_components
     )
     if metric != "euclidean" and (
         version.parse(sklearn.__version__) < version.parse("1.3.0rc1")

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     "random_state",
     "use_fast_tsne",
     "n_jobs",
-    "copy"
+    "copy",
 )
 @_doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)
 def tsne(

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
     "random_state",
     "use_fast_tsne",
     "n_jobs",
-    "copy",
+    "copy"
 )
 @_doc_params(doc_n_pcs=doc_n_pcs, use_rep=doc_use_rep)
 def tsne(
@@ -178,6 +178,7 @@ def tsne(
                 "n_jobs": n_jobs,
                 "metric": metric,
                 "use_rep": use_rep,
+                "n_components": n_components,
             }.items()
             if v is not None
         }

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -116,7 +116,7 @@ def tsne(
         learning_rate=learning_rate,
         n_jobs=n_jobs,
         metric=metric,
-        n_components=n_components
+        n_components=n_components,
     )
     if metric != "euclidean" and (
         version.parse(sklearn.__version__) < version.parse("1.3.0rc1")


### PR DESCRIPTION
Added the ```n_components``` parameter in the tsne function, similar to the one in umap and updated docstring.

This allows for 3D plotting requested by [https://github.com/scverse/scanpy/issues/460](https://github.com/scverse/scanpy/issues/460) and [https://github.com/scverse/scanpy/issues/1435](https://github.com/scverse/scanpy/issues/1435).

![tsne](https://github.com/scverse/scanpy/assets/48340051/6a2083d2-7506-4006-81f8-9779d3ce2b14)
