### PR TITLE
Prevent oversubscription during tests

### DIFF
--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -39,6 +39,20 @@ def _global_test_context(request: pytest.FixtureRequest) -> Generator[None, None
     plt.close("all")
 
 
+@pytest.fixture(autouse=True, scope="session")
+def limit_cpus():
+    import os
+
+    import threadpoolctl
+
+    if "PYTEST_XDIST_WORKER_COUNT" in os.environ:
+        n_workers = int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
+        max_threads = os.cpu_count() // n_workers
+
+        with threadpoolctl.threadpool_limits(limits=max_threads):
+            yield
+
+
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption(
         "--internet-tests",

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -50,7 +50,7 @@ def limit_multithreading():
     if (n_workers := os.environ.get("PYTEST_XDIST_WORKER_COUNT")) is not None:
         import threadpoolctl
 
-        max_threads = os.cpu_count() // n_workers
+        max_threads = max(os.cpu_count() // n_workers, 1)
 
         with threadpoolctl.threadpool_limits(limits=max_threads):
             yield

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -47,10 +47,9 @@ def limit_multithreading():
     Prevents oversubscription of the CPU when multiple tests with parallel code are
     running at once.
     """
-    if "PYTEST_XDIST_WORKER_COUNT" in os.environ:
+    if (n_workers := os.environ.get("PYTEST_XDIST_WORKER_COUNT")) is not None:
         import threadpoolctl
 
-        n_workers = int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
         max_threads = os.cpu_count() // n_workers
 
         with threadpoolctl.threadpool_limits(limits=max_threads):

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -1,6 +1,7 @@
 """A private pytest plugin"""
 from __future__ import annotations
 
+import os
 import sys
 from typing import TYPE_CHECKING
 
@@ -40,12 +41,15 @@ def _global_test_context(request: pytest.FixtureRequest) -> Generator[None, None
 
 
 @pytest.fixture(autouse=True, scope="session")
-def limit_cpus():
-    import os
+def limit_multithreading():
+    """Limit number of threads used per worker when using pytest-xdist.
 
-    import threadpoolctl
-
+    Prevents oversubscription of the CPU when multiple tests with parallel code are
+    running at once.
+    """
     if "PYTEST_XDIST_WORKER_COUNT" in os.environ:
+        import threadpoolctl
+
         n_workers = int(os.environ["PYTEST_XDIST_WORKER_COUNT"])
         max_threads = os.cpu_count() // n_workers
 

--- a/scanpy/testing/_pytest/__init__.py
+++ b/scanpy/testing/_pytest/__init__.py
@@ -55,6 +55,8 @@ def limit_multithreading():
 
         with threadpoolctl.threadpool_limits(limits=max_threads):
             yield
+    else:
+        yield
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:


### PR DESCRIPTION
A number of multithreaded functions and libraries we use default to `os.cpu_count()` number of threads. This is a problem when multiple processes are running in parallel, as is the case when using pytest-xdist.

This oversubscription can lead to an increase in test time when multiple workers are used.

This PR limits how many threads most libraries use via `threadpoolctl`, and scales this to the number of workers available on the host.

I personally see improvements of ~10x when running with this setting on a server with 16 cores, using `-n auto`.