### PR TITLE
Fix coverage ci

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -52,14 +52,14 @@ jobs:
 
   - script: |
       python -m pip install --upgrade pip
-      pip install wheel coverage
+      pip install wheel
       pip install .[dev,$(TEST_EXTRA)]
     displayName: 'Install dependencies'
     condition: eq(variables['DEPENDENCIES_VERSION'], 'latest')
 
   - script: |
       python -m pip install --pre --upgrade pip
-      pip install --pre wheel coverage
+      pip install --pre wheel
       pip install --pre .[dev,$(TEST_EXTRA)]
       pip install -v "anndata[dev,test] @ git+https://github.com/scverse/anndata"
     displayName: 'Install dependencies release candidates'
@@ -81,8 +81,7 @@ jobs:
     condition: eq(variables['TEST_TYPE'], 'standard')
 
   - script: |
-      coverage run -m pytest
-      coverage xml
+      pytest --cov --cov-report=xml --cov-context=test
     displayName: 'PyTest (coverage)'
     condition: eq(variables['TEST_TYPE'], 'coverage')
 

--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -66,7 +66,7 @@ jobs:
     condition: eq(variables['DEPENDENCIES_VERSION'], 'pre-release')
 
   - script: |
-      python -m pip install pip wheel tomli packaging pytest-cov
+      python -m pip install pip wheel tomli packaging
       pip install `python3 ci/scripts/min-deps.py pyproject.toml --extra dev test`
       pip install --no-deps .
     displayName: 'Install dependencies minimum version'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,6 @@ addopts = [
     "--import-mode=importlib",
     "--strict-markers",
     "--doctest-modules",
-    # "-pscanpy.testing._pytest",
 ]
 testpaths = ["scanpy"]
 norecursedirs = ["scanpy/tests/_images"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,7 +160,7 @@ addopts = [
     "--import-mode=importlib",
     "--strict-markers",
     "--doctest-modules",
-    "-pscanpy.testing._pytest",
+    # "-pscanpy.testing._pytest",
 ]
 testpaths = ["scanpy"]
 norecursedirs = ["scanpy/tests/_images"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,7 @@ test-min = [
     "pytest>=7.4.2",
     "pytest-nunit",
     "pytest-mock",
+    "pytest-cov",
     "profimp",
 ]
 test = [

--- a/scanpy/preprocessing/_docs.py
+++ b/scanpy/preprocessing/_docs.py
@@ -26,7 +26,7 @@ use_highly_variable
     By default uses them if they have been determined beforehand.
 
     .. deprecated:: 1.10.0
-       Use `mask` instead
+       Use `mask_var` instead
 """
 
 doc_obs_qc_args = """\

--- a/scanpy/tests/conftest.py
+++ b/scanpy/tests/conftest.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING, TypedDict, Union, cast
 
 import pytest
 
+pytest_plugins = ["scanpy.testing._pytest"]
+
 # just import for the IMPORTED check
 import scanpy as _sc  # noqa: F401
 

--- a/scanpy/tests/test_pca.py
+++ b/scanpy/tests/test_pca.py
@@ -382,7 +382,7 @@ def test_mask_order_warning(request):
         UserWarning,
         match="When using a mask parameter with anndata<0.9 on a dense array",
     ):
-        sc.pp.pca(adata, mask=mask)
+        sc.pp.pca(adata, mask_var=mask)
 
 
 def test_mask_defaults(array_type, float_dtype):


### PR DESCRIPTION
CI runs that report coverage currently don't fail if the tests fail. This is because the way the coverage job is written swallows the error. I'm updating this use the same approach as anndata, which seems to be working.