### PR TITLE
remove self for pynndescent

### DIFF
--- a/docs/release-notes/1.10.0.md
+++ b/docs/release-notes/1.10.0.md
@@ -44,6 +44,7 @@
 * Fix some annoying plotting warnings around violin plots {pr}`2844` {smaller}`P Angerer`
 * Scanpy now has a test job which tests against the minumum versions of the dependencies. In the process of implementing this, many bugs associated with using older versions of `pandas`, `anndata`, `numpy`, and `matplotlib` were fixed. {pr}`2816` {smaller}`I Virshup`
 * Fix warnings caused by internal usage of `pandas.DataFrame.stack` with `pandas>=2.1` {pr}`2864`{smaller}`I Virshup`
+* Removes self from array of neighbors for `use_approx_neighbors = True` in {func}`~scanpy.pp.scrublet` {pr}`2896`{smaller}`S Dicks`
 
 ```{rubric} Development
 ```

--- a/scanpy/preprocessing/_scrublet/core.py
+++ b/scanpy/preprocessing/_scrublet/core.py
@@ -360,7 +360,8 @@ class Scrublet:
             random_state=self._random_state,
         )
         neighbors, _ = _get_indices_distances_from_sparse_matrix(knn.distances, k_adj)
-
+        if use_approx_nn:
+            neighbors = neighbors = neighbors[:, 1:]
         # Calculate doublet score based on ratio of simulated cell neighbors vs. observed cell neighbors
         doub_neigh_mask: NDArray[np.bool_] = (
             manifold.obs["doub_labels"].to_numpy()[neighbors] == "sim"

--- a/scanpy/preprocessing/_scrublet/core.py
+++ b/scanpy/preprocessing/_scrublet/core.py
@@ -361,7 +361,7 @@ class Scrublet:
         )
         neighbors, _ = _get_indices_distances_from_sparse_matrix(knn.distances, k_adj)
         if use_approx_nn:
-            neighbors = neighbors = neighbors[:, 1:]
+            neighbors = neighbors[:, 1:]
         # Calculate doublet score based on ratio of simulated cell neighbors vs. observed cell neighbors
         doub_neigh_mask: NDArray[np.bool_] = (
             manifold.obs["doub_labels"].to_numpy()[neighbors] == "sim"

--- a/scanpy/tests/test_scrublet.py
+++ b/scanpy/tests/test_scrublet.py
@@ -38,14 +38,16 @@ def paul500() -> AnnData:
         pytest.param(paul500, [180], [0.219178], id="dense"),
     ],
 )
+@pytest.mark.parametrize("use_approx_neighbors", [True, False])
 def test_scrublet(
     mk_data: Callable[[], AnnData],
     expected_idx: list[int],
     expected_scores: list[float],
+    use_approx_neighbors: bool,
 ):
     """Check that scrublet runs and detects some doublets."""
     adata = mk_data()
-    sc.pp.scrublet(adata, use_approx_neighbors=False)
+    sc.pp.scrublet(adata, use_approx_neighbors=use_approx_neighbors)
 
     doublet_idx = np.flatnonzero(adata.obs["predicted_doublet"]).tolist()
     assert doublet_idx == expected_idx


### PR DESCRIPTION
This removes `self` for `pynndescent` in `scrublet` and makes it reproducible for smaller datasets. I also added a test param that represent this. I also think this might help with larger datasets to remove self from the computation.