### PR TITLE
Matplotlib 3.9 support

### DIFF
--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -8,5 +8,7 @@
 ```{rubric} Bug fixes
 ```
 
+* Compatibility with `matplotlib` 3.9 {pr}`2999` {smaller}`I Virshup`
+
 ```{rubric} Performance
 ```

--- a/scanpy/experimental/pp/_normalization.py
+++ b/scanpy/experimental/pp/_normalization.py
@@ -136,7 +136,7 @@ def normalize_pearson_residuals(
     msg = f"computing analytic Pearson residuals on {computed_on}"
     start = logg.info(msg)
 
-    residuals = _pearson_residuals(X, theta, clip, check_values, copy=~inplace)
+    residuals = _pearson_residuals(X, theta, clip, check_values, copy=not inplace)
     settings_dict = dict(theta=theta, clip=clip, computed_on=computed_on)
 
     if inplace:

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -518,7 +518,7 @@ def _scatter_obs(
                 frameon=False, loc=legend_loc, fontsize=legend_fontsize
             )
         if legend is not None:
-            for handle in legend.legendHandles:
+            for handle in legend.legend_handles:
                 handle.set_sizes([300.0])
 
     # draw a frame around the scatter

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -8,11 +8,13 @@ from collections.abc import Collection, Iterable, Mapping, Sequence
 from itertools import product
 from typing import TYPE_CHECKING, Literal, Union
 
+import matplotlib as mpl
 import numpy as np
 import pandas as pd
 from matplotlib import gridspec, patheffects, rcParams
 from matplotlib import pyplot as plt
 from matplotlib.colors import Colormap, ListedColormap, Normalize, is_color_like
+from packaging.version import Version
 from pandas.api.types import CategoricalDtype, is_numeric_dtype
 from scipy.sparse import issparse
 
@@ -518,7 +520,11 @@ def _scatter_obs(
                 frameon=False, loc=legend_loc, fontsize=legend_fontsize
             )
         if legend is not None:
-            for handle in legend.legend_handles:
+            if Version(mpl.__version__) < Version("3.7"):
+                _attr = "legendHandles"
+            else:
+                _attr = "legend_handles"
+            for handle in getattr(legend, _attr):
                 handle.set_sizes([300.0])
 
     # draw a frame around the scatter

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -165,9 +165,9 @@ def leiden(
     # as this allows for the accounting of a None resolution
     # (in the case of a partition variant that doesn't take it on input)
     clustering_args["n_iterations"] = n_iterations
-    if resolution is not None:
-        clustering_args["resolution_parameter"] = resolution
     if flavor == "leidenalg":
+        if resolution is not None:
+            clustering_args["resolution_parameter"] = resolution
         directed = True if directed is None else directed
         g = _utils.get_igraph_from_adjacency(adjacency, directed=directed)
         if partition_type is None:
@@ -180,6 +180,8 @@ def leiden(
         g = _utils.get_igraph_from_adjacency(adjacency, directed=False)
         if use_weights:
             clustering_args["weights"] = "weight"
+        if resolution is not None:
+            clustering_args["resolution"] = resolution
         clustering_args.setdefault("objective_function", "modularity")
         with _utils.set_igraph_random_state(random_state):
             part = g.community_leiden(**clustering_args)


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

Fixes:

* Error caused by new matplotlib release candidate (it had been deprecated for a while, we just hadn't caught it....)
* Corrects deprecation warnings in igraph leiden clustering code and pearson residuals code

<!-- Please check (“- [x]”) and fill in the following boxes -->

- [x] Tests included or not required because: just fixin' warnings
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because:
