### PR TITLE
Test full Dask support for `log1p`, `normalize_per_cell`, `filter_cells`/`filter_genes`

### DIFF
--- a/scanpy/_compat.py
+++ b/scanpy/_compat.py
@@ -22,6 +22,14 @@ except ImportError:
         pass
 
 
+try:
+    from zappy.base import ZappyArray
+except ImportError:
+
+    class ZappyArray:
+        pass
+
+
 __all__ = ["cache", "DaskArray", "fullname", "pkg_metadata", "pkg_version"]
 
 

--- a/scanpy/preprocessing/_distributed.py
+++ b/scanpy/preprocessing/_distributed.py
@@ -1,18 +1,49 @@
 from __future__ import annotations
 
+from typing import TYPE_CHECKING, overload
+
 import numpy as np
 
-# install dask if available
-try:
-    import dask.array as da
-except ImportError:
-    da = None
+from scanpy._compat import DaskArray, ZappyArray
+
+if TYPE_CHECKING:
+    from numpy.typing import ArrayLike
 
 
-def materialize_as_ndarray(a):
+@overload
+def materialize_as_ndarray(a: ArrayLike) -> np.ndarray:
+    ...
+
+
+@overload
+def materialize_as_ndarray(a: tuple[ArrayLike]) -> tuple[np.ndarray]:
+    ...
+
+
+@overload
+def materialize_as_ndarray(
+    a: tuple[ArrayLike, ArrayLike],
+) -> tuple[np.ndarray, np.ndarray]:
+    ...
+
+
+@overload
+def materialize_as_ndarray(
+    a: tuple[ArrayLike, ArrayLike, ArrayLike],
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ...
+
+
+def materialize_as_ndarray(
+    a: ArrayLike | tuple[ArrayLike | ZappyArray | DaskArray, ...],
+) -> tuple[np.ndarray] | np.ndarray:
     """Convert distributed arrays to ndarrays."""
-    if type(a) in (list, tuple):
-        if da is not None and any(isinstance(arr, da.Array) for arr in a):
-            return da.compute(*a, sync=True)
+    if not isinstance(a, tuple):
+        return np.asarray(a)
+
+    if not any(isinstance(arr, DaskArray) for arr in a):
         return tuple(np.asarray(arr) for arr in a)
-    return np.asarray(a)
+
+    import dask.array as da
+
+    return da.compute(*a, sync=True)

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -354,7 +354,7 @@ def log1p(
 
 
 @log1p.register(spmatrix)
-def log1p_sparse(X, *, base: Number | None = None, copy: bool = False):
+def log1p_sparse(X: spmatrix, *, base: Number | None = None, copy: bool = False):
     X = check_array(
         X, accept_sparse=("csr", "csc"), dtype=(np.float64, np.float32), copy=copy
     )
@@ -363,7 +363,7 @@ def log1p_sparse(X, *, base: Number | None = None, copy: bool = False):
 
 
 @log1p.register(np.ndarray)
-def log1p_array(X, *, base: Number | None = None, copy: bool = False):
+def log1p_array(X: np.ndarray, *, base: Number | None = None, copy: bool = False):
     # Can force arrays to be np.ndarrays, but would be useful to not
     # X = check_array(X, dtype=(np.float64, np.float32), ensure_2d=False, copy=copy)
     if copy:
@@ -381,7 +381,7 @@ def log1p_array(X, *, base: Number | None = None, copy: bool = False):
 
 @log1p.register(AnnData)
 def log1p_anndata(
-    adata,
+    adata: AnnData,
     *,
     base: Number | None = None,
     copy: bool = False,
@@ -564,7 +564,7 @@ def normalize_per_cell(  # noqa: PLR0917
         else:
             raise ValueError('use_rep should be "after", "X" or None')
         for layer in layers:
-            subset, counts = filter_cells(adata.layers[layer], min_counts=min_counts)
+            _subset, counts = filter_cells(adata.layers[layer], min_counts=min_counts)
             temp = normalize_per_cell(adata.layers[layer], after, counts, copy=True)
             adata.layers[layer] = temp
 

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -172,7 +172,7 @@ def filter_cells(
     if max_number is not None:
         cell_subset = number_per_cell <= max_number
 
-    s = np.sum(~cell_subset)
+    s = materialize_as_ndarray(np.sum(~cell_subset))
     if s > 0:
         msg = f"filtered out {s} cells that have "
         if min_genes is not None or min_counts is not None:
@@ -589,7 +589,7 @@ def normalize_per_cell(  # noqa: PLR0917
         counts_per_cell += counts_per_cell == 0
         counts_per_cell /= counts_per_cell_after
         if not issparse(X):
-            X /= materialize_as_ndarray(counts_per_cell[:, np.newaxis])
+            X /= counts_per_cell[:, np.newaxis]
         else:
             sparsefuncs.inplace_row_scale(X, 1 / counts_per_cell)
     return X if copy else None


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2813
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: only dev changes

this tests that `log1p`, `normalize_per_cell`, `filter_cells`, and `filter_genes` return dask arrays when handed dask arrays.