### PR TITLE
Pin pytest < 8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ scanpy = "scanpy.cli:console_main"
 
 [project.optional-dependencies]
 test-min = [
-    "pytest>=7.4.2",
+    "pytest>=7.4.2,<8",
     "pytest-nunit",
     "pytest-mock",
     "profimp",

--- a/scanpy/tests/test_datasets.py
+++ b/scanpy/tests/test_datasets.py
@@ -4,6 +4,7 @@ Tests to make sure the example datasets load.
 from __future__ import annotations
 
 import subprocess
+import warnings
 from pathlib import Path
 
 import numpy as np
@@ -86,9 +87,9 @@ def test_toggleswitch():
 
 
 def test_pbmc68k_reduced():
-    with pytest.warns(None) as records:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         sc.datasets.pbmc68k_reduced()
-    assert len(records) == 0  # Test that loading a dataset does not warn
 
 
 @pytest.mark.internet


### PR DESCRIPTION
As reported in https://github.com/scverse/scanpy/issues/2836

I've included one fix here that lets us use pytest 8, but I'm pinning because I couldn't figure out the other case.