### PR TITLE
Fix for _validate_palette for old numpy versions, prepare 1.9.8 hotfix release

### DIFF
--- a/docs/release-notes/1.9.8.md
+++ b/docs/release-notes/1.9.8.md
@@ -1,4 +1,4 @@
-### 1.9.8 {small}`the future`
+### 1.9.8 {small}`2024-01-26`
 
 ```{rubric} Bug fixes
 ```

--- a/docs/release-notes/1.9.8.md
+++ b/docs/release-notes/1.9.8.md
@@ -2,3 +2,4 @@
 
 ```{rubric} Bug fixes
 ```
+- Fix handling of numpy array palettes for old numpy versions {pr}`2832` {smaller}`P Angerer`

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -380,8 +380,8 @@ def _validate_palette(adata: AnnData, key: str) -> None:
                 _palette = None
                 break
         _palette.append(color)
-    # Don't modify if nothing changed
-    if _palette is None or np.equal(_palette, adata.uns[color_key]).all():
+    # Don’t modify if nothing changed
+    if _palette is None or np.array_equal(_palette, adata.uns[color_key]):
         return
     adata.uns[color_key] = _palette
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Fixes #2830, fixes https://github.com/scverse/spatialdata/issues/440
- [x] Tests included or not required because: Tests are in #2816
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:
