### PR TITLE
fixes pca_test `test_mask_defaults`

### DIFF
--- a/scanpy/tests/test_pca.py
+++ b/scanpy/tests/test_pca.py
@@ -390,14 +390,13 @@ def test_mask_defaults(array_type, float_dtype):
     Test if pca result is equal without highly variable and with-but mask is None
     and if pca takes highly variable as mask as default
     """
-    A = array_type(A_list).astype("float32")
+    A = array_type(A_list).astype("float64")
     adata = AnnData(A)
 
     without_var = sc.pp.pca(adata, copy=True, dtype=float_dtype)
 
-    mask = np.random.choice([True, False], adata.shape[1])
-    mask[0] = True
-    mask[1] = True
+    rng = np.random.default_rng(8)
+    mask = rng.choice([True, False], adata.shape[1])
     adata.var["highly_variable"] = mask
     with_var = sc.pp.pca(adata, copy=True, dtype=float_dtype)
     assert without_var.uns["pca"]["params"]["mask_var"] is None


### PR DESCRIPTION
The PCA test `test_mask_defaults` only passed because of `float32` being to loose in some situation. When the mask randomly was `[True, True, True, True, True]` the test should have failed. Now the test works as intended. 