### PR TITLE
Fix aggregate for more than two groups

### DIFF
--- a/docs/release-notes/1.10.1.md
+++ b/docs/release-notes/1.10.1.md
@@ -1,0 +1,13 @@
+### 1.10.1 {small}`the future`
+
+
+```{rubric} Docs
+```
+
+```{rubric} Bug fixes
+```
+
+* Fix `aggregate` when aggregating by more than two groups {pr}`2965` {smaller}`I Virshup`
+
+```{rubric} Performance
+```

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -9,6 +9,9 @@
 
 ## Version 1.10
 
+```{include} /release-notes/1.10.1.md
+```
+
 ```{include} /release-notes/1.10.0.md
 ```
 

--- a/scanpy/get/_aggregated.py
+++ b/scanpy/get/_aggregated.py
@@ -377,7 +377,7 @@ def _combine_categories(
 
     # Calculating result codes
     factors = np.ones(len(cols) + 1, dtype=np.int32)  # First factor needs to be 1
-    np.cumsum(n_categories[::-1], out=factors[1:])
+    np.cumprod(n_categories[::-1], out=factors[1:])
     factors = factors[:-1][::-1]
 
     code_array = np.zeros((len(cols), df.shape[0]), dtype=np.int32)

--- a/scanpy/tests/test_aggregated.py
+++ b/scanpy/tests/test_aggregated.py
@@ -460,3 +460,19 @@ def test_dispatch_not_implemented():
     adata = sc.datasets.blobs()
     with pytest.raises(NotImplementedError):
         sc.get.aggregate(adata.X, adata.obs["blobs"], "sum")
+
+
+def test_factors():
+    from itertools import product
+
+    obs = pd.DataFrame(
+        product(range(5), range(5), range(5), range(5)), columns=list("abcd")
+    )
+    obs.index = [f"cell_{i:04d}" for i in range(obs.shape[0])]
+    adata = ad.AnnData(
+        X=np.arange(obs.shape[0]).reshape(-1, 1),
+        obs=obs,
+    )
+
+    res = sc.get.aggregate(adata, by=["a", "b", "c", "d"], func="sum")
+    np.testing.assert_equal(res.layers["sum"], adata.X)


### PR DESCRIPTION
Offsets for factors were being calculated wrong. It was being done with a sum when it should have been product.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2964
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because:
