### PR TITLE
Fix pytest 8 compat

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ scanpy = "scanpy.cli:console_main"
 
 [project.optional-dependencies]
 test-min = [
-    "pytest>=7.4.2,<8",
+    "pytest>=7.4.2",
     "pytest-nunit",
     "pytest-mock",
     "profimp",

--- a/scanpy/testing/_doctests.py
+++ b/scanpy/testing/_doctests.py
@@ -24,7 +24,7 @@ def doctest_needs(mod: str) -> Callable[[F], F]:
 
     def decorator(func: F) -> F:
         if mark is not None:
-            func._doctest_mark = mark
+            func._doctest_needs = mark
         return func
 
     return decorator

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -19,14 +19,17 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _global_test_context(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Switch to agg backend, reset settings, and close all figures at teardown."""
+    # make sure seaborn is imported and did its thing
+    import seaborn as sns  # noqa: F401
     from matplotlib import pyplot as plt
+    from matplotlib.testing import setup
 
-    from scanpy import settings
+    import scanpy as sc
 
-    plt.switch_backend("agg")
-    settings.logfile = sys.stderr
-    settings.verbosity = "hint"
-    settings.autoshow = True
+    setup()
+    sc.settings.logfile = sys.stderr
+    sc.settings.verbosity = "hint"
+    sc.settings.autoshow = True
 
     if isinstance(request.node, pytest.DoctestItem):
         _modify_doctests(request)

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -65,7 +65,7 @@ def pytest_collection_modifyitems(
 def _modify_doctests(request: pytest.FixtureRequest) -> None:
     assert isinstance(request.node, pytest.DoctestItem)
 
-    request.getfixturevalue("doctest_env")
+    request.getfixturevalue("_doctest_env")
 
     func = _import_name(request.node.name)
     needs_marker: needs | None

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
 
 # Defining it here because it’s autouse.
 @pytest.fixture(autouse=True)
-def global_test_context() -> Generator[None, None, None]:
+def _global_test_context(request: pytest.FixtureRequest) -> Generator[None, None, None]:
     """Switch to agg backend, reset settings, and close all figures at teardown."""
     from matplotlib import pyplot as plt
 
@@ -27,6 +27,9 @@ def global_test_context() -> Generator[None, None, None]:
     settings.logfile = sys.stderr
     settings.verbosity = "hint"
     settings.autoshow = True
+
+    if isinstance(request.node, pytest.DoctestItem):
+        _modify_doctests(request)
 
     yield
 
@@ -59,10 +62,8 @@ def pytest_collection_modifyitems(
             item.add_marker(skip_internet)
 
 
-@pytest.fixture(autouse=True)
 def _modify_doctests(request: pytest.FixtureRequest) -> None:
-    if not isinstance(request.node, pytest.DoctestItem):
-        return
+    assert isinstance(request.node, pytest.DoctestItem)
 
     request.getfixturevalue("doctest_env")
 

--- a/scanpy/testing/_pytest/fixtures/__init__.py
+++ b/scanpy/testing/_pytest/fixtures/__init__.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "float_dtype",
-    "doctest_env",
+    "_doctest_env",
     "_pbmc3ks_parametrized_session",
     "pbmc3k_parametrized",
     "pbmc3k_parametrized_small",
@@ -35,7 +35,7 @@ def float_dtype(request):
 
 
 @pytest.fixture()
-def doctest_env(cache: pytest.Cache, tmp_path: Path) -> Generator[None, None, None]:
+def _doctest_env(cache: pytest.Cache, tmp_path: Path) -> Generator[None, None, None]:
     from scanpy import settings
     from scanpy._compat import chdir
 

--- a/scanpy/tests/test_plotting.py
+++ b/scanpy/tests/test_plotting.py
@@ -3,22 +3,17 @@ from __future__ import annotations
 from functools import partial
 from itertools import chain, combinations, repeat
 from pathlib import Path
-
-import pytest
-from matplotlib.testing import setup
-from packaging import version
-
-setup()
-
 from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+import pytest
 import seaborn as sns
 from anndata import AnnData
 from matplotlib.testing.compare import compare_images
+from packaging import version
 
 import scanpy as sc
 from scanpy._compat import pkg_version
@@ -35,9 +30,6 @@ if TYPE_CHECKING:
 
 HERE: Path = Path(__file__).parent
 ROOT = HERE / "_images"
-
-sc.pl.set_rcParams_defaults()
-sc.set_figure_params(dpi=40, color_map="viridis")
 
 
 # Test images are saved in the directory ./_images/<test-name>/


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2836
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: dev change

Changes:
- Removes import-time change to globals:
	- `matplotlib.testing:setup` should be called before each (plotting) test
	- `sc.set_figure_params(dpi=40, color_map="viridis")` seems to be overwritten. When calling it inline, it messes up the figure params
	- `sc.pl.set_rcParams_defaults()` is redundant, `setup` from above does that.
- Use workaround from https://github.com/pytest-dev/pytest/issues/11759#issuecomment-1888888146