### PR TITLE
Fix pandas stack warning

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -37,6 +37,7 @@
 * Fix all remaining pandas warnings {pr}`2789` {smaller}`P Angerer`
 * Fix some annoying plotting warnings around violin plots {pr}`2844` {smaller}`P Angerer`
 * Scanpy now has a test job which tests against the minumum versions of the dependencies. In the process of implementing this, many bugs associated with using older versions of `pandas`, `anndata`, `numpy`, and `matplotlib` were fixed. {pr}`2816` {smaller}`I Virshup`
+* Fix warnings caused by internal usage of `pandas.DataFrame.stack` with `pandas>=2.1` {pr}`2864`{smaller}`I Virshup`
 
 ```{rubric} Development
 ```

--- a/scanpy/plotting/_stacked_violin.py
+++ b/scanpy/plotting/_stacked_violin.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
 from matplotlib.colors import Normalize, is_color_like
+from packaging.version import Version
 
 from .. import logging as logg
 from .._compat import old_positionals
@@ -468,9 +469,13 @@ class StackedViolin(BasePlot):
         # the expression value
         # This format is convenient to aggregate per gene or per category
         # while making the violin plots.
+        if Version(pd.__version__) >= Version("2.1"):
+            stack_kwargs = {"future_stack": True}
+        else:
+            stack_kwargs = {"dropna": False}
 
         df = (
-            pd.DataFrame(_matrix.stack(dropna=False))
+            pd.DataFrame(_matrix.stack(**stack_kwargs))
             .reset_index()
             .rename(
                 columns={

--- a/scanpy/tests/test_pca.py
+++ b/scanpy/tests/test_pca.py
@@ -165,7 +165,7 @@ def test_pca_transform(array_type):
 
     with warnings.catch_warnings(record=True) as record:
         sc.pp.pca(adata, n_comps=4, zero_center=True, dtype="float64")
-    assert len(record) == 0
+    assert len(record) == 0, record
 
     assert np.linalg.norm(A_pca_abs[:, :4] - np.abs(adata.obsm["X_pca"])) < 2e-05
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

Pandas was throwing a warning:


`FutureWarning: The previous implementation of stack is deprecated and will be removed in a future version of pandas. See the What's New notes for pandas 2.1.0 for details. Specify future_stack=True to adopt the new implementation and silence this warning.`


This fixes that warning. The fix is a little weird, but it's what pandas says to do. Pandas explanation of the new behaviour is [here](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.1.0.html#new-implementation-of-dataframe-stack).

Changes here:

`rank_genes_group_df`

* The sort order doesn't matter here since we sort again anyways
* `dropna=True` here actually doesn't drop null values from `filter_rank_genes_groups`. AFAICT, this doesn't change anything.

`StackedViolin`

Here, we were already opting in to the future behaviour with `dropna=False`.


------


This also fixes a type signature for `sc.get.rank_genes_groups_df` and makes a better error reporting for a test I saw fail locally.