### PR TITLE
Improve image compare code

### DIFF
--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING
+from textwrap import dedent
+from typing import TYPE_CHECKING, TypedDict, cast
 
 import pytest
 
@@ -60,9 +61,19 @@ def imported_modules():
     return IMPORTED
 
 
+class CompareResult(TypedDict):
+    rms: float
+    expected: str
+    actual: str
+    diff: str
+    tol: float
+
+
 @pytest.fixture
 def check_same_image(add_nunit_attachment):
-    from matplotlib.testing.compare import compare_images, make_test_filename
+    from urllib.parse import quote
+
+    from matplotlib.testing.compare import compare_images
 
     def _(pth1, pth2, *, tol: int, basename: str = ""):
         def fmt_descr(descr):
@@ -72,16 +83,33 @@ def check_same_image(add_nunit_attachment):
                 return descr
 
         pth1, pth2 = Path(pth1), Path(pth2)
-        try:
-            result = compare_images(str(pth1), str(pth2), tol=tol)
-            assert result is None, result
-        except Exception as e:
-            diff_pth = make_test_filename(pth2, "failed-diff")
-            add_nunit_attachment(str(pth1), fmt_descr("Expected"))
-            add_nunit_attachment(str(pth2), fmt_descr("Result"))
-            if Path(diff_pth).is_file():
-                add_nunit_attachment(str(diff_pth), fmt_descr("Difference"))
-            raise e
+        result = cast(
+            CompareResult | None,
+            compare_images(str(pth1), str(pth2), tol=tol, in_decorator=True),
+        )
+        if result is None:
+            return
+
+        add_nunit_attachment(str(pth1), fmt_descr("Expected"))
+        add_nunit_attachment(str(pth2), fmt_descr("Result"))
+        if (diff_pth := Path(result["diff"])).is_file():
+            add_nunit_attachment(str(diff_pth), fmt_descr("Difference"))
+
+        result_urls = {
+            k: f"file://{quote(v)}" if isinstance(v, str) else v
+            for k, v in result.items()
+        }
+        msg = dedent(
+            """\
+            Image files did not match.
+            RMS Value:  {rms}
+            Expected:   {expected}
+            Actual:     {actual}
+            Difference: {diff}
+            Tolerance:  {tol}
+            """
+        ).format_map(result_urls)
+        raise AssertionError(msg)
 
     return _
 

--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -66,7 +66,7 @@ class CompareResult(TypedDict):
     expected: str
     actual: str
     diff: str
-    tol: float
+    tol: int
 
 
 @pytest.fixture
@@ -75,14 +75,13 @@ def check_same_image(add_nunit_attachment):
 
     from matplotlib.testing.compare import compare_images
 
-    def _(pth1, pth2, *, tol: int, basename: str = ""):
+    def _(pth1: Path | os.PathLike, pth2: Path | os.PathLike, *, tol: int, basename: str = ""):
         def fmt_descr(descr):
             if basename != "":
                 return f"{descr} ({basename})"
             else:
                 return descr
 
-        pth1, pth2 = Path(pth1), Path(pth2)
         result = cast(
             CompareResult | None,
             compare_images(str(pth1), str(pth2), tol=tol, in_decorator=True),
@@ -90,10 +89,9 @@ def check_same_image(add_nunit_attachment):
         if result is None:
             return
 
-        add_nunit_attachment(str(pth1), fmt_descr("Expected"))
-        add_nunit_attachment(str(pth2), fmt_descr("Result"))
-        if (diff_pth := Path(result["diff"])).is_file():
-            add_nunit_attachment(str(diff_pth), fmt_descr("Difference"))
+        add_nunit_attachment(result["expected"], fmt_descr("Expected"))
+        add_nunit_attachment(result["actual"], fmt_descr("Result"))
+        add_nunit_attachment(result["diff"], fmt_descr("Difference"))
 
         result_urls = {
             k: f"file://{quote(v)}" if isinstance(v, str) else v

--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from textwrap import dedent
-from typing import TYPE_CHECKING, TypedDict, cast
+from typing import TYPE_CHECKING, TypedDict, Union, cast
 
 import pytest
 
@@ -75,16 +75,19 @@ def check_same_image(add_nunit_attachment):
 
     from matplotlib.testing.compare import compare_images
 
-    def _(pth1: Path | os.PathLike, pth2: Path | os.PathLike, *, tol: int, basename: str = ""):
+    def check_same_image(
+        expected: Path | os.PathLike,
+        actual: Path | os.PathLike,
+        *,
+        tol: int,
+        basename: str = "",
+    ) -> None:
         def fmt_descr(descr):
-            if basename != "":
-                return f"{descr} ({basename})"
-            else:
-                return descr
+            return f"{descr} ({basename})" if basename else descr
 
         result = cast(
-            CompareResult | None,
-            compare_images(str(pth1), str(pth2), tol=tol, in_decorator=True),
+            Union[CompareResult, None],
+            compare_images(str(expected), str(actual), tol=tol, in_decorator=True),
         )
         if result is None:
             return
@@ -109,7 +112,7 @@ def check_same_image(add_nunit_attachment):
         ).format_map(result_urls)
         raise AssertionError(msg)
 
-    return _
+    return check_same_image
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes NA
- [x] Tests included or not required because: dev change
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: dev change

This allows clickable links when developing in a path with spaces.

TODO: check if nunit attachment URLs are predictable. If yes, emit them instead of paths in CI runs, i.e. instead of the Expected/Actual/Diff part, display just this URL:

display: https://dev.azure.com/scverse/scanpy/_build/results?buildId=5698&view=ms.vss-test-web.build-test-results-tab&runId=18968&resultId=100831&paneView=attachments

/edit: doesn’t seem like it’s possible. The URL contains `resultId=100831`, and I don’t see how this could be known at runtime. I assume those get assigned after the NUnit XML gets uploaded.

----

Once https://github.com/microsoft/vscode/issues/176812 is fixed, we can change this to [OSC 8](https://github.com/Alhadis/OSC8-Adoption) links