### PR TITLE
Even more subtle blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,6 +3,3 @@ contact_links:
   - name: Scanpy Community Forum
     url: https://discourse.scverse.org/
     about: If you have questions about “How to do X”, please ask them here.
-  - name: Blank issue
-    url: https://github.com/scverse/scanpy/issues/new
-    about: For things that don't quite fit elsewhere. Please note that other templates should be used in most cases – this is mainly for use by the developers.


### PR DESCRIPTION
As noted by @ilan-gold, just setting `blank_issues = true` makes a little link visible:

<img width="752" alt="image" src="https://github.com/scverse/scanpy/assets/8238804/85df7f67-d259-4d0c-a80a-c364aea73675">
