### PR TITLE
Import types only in `if TYPE_CHECKING` blocks

### DIFF
--- a/benchmarks/benchmarks/_utils.py
+++ b/benchmarks/benchmarks/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from functools import cache
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pooch
@@ -11,6 +11,8 @@ from anndata import concat
 import scanpy as sc
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
 
     Dataset = Literal["pbmc68k_reduced", "pbmc3k", "bmmc", "lung93k"]

--- a/docs/extensions/function_images.py
+++ b/docs/extensions/function_images.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from sphinx.application import Sphinx
     from sphinx.ext.autodoc import Options
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,3 +252,6 @@ required-imports = ["from __future__ import annotations"]
 "pytest.importorskip".msg = "Use the “@needs” decorator/mark instead"
 "pandas.api.types.is_categorical_dtype".msg = "Use isinstance(s.dtype, CategoricalDtype) instead"
 "pandas.value_counts".msg = "Use pd.Series(a).value_counts() instead"
+[tool.ruff.lint.flake8-type-checking]
+exempt-modules = []
+strict = true

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -7,7 +7,7 @@ from enum import IntEnum
 from logging import getLevelName
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Any, Literal, TextIO, Union
+from typing import TYPE_CHECKING, Literal, Union
 
 from . import logging
 from ._compat import old_positionals
@@ -15,6 +15,7 @@ from .logging import _RootLogger, _set_log_file, _set_log_level
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
+    from typing import Any, TextIO
 
 _VERBOSITY_TO_LOGLEVEL = {
     "error": "ERROR",

--- a/scanpy/_settings.py
+++ b/scanpy/_settings.py
@@ -7,7 +7,7 @@ from enum import IntEnum
 from logging import getLevelName
 from pathlib import Path
 from time import time
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING
 
 from . import logging
 from ._compat import old_positionals
@@ -15,7 +15,14 @@ from .logging import _RootLogger, _set_log_file, _set_log_level
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
-    from typing import Any, TextIO
+    from typing import Any, Literal, TextIO, Union
+
+    # Collected from the print_* functions in matplotlib.backends
+    _Format = Union[
+        Literal["png", "jpg", "tif", "tiff"],
+        Literal["pdf", "ps", "eps", "svg", "svgz", "pgf"],
+        Literal["raw", "rgba"],
+    ]
 
 _VERBOSITY_TO_LOGLEVEL = {
     "error": "ERROR",
@@ -27,14 +34,6 @@ _VERBOSITY_TO_LOGLEVEL = {
 # Python 3.7+ ensures iteration order
 for v, level in enumerate(list(_VERBOSITY_TO_LOGLEVEL.values())):
     _VERBOSITY_TO_LOGLEVEL[v] = level
-
-
-# Collected from the print_* functions in matplotlib.backends
-_Format = Union[
-    Literal["png", "jpg", "tif", "tiff"],
-    Literal["pdf", "ps", "eps", "svg", "svgz", "pgf"],
-    Literal["raw", "rgba"],
-]
 
 
 class Verbosity(IntEnum):

--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -19,19 +19,10 @@ from functools import partial, singledispatch, wraps
 from operator import mul, truediv
 from textwrap import dedent
 from types import MethodType, ModuleType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Literal,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, TypeVar, Union, overload
 from weakref import WeakSet
 
 import numpy as np
-from anndata import AnnData
 from anndata import __version__ as anndata_version
 from numpy.typing import NDArray
 from packaging.version import Version
@@ -46,7 +37,9 @@ from .compute.is_constant import is_constant  # noqa: F401
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
+    from typing import Any, Callable, Literal
 
+    from anndata import AnnData
     from numpy.typing import DTypeLike
 
 

--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -19,12 +19,11 @@ from functools import partial, singledispatch, wraps
 from operator import mul, truediv
 from textwrap import dedent
 from types import MethodType, ModuleType
-from typing import TYPE_CHECKING, TypeVar, Union, overload
+from typing import TYPE_CHECKING, overload
 from weakref import WeakSet
 
 import numpy as np
 from anndata import __version__ as anndata_version
-from numpy.typing import NDArray
 from packaging.version import Version
 from scipy import sparse
 from sklearn.utils import check_random_state
@@ -37,10 +36,14 @@ from .compute.is_constant import is_constant  # noqa: F401
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from pathlib import Path
-    from typing import Any, Callable, Literal
+    from typing import Any, Callable, Literal, TypeVar, Union
 
     from anndata import AnnData
-    from numpy.typing import DTypeLike
+    from numpy.typing import DTypeLike, NDArray
+
+    # e.g. https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html
+    # maybe in the future random.Generator
+    AnyRandom = Union[int, np.random.RandomState, None]
 
 
 class Empty(Enum):
@@ -51,10 +54,6 @@ class Empty(Enum):
 
 
 _empty = Empty.token
-
-# e.g. https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html
-# maybe in the future random.Generator
-AnyRandom = Union[int, np.random.RandomState, None]
 
 
 class RNGIgraph:
@@ -528,9 +527,10 @@ def update_params(
 # --------------------------------------------------------------------------------
 
 
-_SparseMatrix = Union[sparse.csr_matrix, sparse.csc_matrix]
-_MemoryArray = Union[NDArray, _SparseMatrix]
-_SupportedArray = Union[_MemoryArray, DaskArray]
+if TYPE_CHECKING:
+    _SparseMatrix = Union[sparse.csr_matrix, sparse.csc_matrix]
+    _MemoryArray = Union[NDArray, _SparseMatrix]
+    _SupportedArray = Union[_MemoryArray, DaskArray]
 
 
 @singledispatch
@@ -554,7 +554,8 @@ def _elem_mul_dask(x: DaskArray, y: DaskArray) -> DaskArray:
     return da.map_blocks(elem_mul, x, y)
 
 
-Scaling_T = TypeVar("Scaling_T", DaskArray, np.ndarray)
+if TYPE_CHECKING:
+    Scaling_T = TypeVar("Scaling_T", DaskArray, np.ndarray)
 
 
 def broadcast_axis(divisor: Scaling_T, axis: Literal[0, 1]) -> Scaling_T:

--- a/scanpy/_utils/compute/is_constant.py
+++ b/scanpy/_utils/compute/is_constant.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from functools import partial, singledispatch, wraps
 from numbers import Integral
-from typing import TYPE_CHECKING, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, TypeVar, overload
 
 import numpy as np
 from numba import njit
@@ -12,6 +12,8 @@ from scipy import sparse
 from ..._compat import DaskArray
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import NDArray
 
 C = TypeVar("C", bound=Callable)

--- a/scanpy/cli.py
+++ b/scanpy/cli.py
@@ -7,11 +7,13 @@ from argparse import ArgumentParser, Namespace, _SubParsersAction
 from functools import lru_cache, partial
 from pathlib import Path
 from shutil import which
-from subprocess import CompletedProcess, run
-from typing import TYPE_CHECKING, Any
+from subprocess import run
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Mapping, Sequence
+    from subprocess import CompletedProcess
+    from typing import Any
 
 
 class _DelegatingSubparsersAction(_SubParsersAction):

--- a/scanpy/datasets/_datasets.py
+++ b/scanpy/datasets/_datasets.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import anndata as ad
 import numpy as np
@@ -16,6 +16,8 @@ from ..readwrite import read, read_visium
 from ._utils import check_datasetdir_exists, filter_oldformatwarning
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from .._utils import AnyRandom
 
 HERE = Path(__file__).parent

--- a/scanpy/datasets/_ebi_expression_atlas.py
+++ b/scanpy/datasets/_ebi_expression_atlas.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import BinaryIO
+from typing import TYPE_CHECKING
 from urllib.error import HTTPError
 from urllib.request import urlopen
 from zipfile import ZipFile
@@ -14,6 +14,9 @@ from .. import logging as logg
 from .._settings import settings
 from ..readwrite import _download
 from ._utils import check_datasetdir_exists
+
+if TYPE_CHECKING:
+    from typing import BinaryIO
 
 
 def _filter_boring(dataframe: pd.DataFrame) -> pd.DataFrame:

--- a/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/scanpy/experimental/pp/_highly_variable_genes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from functools import partial
 from math import sqrt
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numba as nb
 import numpy as np
@@ -27,6 +27,8 @@ from scanpy.preprocessing._distributed import materialize_as_ndarray
 from scanpy.preprocessing._utils import _get_mean_var
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import NDArray
 
 

--- a/scanpy/experimental/pp/_normalization.py
+++ b/scanpy/experimental/pp/_normalization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
@@ -10,7 +10,6 @@ from scipy.sparse import issparse
 
 from ... import logging as logg
 from ..._utils import (
-    Empty,
     _doc_params,
     _empty,
     check_nonnegative_integers,
@@ -31,6 +30,9 @@ from ...preprocessing._pca import _handle_mask_var, pca
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from typing import Any
+
+    from ..._utils import Empty
 
 
 def _pearson_residuals(X, theta, clip, check_values, copy: bool = False):

--- a/scanpy/external/pl.py
+++ b/scanpy/external/pl.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -23,6 +23,7 @@ from .tl._wishbone import _anndata_to_wishbone
 
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from typing import Any
 
 
 __all__ = [

--- a/scanpy/external/pp/_bbknn.py
+++ b/scanpy/external/pp/_bbknn.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from ..._compat import old_positionals
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Callable
+
     from anndata import AnnData
     from sklearn.metrics import DistanceMetric
 

--- a/scanpy/external/pp/_dca.py
+++ b/scanpy/external/pp/_dca.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 from ..._compat import old_positionals
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from typing import Any
 
     from anndata import AnnData
 

--- a/scanpy/external/pp/_dca.py
+++ b/scanpy/external/pp/_dca.py
@@ -1,19 +1,19 @@
 from __future__ import annotations
 
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from ..._compat import old_positionals
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
-    from typing import Any
+    from typing import Any, Literal
 
     from anndata import AnnData
 
     from ..._utils import AnyRandom
 
-_AEType = Literal["zinb-conddisp", "zinb", "nb-conddisp", "nb"]
+    _AEType = Literal["zinb-conddisp", "zinb", "nb-conddisp", "nb"]
 
 
 @old_positionals(

--- a/scanpy/external/pp/_magic.py
+++ b/scanpy/external/pp/_magic.py
@@ -4,7 +4,7 @@ Denoise high-dimensional data using MAGIC
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from packaging.version import Version
 
@@ -14,6 +14,7 @@ from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Literal
 
     from anndata import AnnData
 

--- a/scanpy/external/pp/_mnn_correct.py
+++ b/scanpy/external/pp/_mnn_correct.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 from ..._settings import settings
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Sequence
+    from typing import Any, Literal
 
     import numpy as np
     import pandas as pd

--- a/scanpy/external/tl/_phate.py
+++ b/scanpy/external/tl/_phate.py
@@ -4,7 +4,7 @@ Embed high-dimensional data using PHATE
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from ... import logging as logg
 from ..._compat import old_positionals
@@ -12,6 +12,8 @@ from ..._settings import settings
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
 
     from ..._utils import AnyRandom

--- a/scanpy/external/tl/_phenograph.py
+++ b/scanpy/external/tl/_phenograph.py
@@ -4,7 +4,7 @@ Perform clustering using PhenoGraph
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from anndata import AnnData
@@ -15,6 +15,8 @@ from ..._utils import renamed_arg
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Any, Literal
+
     import numpy as np
     from scipy.sparse import spmatrix
 

--- a/scanpy/external/tl/_pypairs.py
+++ b/scanpy/external/tl/_pypairs.py
@@ -4,7 +4,7 @@ Calculate scores based on relative expression change of maker pairs
 
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping
+from collections.abc import Collection
 from typing import TYPE_CHECKING, Union
 
 from packaging.version import Version
@@ -13,6 +13,8 @@ from ..._settings import settings
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from collections.abc import Mapping
+
     import pandas as pd
     from anndata import AnnData
 

--- a/scanpy/external/tl/_pypairs.py
+++ b/scanpy/external/tl/_pypairs.py
@@ -4,8 +4,7 @@ Calculate scores based on relative expression change of maker pairs
 
 from __future__ import annotations
 
-from collections.abc import Collection
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from packaging.version import Version
 
@@ -13,12 +12,13 @@ from ..._settings import settings
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping
+    from collections.abc import Collection, Mapping
+    from typing import Union
 
     import pandas as pd
     from anndata import AnnData
 
-Genes = Collection[Union[str, int, bool]]
+    Genes = Collection[Union[str, int, bool]]
 
 
 @doctest_needs("pypairs")

--- a/scanpy/external/tl/_sam.py
+++ b/scanpy/external/tl/_sam.py
@@ -4,13 +4,15 @@ Run the Self-Assembling Manifold algorithm
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from ... import logging as logg
 from ..._compat import old_positionals
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
     from samalg import SAM
 

--- a/scanpy/external/tl/_trimap.py
+++ b/scanpy/external/tl/_trimap.py
@@ -4,7 +4,7 @@ Embed high-dimensional data using TriMap
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import scipy.sparse as scp
 
@@ -14,6 +14,8 @@ from ..._settings import settings
 from ..._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
 
 

--- a/scanpy/get/_aggregated.py
+++ b/scanpy/get/_aggregated.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import TYPE_CHECKING, get_args
+from typing import TYPE_CHECKING, Literal, get_args
 
 import numpy as np
 import pandas as pd
@@ -13,12 +13,14 @@ from .get import _check_mask
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
-    from typing import Literal, Union
+    from typing import Union
 
     from numpy.typing import NDArray
 
     Array = Union[np.ndarray, sparse.csc_matrix, sparse.csr_matrix]
-    AggType = Literal["count_nonzero", "mean", "sum", "var"]
+
+# Used with get_args
+AggType = Literal["count_nonzero", "mean", "sum", "var"]
 
 
 class Aggregate:

--- a/scanpy/get/_aggregated.py
+++ b/scanpy/get/_aggregated.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import TYPE_CHECKING, Literal, Union, get_args
+from typing import TYPE_CHECKING, get_args
 
 import numpy as np
 import pandas as pd
@@ -13,11 +13,12 @@ from .get import _check_mask
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
+    from typing import Literal, Union
 
     from numpy.typing import NDArray
 
-Array = Union[np.ndarray, sparse.csc_matrix, sparse.csr_matrix]
-AggType = Literal["count_nonzero", "mean", "sum", "var"]
+    Array = Union[np.ndarray, sparse.csc_matrix, sparse.csr_matrix]
+    AggType = Literal["count_nonzero", "mean", "sum", "var"]
 
 
 class Aggregate:

--- a/scanpy/get/get.py
+++ b/scanpy/get/get.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -12,6 +12,7 @@ from scipy.sparse import spmatrix
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Any, Literal
 
     from anndata._core.sparse_dataset import BaseCompressedSparseDataset
     from anndata._core.views import ArrayView

--- a/scanpy/logging.py
+++ b/scanpy/logging.py
@@ -8,11 +8,13 @@ import warnings
 from datetime import datetime, timedelta, timezone
 from functools import partial, update_wrapper
 from logging import CRITICAL, DEBUG, ERROR, INFO, WARNING
-from typing import IO, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 import anndata.logging
 
 if TYPE_CHECKING:
+    from typing import IO
+
     from ._settings import ScanpyConfig
 
 

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from textwrap import indent
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple, TypedDict, get_args
@@ -25,7 +24,7 @@ from ._doc import doc_n_pcs, doc_use_rep
 from ._types import _KnownTransformer, _Method
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, MutableMapping
+    from collections.abc import Callable, Mapping, MutableMapping
     from typing import Any, Literal
 
     from anndata import AnnData
@@ -35,7 +34,7 @@ if TYPE_CHECKING:
     from .._utils import AnyRandom
     from ._types import KnnTransformerLike, _Metric, _MetricFn
 
-RPForestDict = Mapping[str, Mapping[str, np.ndarray]]
+    RPForestDict = Mapping[str, Mapping[str, np.ndarray]]
 
 
 N_DCS = 15  # default number of diffusion components

--- a/scanpy/neighbors/__init__.py
+++ b/scanpy/neighbors/__init__.py
@@ -1,35 +1,39 @@
 from __future__ import annotations
 
-from collections.abc import Callable, Mapping, MutableMapping
+from collections.abc import Mapping
 from textwrap import indent
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, get_args
+from typing import TYPE_CHECKING, NamedTuple, TypedDict, get_args
 from warnings import warn
 
 import numpy as np
 import scipy
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import issparse
 from sklearn.utils import check_random_state
-
-from .._compat import old_positionals
-
-if TYPE_CHECKING:
-    from anndata import AnnData
-    from igraph import Graph
-
-    from ._types import KnnTransformerLike
 
 from .. import _utils
 from .. import logging as logg
+from .._compat import old_positionals
 from .._settings import settings
-from .._utils import AnyRandom, NeighborsView, _doc_params
+from .._utils import NeighborsView, _doc_params
 from . import _connectivity
 from ._common import (
     _get_indices_distances_from_sparse_matrix,
     _get_sparse_matrix_from_indices_distances,
 )
 from ._doc import doc_n_pcs, doc_use_rep
-from ._types import _KnownTransformer, _Method, _Metric, _MetricFn
+from ._types import _KnownTransformer, _Method
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, MutableMapping
+    from typing import Any, Literal
+
+    from anndata import AnnData
+    from igraph import Graph
+    from scipy.sparse import csr_matrix
+
+    from .._utils import AnyRandom
+    from ._types import KnnTransformerLike, _Metric, _MetricFn
 
 RPForestDict = Mapping[str, Mapping[str, np.ndarray]]
 

--- a/scanpy/neighbors/_backends/rapids.py
+++ b/scanpy/neighbors/_backends/rapids.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Literal
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -12,6 +12,7 @@ from ._common import TransformerChecksMixin
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from typing import Any
 
     from numpy.typing import ArrayLike
     from scipy.sparse import csr_matrix

--- a/scanpy/neighbors/_backends/rapids.py
+++ b/scanpy/neighbors/_backends/rapids.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.base import BaseEstimator, TransformerMixin
@@ -12,27 +12,27 @@ from ._common import TransformerChecksMixin
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-    from typing import Any
+    from typing import Any, Literal
 
     from numpy.typing import ArrayLike
     from scipy.sparse import csr_matrix
 
-_Algorithm = Literal["rbc", "brute", "ivfflat", "ivfpq"]
-_Metric = Literal[
-    "l1",
-    "cityblock",
-    "taxicab",
-    "manhattan",
-    "euclidean",
-    "l2",
-    "braycurtis",
-    "canberra",
-    "minkowski",
-    "chebyshev",
-    "jensenshannon",
-    "cosine",
-    "correlation",
-]
+    _Algorithm = Literal["rbc", "brute", "ivfflat", "ivfpq"]
+    _Metric = Literal[
+        "l1",
+        "cityblock",
+        "taxicab",
+        "manhattan",
+        "euclidean",
+        "l2",
+        "braycurtis",
+        "canberra",
+        "minkowski",
+        "chebyshev",
+        "jensenshannon",
+        "cosine",
+        "correlation",
+    ]
 
 
 class RapidsKNNTransformer(TransformerChecksMixin, TransformerMixin, BaseEstimator):

--- a/scanpy/neighbors/_types.py
+++ b/scanpy/neighbors/_types.py
@@ -1,46 +1,43 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Literal, Protocol
-from typing import Callable as _C
-from typing import Union as _U
-
-import numpy as np
 
 if TYPE_CHECKING:
-    from typing import Any, Self
+    from collections.abc import Callable
+    from typing import Any, Self, Union
 
+    import numpy as np
     from scipy.sparse import spmatrix
 
+    _MetricFn = Callable[[np.ndarray, np.ndarray], float]
+    # from sklearn.metrics.pairwise_distances.__doc__:
+    _MetricSparseCapable = Literal[
+        "cityblock", "cosine", "euclidean", "l1", "l2", "manhattan"
+    ]
+    _MetricScipySpatial = Literal[
+        "braycurtis",
+        "canberra",
+        "chebyshev",
+        "correlation",
+        "dice",
+        "hamming",
+        "jaccard",
+        "kulsinski",
+        "mahalanobis",
+        "minkowski",
+        "rogerstanimoto",
+        "russellrao",
+        "seuclidean",
+        "sokalmichener",
+        "sokalsneath",
+        "sqeuclidean",
+        "yule",
+    ]
+    _Metric = Union[_MetricSparseCapable, _MetricScipySpatial]
 
+# These two are used with get_Args elsewhere
 _Method = Literal["umap", "gauss"]
-
 _KnownTransformer = Literal["pynndescent", "sklearn", "rapids"]
-
-_MetricFn = _C[[np.ndarray, np.ndarray], float]
-# from sklearn.metrics.pairwise_distances.__doc__:
-_MetricSparseCapable = Literal[
-    "cityblock", "cosine", "euclidean", "l1", "l2", "manhattan"
-]
-_MetricScipySpatial = Literal[
-    "braycurtis",
-    "canberra",
-    "chebyshev",
-    "correlation",
-    "dice",
-    "hamming",
-    "jaccard",
-    "kulsinski",
-    "mahalanobis",
-    "minkowski",
-    "rogerstanimoto",
-    "russellrao",
-    "seuclidean",
-    "sokalmichener",
-    "sokalsneath",
-    "sqeuclidean",
-    "yule",
-]
-_Metric = _U[_MetricSparseCapable, _MetricScipySpatial]
 
 
 class KnnTransformerLike(Protocol):

--- a/scanpy/neighbors/_types.py
+++ b/scanpy/neighbors/_types.py
@@ -1,50 +1,54 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, Protocol
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Literal, Protocol, Union
+
+import numpy as np
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, Self, Union
+    from typing import Any, Self
 
-    import numpy as np
     from scipy.sparse import spmatrix
 
-    _MetricFn = Callable[[np.ndarray, np.ndarray], float]
-    # from sklearn.metrics.pairwise_distances.__doc__:
-    _MetricSparseCapable = Literal[
-        "cityblock", "cosine", "euclidean", "l1", "l2", "manhattan"
-    ]
-    _MetricScipySpatial = Literal[
-        "braycurtis",
-        "canberra",
-        "chebyshev",
-        "correlation",
-        "dice",
-        "hamming",
-        "jaccard",
-        "kulsinski",
-        "mahalanobis",
-        "minkowski",
-        "rogerstanimoto",
-        "russellrao",
-        "seuclidean",
-        "sokalmichener",
-        "sokalsneath",
-        "sqeuclidean",
-        "yule",
-    ]
-    _Metric = Union[_MetricSparseCapable, _MetricScipySpatial]
 
-# These two are used with get_Args elsewhere
+# These two are used with get_args elsewhere
 _Method = Literal["umap", "gauss"]
 _KnownTransformer = Literal["pynndescent", "sklearn", "rapids"]
+
+# sphinx-autodoc-typehints can’t transitively import types from if TYPE_CHECKING blocks,
+# so these four needs to be importable
+
+_MetricFn = Callable[[np.ndarray, np.ndarray], float]
+# from sklearn.metrics.pairwise_distances.__doc__:
+_MetricSparseCapable = Literal[
+    "cityblock", "cosine", "euclidean", "l1", "l2", "manhattan"
+]
+_MetricScipySpatial = Literal[
+    "braycurtis",
+    "canberra",
+    "chebyshev",
+    "correlation",
+    "dice",
+    "hamming",
+    "jaccard",
+    "kulsinski",
+    "mahalanobis",
+    "minkowski",
+    "rogerstanimoto",
+    "russellrao",
+    "seuclidean",
+    "sokalmichener",
+    "sokalsneath",
+    "sqeuclidean",
+    "yule",
+]
+_Metric = Union[_MetricSparseCapable, _MetricScipySpatial]
 
 
 class KnnTransformerLike(Protocol):
     """See :class:`~sklearn.neighbors.KNeighborsTransformer`."""
 
     def fit(self, X, y: None = None): ...
-
     def transform(self, X) -> spmatrix: ...
 
     # from TransformerMixin
@@ -52,5 +56,4 @@ class KnnTransformerLike(Protocol):
 
     # from BaseEstimator
     def get_params(self, deep: bool = True) -> dict[str, Any]: ...
-
     def set_params(self, **params: Any) -> Self: ...

--- a/scanpy/neighbors/_types.py
+++ b/scanpy/neighbors/_types.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Literal, Protocol
 from typing import Callable as _C
 from typing import Union as _U
 
 import numpy as np
 
 if TYPE_CHECKING:
-    from typing import Self
+    from typing import Any, Self
 
     from scipy.sparse import spmatrix
 

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 from collections import OrderedDict
-from collections.abc import Collection, Iterable, Mapping, Sequence
+from collections.abc import Sequence
 from itertools import product
 from typing import TYPE_CHECKING, Literal, Union
 
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 from matplotlib import gridspec, patheffects, rcParams
 from matplotlib import pyplot as plt
-from matplotlib.colors import Colormap, ListedColormap, Normalize, is_color_like
+from matplotlib.colors import is_color_like
 from packaging.version import Version
 from pandas.api.types import CategoricalDtype, is_numeric_dtype
 from scipy.sparse import issparse
@@ -31,9 +31,6 @@ from ._docs import (
     doc_vboundnorm,
 )
 from ._utils import (
-    ColorLike,
-    _FontSize,
-    _FontWeight,
     check_colornorm,
     scatter_base,
     scatter_group,
@@ -41,11 +38,16 @@ from ._utils import (
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Iterable, Mapping
+
     from anndata import AnnData
     from cycler import Cycler
     from matplotlib.axes import Axes
+    from matplotlib.colors import Colormap, ListedColormap, Normalize
     from seaborn import FacetGrid
     from seaborn.matrix import ClusterGrid
+
+    from ._utils import ColorLike, _FontSize, _FontWeight
 
 VALID_LEGENDLOCS = {
     "none",

--- a/scanpy/plotting/_anndata.py
+++ b/scanpy/plotting/_anndata.py
@@ -4,9 +4,8 @@ from __future__ import annotations
 
 import collections.abc as cabc
 from collections import OrderedDict
-from collections.abc import Sequence
 from itertools import product
-from typing import TYPE_CHECKING, Literal, Union
+from typing import TYPE_CHECKING
 
 import matplotlib as mpl
 import numpy as np
@@ -38,7 +37,8 @@ from ._utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterable, Mapping
+    from collections.abc import Collection, Iterable, Mapping, Sequence
+    from typing import Literal, Union
 
     from anndata import AnnData
     from cycler import Cycler
@@ -48,6 +48,11 @@ if TYPE_CHECKING:
     from seaborn.matrix import ClusterGrid
 
     from ._utils import ColorLike, _FontSize, _FontWeight
+
+    # TODO: is that all?
+    _Basis = Literal["pca", "tsne", "umap", "diffmap", "draw_graph_fr"]
+    _VarNames = Union[str, Sequence[str]]
+
 
 VALID_LEGENDLOCS = {
     "none",
@@ -66,10 +71,6 @@ VALID_LEGENDLOCS = {
     "upper center",
     "center",
 }
-
-# TODO: is that all?
-_Basis = Literal["pca", "tsne", "umap", "diffmap", "draw_graph_fr"]
-_VarNames = Union[str, Sequence[str]]
 
 
 @old_positionals(

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import collections.abc as cabc
 from collections import namedtuple
-from collections.abc import Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Literal, Union
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Union
 from warnings import warn
 
 import numpy as np
@@ -15,12 +15,17 @@ from matplotlib import pyplot as plt
 from .. import logging as logg
 from .._compat import old_positionals
 from ._anndata import _get_dendrogram_key, _plot_dendrogram, _prepare_dataframe
-from ._utils import ColorLike, _AxesSubplot, check_colornorm, make_grid_spec
+from ._utils import check_colornorm, make_grid_spec
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+    from typing import Literal, Self
+
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.colors import Normalize
+
+    from ._utils import ColorLike, _AxesSubplot
 
 _VarNames = Union[str, Sequence[str]]
 
@@ -193,7 +198,7 @@ class BasePlot:
         self.ax_dict = None
         self.ax = ax
 
-    def swap_axes(self, swap_axes: bool | None = True) -> BasePlot:
+    def swap_axes(self, swap_axes: bool | None = True) -> Self:
         """
         Plots a transposed image.
 
@@ -225,7 +230,7 @@ class BasePlot:
         show: bool | None = True,
         dendrogram_key: str | None = None,
         size: float | None = 0.8,
-    ) -> BasePlot:
+    ) -> Self:
         r"""\
         Show dendrogram based on the hierarchical clustering between the `groupby`
         categories. Categories are reordered to match the dendrogram order.
@@ -308,10 +313,10 @@ class BasePlot:
     def add_totals(
         self,
         show: bool | None = True,
-        sort: Literal["ascending", "descending"] = None,
+        sort: Literal["ascending", "descending"] | None = None,
         size: float | None = 0.8,
         color: ColorLike | Sequence[ColorLike] | None = None,
-    ) -> BasePlot:
+    ) -> Self:
         r"""\
         Show barplot for the number of cells in in `groupby` category.
 
@@ -386,7 +391,7 @@ class BasePlot:
         return self
 
     @old_positionals("cmap")
-    def style(self, *, cmap: str | None = DEFAULT_COLORMAP) -> BasePlot:
+    def style(self, *, cmap: str | None = DEFAULT_COLORMAP) -> Self:
         """\
         Set visual style parameters
 
@@ -410,7 +415,7 @@ class BasePlot:
         show: bool | None = True,
         title: str | None = DEFAULT_COLOR_LEGEND_TITLE,
         width: float | None = DEFAULT_LEGENDS_WIDTH,
-    ) -> BasePlot:
+    ) -> Self:
         r"""\
         Configure legend parameters
 

--- a/scanpy/plotting/_baseplot_class.py
+++ b/scanpy/plotting/_baseplot_class.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import collections.abc as cabc
-from collections import namedtuple
-from collections.abc import Sequence
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, NamedTuple
 from warnings import warn
 
 import numpy as np
@@ -18,8 +16,8 @@ from ._anndata import _get_dendrogram_key, _plot_dendrogram, _prepare_dataframe
 from ._utils import check_colornorm, make_grid_spec
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable, Mapping
-    from typing import Literal, Self
+    from collections.abc import Iterable, Mapping, Sequence
+    from typing import Literal, Self, Union
 
     from anndata import AnnData
     from matplotlib.axes import Axes
@@ -27,7 +25,15 @@ if TYPE_CHECKING:
 
     from ._utils import ColorLike, _AxesSubplot
 
-_VarNames = Union[str, Sequence[str]]
+    _VarNames = Union[str, Sequence[str]]
+
+
+class VBoundNorm(NamedTuple):
+    vmin: float | None
+    vmax: float | None
+    vcenter: float | None
+    norm: Normalize | None
+
 
 doc_common_groupby_plot_args = """\
 title
@@ -168,7 +174,6 @@ class BasePlot:
         self.log = log
         self.kwds = kwds
 
-        VBoundNorm = namedtuple("VBoundNorm", ["vmin", "vmax", "vcenter", "norm"])
         self.vboundnorm = VBoundNorm(vmin=vmin, vmax=vmax, vcenter=vcenter, norm=norm)
 
         # set default values for legend

--- a/scanpy/plotting/_docs.py
+++ b/scanpy/plotting/_docs.py
@@ -84,7 +84,7 @@ size
 color_map
     Color map to use for continous variables. Can be a name or a
     :class:`~matplotlib.colors.Colormap` instance (e.g. `"magma`", `"viridis"`
-    or `mpl.cm.cividis`), see :func:`~matplotlib.cm.get_cmap`.
+    or `mpl.cm.cividis`), see :func:`~matplotlib.pyplot.get_cmap`.
     If `None`, the value of `mpl.rcParams["image.cmap"]` is used.
     The default `color_map` can be set using :func:`~scanpy.set_figure_params`.
 palette

--- a/scanpy/plotting/_dotplot.py
+++ b/scanpy/plotting/_dotplot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -9,11 +9,9 @@ from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params
-from ._baseplot_class import BasePlot, _VarNames, doc_common_groupby_plot_args
+from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
 from ._utils import (
-    ColorLike,
-    _AxesSubplot,
     check_colornorm,
     fix_kwds,
     make_grid_spec,
@@ -21,15 +19,19 @@ from ._utils import (
 )
 
 if TYPE_CHECKING:
-    from collections.abc import (
-        Mapping,  # Special
-        Sequence,  # ABCs
-    )
+    from collections.abc import Mapping, Sequence
+    from typing import Literal, Self
 
     import pandas as pd
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.colors import Normalize
+
+    from ._baseplot_class import _VarNames
+    from ._utils import (
+        ColorLike,
+        _AxesSubplot,
+    )
 
 
 @_doc_params(common_plot_args=doc_common_plot_args)
@@ -163,7 +165,7 @@ class DotPlot(BasePlot):
         vcenter: float | None = None,
         norm: Normalize | None = None,
         **kwds,
-    ):
+    ) -> None:
         BasePlot.__init__(
             self,
             adata,
@@ -309,7 +311,7 @@ class DotPlot(BasePlot):
         grid: float | None = False,
         x_padding: float | None = DEFAULT_PLOT_X_PADDING,
         y_padding: float | None = DEFAULT_PLOT_Y_PADDING,
-    ):
+    ) -> Self:
         r"""\
         Modifies plot visual parameters
 
@@ -428,7 +430,7 @@ class DotPlot(BasePlot):
         size_title: str | None = DEFAULT_SIZE_LEGEND_TITLE,
         colorbar_title: str | None = DEFAULT_COLOR_LEGEND_TITLE,
         width: float | None = DEFAULT_LEGENDS_WIDTH,
-    ):
+    ) -> Self:
         """\
         Configures dot size and the colorbar legends
 

--- a/scanpy/plotting/_matrixplot.py
+++ b/scanpy/plotting/_matrixplot.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from matplotlib import pyplot as plt
@@ -10,24 +10,25 @@ from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params
-from ._baseplot_class import BasePlot, _VarNames, doc_common_groupby_plot_args
+from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import (
     doc_common_plot_args,
     doc_show_save_ax,
     doc_vboundnorm,
 )
-from ._utils import ColorLike, _AxesSubplot, check_colornorm, fix_kwds, savefig_or_show
+from ._utils import check_colornorm, fix_kwds, savefig_or_show
 
 if TYPE_CHECKING:
-    from collections.abc import (
-        Mapping,  # Special
-        Sequence,  # ABCs
-    )
+    from collections.abc import Mapping, Sequence
+    from typing import Literal, Self
 
     import pandas as pd
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.colors import Normalize
+
+    from ._baseplot_class import _VarNames
+    from ._utils import ColorLike, _AxesSubplot
 
 
 @_doc_params(common_plot_args=doc_common_plot_args)
@@ -200,7 +201,7 @@ class MatrixPlot(BasePlot):
         cmap: str = DEFAULT_COLORMAP,
         edge_color: ColorLike | None = DEFAULT_EDGE_COLOR,
         edge_lw: float | None = DEFAULT_EDGE_LW,
-    ):
+    ) -> Self:
         """\
         Modifies plot visual parameters.
 

--- a/scanpy/plotting/_scrublet.py
+++ b/scanpy/plotting/_scrublet.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
-from typing import Union as _U
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -12,12 +11,13 @@ from . import _utils
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Literal, Union
 
     from anndata import AnnData
     from matplotlib.axes import Axes
     from matplotlib.figure import Figure
 
-Scale = _U[Literal["linear", "log", "symlog", "logit"], str]
+    Scale = Union[Literal["linear", "log", "symlog", "logit"], str]
 
 
 @old_positionals(

--- a/scanpy/plotting/_stacked_violin.py
+++ b/scanpy/plotting/_stacked_violin.py
@@ -1,22 +1,21 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 from matplotlib import pyplot as plt
-from matplotlib.colors import Normalize, is_color_like
+from matplotlib.colors import is_color_like
 from packaging.version import Version
 
 from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params
-from ._baseplot_class import BasePlot, _VarNames, doc_common_groupby_plot_args
+from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
 from ._utils import (
-    _AxesSubplot,
     _deprecated_scale,
     check_colornorm,
     make_grid_spec,
@@ -28,8 +27,13 @@ if TYPE_CHECKING:
         Mapping,  # Special
         Sequence,  # ABCs
     )
+    from typing import Literal, Self
 
     from anndata import AnnData
+    from matplotlib.colors import Normalize
+
+    from ._baseplot_class import _VarNames
+    from ._utils import _AxesSubplot
 
 
 @_doc_params(common_plot_args=doc_common_plot_args)
@@ -275,7 +279,7 @@ class StackedViolin(BasePlot):
         y_padding: float | None = DEFAULT_PLOT_Y_PADDING,
         # deprecated
         scale: Literal["area", "count", "width"] | None = None,
-    ):
+    ) -> Self:
         r"""\
         Modifies plot visual parameters
 

--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import collections.abc as cabc
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping
 from copy import copy
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -36,6 +36,9 @@ from .._utils import (
 from .scatterplots import _panel_grid, embedding, pca
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+    from typing import Literal
+
     from anndata import AnnData
     from cycler import Cycler
     from matplotlib.axes import Axes

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -4,14 +4,14 @@ import collections.abc as cabc
 import warnings
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
 import scipy
 from matplotlib import patheffects, rcParams, ticker
 from matplotlib import pyplot as plt
-from matplotlib.colors import Colormap, is_color_like
+from matplotlib.colors import is_color_like
 from pandas.api.types import CategoricalDtype
 from scipy.sparse import issparse
 from sklearn.utils import check_random_state
@@ -21,13 +21,17 @@ from ... import logging as logg
 from ..._compat import old_positionals
 from ..._settings import settings
 from .. import _utils
-from .._utils import _FontSize, _FontWeight, _IGraphLayout, matrix
+from .._utils import matrix
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from typing import Any, Literal
 
     from anndata import AnnData
     from matplotlib.axes import Axes
+    from matplotlib.colors import Colormap
+
+    from .._utils import _FontSize, _FontWeight, _IGraphLayout
 
 
 @old_positionals(

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -8,7 +8,11 @@ from copy import copy
 from functools import partial
 from itertools import combinations, product
 from numbers import Integral
-from typing import TYPE_CHECKING
+from typing import (
+    TYPE_CHECKING,
+    Any,  # noqa: TCH003
+    Literal,  # noqa: TCH003
+)
 
 import numpy as np
 import pandas as pd
@@ -17,14 +21,22 @@ from cycler import Cycler  # noqa: TCH002
 from matplotlib import colormaps, colors, patheffects, rcParams
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes  # noqa: TCH002
-from matplotlib.colors import Normalize
+from matplotlib.colors import (
+    Colormap,  # noqa: TCH002
+    Normalize,
+)
 from matplotlib.figure import Figure  # noqa: TCH002
 from numpy.typing import NDArray  # noqa: TCH002
 from packaging.version import Version
 
 from ... import logging as logg
 from ..._settings import settings
-from ..._utils import _doc_params, _empty, sanitize_anndata
+from ..._utils import (
+    Empty,  # noqa: TCH001
+    _doc_params,
+    _empty,
+    sanitize_anndata,
+)
 from ...get import _check_mask
 from .. import _utils
 from .._docs import (
@@ -34,22 +46,19 @@ from .._docs import (
     doc_scatter_spatial,
     doc_show_save_ax,
 )
-from .._utils import check_colornorm, check_projection, circles
+from .._utils import (
+    ColorLike,  # noqa: TCH001
+    VBound,  # noqa: TCH001
+    _FontSize,  # noqa: TCH001
+    _FontWeight,  # noqa: TCH001
+    _IGraphLayout,  # noqa: TCH001
+    check_colornorm,
+    check_projection,
+    circles,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Collection
-    from typing import Any, Literal
-
-    from matplotlib.colors import Colormap
-
-    from ..._utils import Empty
-    from .._utils import (
-        ColorLike,
-        VBound,
-        _FontSize,
-        _FontWeight,
-        _IGraphLayout,
-    )
 
 
 @_doc_params(

--- a/scanpy/plotting/_tools/scatterplots.py
+++ b/scanpy/plotting/_tools/scatterplots.py
@@ -8,7 +8,7 @@ from copy import copy
 from functools import partial
 from itertools import combinations, product
 from numbers import Integral
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -17,14 +17,14 @@ from cycler import Cycler  # noqa: TCH002
 from matplotlib import colormaps, colors, patheffects, rcParams
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes  # noqa: TCH002
-from matplotlib.colors import Colormap, Normalize
+from matplotlib.colors import Normalize
 from matplotlib.figure import Figure  # noqa: TCH002
 from numpy.typing import NDArray  # noqa: TCH002
 from packaging.version import Version
 
 from ... import logging as logg
 from ..._settings import settings
-from ..._utils import Empty, _doc_params, _empty, sanitize_anndata
+from ..._utils import _doc_params, _empty, sanitize_anndata
 from ...get import _check_mask
 from .. import _utils
 from .._docs import (
@@ -34,19 +34,22 @@ from .._docs import (
     doc_scatter_spatial,
     doc_show_save_ax,
 )
-from .._utils import (
-    ColorLike,
-    VBound,
-    _FontSize,
-    _FontWeight,
-    _IGraphLayout,
-    check_colornorm,
-    check_projection,
-    circles,
-)
+from .._utils import check_colornorm, check_projection, circles
 
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from typing import Any, Literal
+
+    from matplotlib.colors import Colormap
+
+    from ..._utils import Empty
+    from .._utils import (
+        ColorLike,
+        VBound,
+        _FontSize,
+        _FontWeight,
+        _IGraphLayout,
+    )
 
 
 @_doc_params(

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable, Literal
-from typing import Union as _U
+from typing import TYPE_CHECKING, Callable, Literal, Union
 
 import matplotlib as mpl
 import numpy as np
@@ -33,13 +32,17 @@ if TYPE_CHECKING:
     from numpy.typing import ArrayLike
     from PIL.Image import Image
 
-ColorLike = _U[str, tuple[float, ...]]
-_IGraphLayout = Literal["fa", "fr", "rt", "rt_circular", "drl", "eq_tree", ...]
+    # TODO: more
+    DensityNorm = Literal["area", "count", "width"]
+
+# These are needed by _wraps_plot_scatter
+_IGraphLayout = Literal["fa", "fr", "rt", "rt_circular", "drl", "eq_tree"]
+VBound = Union[str, float, Callable[[Sequence[float]], float]]
 _FontWeight = Literal["light", "normal", "medium", "semibold", "bold", "heavy", "black"]
 _FontSize = Literal[
     "xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large"
 ]
-VBound = _U[str, float, Callable[[Sequence[float]], float]]
+ColorLike = Union[str, tuple[float, ...]]
 
 
 class _AxesSubplot(Axes, axes.SubplotBase):
@@ -1273,10 +1276,9 @@ def check_colornorm(vmin=None, vmax=None, vcenter=None, norm=None):
     return norm
 
 
-DN = Literal["area", "count", "width"]
-
-
-def _deprecated_scale(density_norm: DN, scale: DN | None, *, default: DN) -> DN:
+def _deprecated_scale(
+    density_norm: DensityNorm, scale: DensityNorm | None, *, default: DensityNorm
+) -> DensityNorm:
     if scale is None:
         return density_norm
     if density_norm != default:

--- a/scanpy/plotting/_utils.py
+++ b/scanpy/plotting/_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import collections.abc as cabc
 import warnings
-from collections.abc import Collection, Sequence
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, Callable, Literal
 from typing import Union as _U
 
@@ -13,8 +13,7 @@ from matplotlib import axes, gridspec, rcParams, ticker
 from matplotlib import pyplot as plt
 from matplotlib.axes import Axes
 from matplotlib.collections import PatchCollection
-from matplotlib.colors import Colormap, is_color_like
-from matplotlib.figure import Figure
+from matplotlib.colors import is_color_like
 from matplotlib.figure import SubplotParams as sppars
 from matplotlib.patches import Circle
 
@@ -25,7 +24,11 @@ from .._utils import NeighborsView
 from . import palettes
 
 if TYPE_CHECKING:
+    from collections.abc import Collection
+
     from anndata import AnnData
+    from matplotlib.colors import Colormap
+    from matplotlib.figure import Figure
     from matplotlib.typing import MarkerType
     from numpy.typing import ArrayLike
     from PIL.Image import Image

--- a/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -13,6 +13,8 @@ from .._distributed import materialize_as_ndarray
 from .._utils import _get_mean_var
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from scipy.sparse import spmatrix
 
 

--- a/scanpy/preprocessing/_distributed.py
+++ b/scanpy/preprocessing/_distributed.py
@@ -4,10 +4,12 @@ from typing import TYPE_CHECKING, overload
 
 import numpy as np
 
-from scanpy._compat import DaskArray, ZappyArray
+from scanpy._compat import DaskArray
 
 if TYPE_CHECKING:
     from numpy.typing import ArrayLike
+
+    from scanpy._compat import ZappyArray
 
 
 @overload

--- a/scanpy/preprocessing/_highly_variable_genes.py
+++ b/scanpy/preprocessing/_highly_variable_genes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import warnings
 from dataclasses import dataclass
 from inspect import signature
-from typing import TYPE_CHECKING, Literal, cast
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -20,6 +20,8 @@ from ._simple import filter_genes
 from ._utils import _get_mean_var
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import NDArray
 
 

--- a/scanpy/preprocessing/_normalization.py
+++ b/scanpy/preprocessing/_normalization.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from operator import truediv
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 from warnings import warn
 
 import numpy as np
@@ -21,6 +21,7 @@ except ImportError:
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Literal
 
     from anndata import AnnData
 

--- a/scanpy/preprocessing/_pca.py
+++ b/scanpy/preprocessing/_pca.py
@@ -8,7 +8,7 @@ import anndata as ad
 import numpy as np
 from anndata import AnnData
 from packaging.version import Version
-from scipy.sparse import issparse, spmatrix
+from scipy.sparse import issparse
 from scipy.sparse.linalg import LinearOperator, svds
 from sklearn.utils import check_array, check_random_state
 from sklearn.utils.extmath import svd_flip
@@ -16,13 +16,16 @@ from sklearn.utils.extmath import svd_flip
 from .. import logging as logg
 from .._compat import DaskArray, pkg_version
 from .._settings import settings
-from .._utils import AnyRandom, Empty, _doc_params, _empty
+from .._utils import _doc_params, _empty
 from ..get import _check_mask, _get_obs_rep
 from ._docs import doc_mask_var_hvg
 from ._utils import _get_mean_var
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike, NDArray
+    from scipy.sparse import spmatrix
+
+    from .._utils import AnyRandom, Empty
 
 
 @_doc_params(

--- a/scanpy/preprocessing/_qc.py
+++ b/scanpy/preprocessing/_qc.py
@@ -6,7 +6,7 @@ from warnings import warn
 import numba
 import numpy as np
 import pandas as pd
-from scipy.sparse import csr_matrix, issparse, isspmatrix_coo, isspmatrix_csr, spmatrix
+from scipy.sparse import csr_matrix, issparse, isspmatrix_coo, isspmatrix_csr
 from sklearn.utils.sparsefuncs import mean_variance_axis
 
 from .._utils import _doc_params
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Collection
 
     from anndata import AnnData
+    from scipy.sparse import spmatrix
 
 
 def _choose_mtx_rep(adata, use_raw: bool = False, layer: str | None = None):

--- a/scanpy/preprocessing/_scrublet/core.py
+++ b/scanpy/preprocessing/_scrublet/core.py
@@ -10,12 +10,10 @@ from anndata import AnnData, concat
 from scipy import sparse
 
 from ... import logging as logg
-from ..._utils import AnyRandom, get_random_state
+from ..._utils import get_random_state
 from ...neighbors import (
     Neighbors,
     _get_indices_distances_from_sparse_matrix,
-    _Metric,
-    _MetricFn,
 )
 from .._utils import sample_comb
 from .sparse_utils import subsample_counts
@@ -23,6 +21,9 @@ from .sparse_utils import subsample_counts
 if TYPE_CHECKING:
     from numpy.random import RandomState
     from numpy.typing import NDArray
+
+    from ..._utils import AnyRandom
+    from ...neighbors import _Metric, _MetricFn
 
 __all__ = ["Scrublet"]
 

--- a/scanpy/preprocessing/_scrublet/pipeline.py
+++ b/scanpy/preprocessing/_scrublet/pipeline.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from scipy import sparse
@@ -10,6 +10,8 @@ from scanpy.preprocessing._utils import _get_mean_var
 from .sparse_utils import sparse_multiply, sparse_zscore
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from ..._utils import AnyRandom
     from .core import Scrublet
 

--- a/scanpy/preprocessing/_scrublet/sparse_utils.py
+++ b/scanpy/preprocessing/_scrublet/sparse_utils.py
@@ -7,10 +7,12 @@ from scipy import sparse
 
 from scanpy.preprocessing._utils import _get_mean_var
 
-from ..._utils import AnyRandom, get_random_state
+from ..._utils import get_random_state
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
+
+    from ..._utils import AnyRandom
 
 
 def sparse_multiply(

--- a/scanpy/preprocessing/_simple.py
+++ b/scanpy/preprocessing/_simple.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import warnings
 from functools import singledispatch
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
@@ -18,10 +18,9 @@ from scipy.sparse import csr_matrix, issparse, isspmatrix_csr, spmatrix
 from sklearn.utils import check_array, sparsefuncs
 
 from .. import logging as logg
-from .._compat import DaskArray, old_positionals
+from .._compat import old_positionals
 from .._settings import settings as sett
 from .._utils import (
-    AnyRandom,
     _check_array_function_arguments,
     axis_sum,
     renamed_arg,
@@ -43,8 +42,12 @@ from ._deprecated.highly_variable_genes import filter_genes_dispersion  # noqa: 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable, Sequence
     from numbers import Number
+    from typing import Literal
 
     from numpy.typing import NDArray
+
+    from .._compat import DaskArray
+    from .._utils import AnyRandom
 
 
 @old_positionals(

--- a/scanpy/preprocessing/_utils.py
+++ b/scanpy/preprocessing/_utils.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
 from functools import singledispatch
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
 from scipy import sparse
 from sklearn.random_projection import sample_without_replacement
 
-from .._utils import AnyRandom, _SupportedArray, axis_sum, elem_mul
+from .._utils import axis_sum, elem_mul
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from numpy.typing import DTypeLike, NDArray
 
     from .._compat import DaskArray
+    from .._utils import AnyRandom, _SupportedArray
 
 
 @singledispatch

--- a/scanpy/queries/_queries.py
+++ b/scanpy/queries/_queries.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 from functools import singledispatch
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from anndata import AnnData
 
@@ -13,6 +13,7 @@ from ..get import rank_genes_groups_df
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
+    from typing import Any
 
     import pandas as pd
 

--- a/scanpy/readwrite.py
+++ b/scanpy/readwrite.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path, PurePath
-from typing import BinaryIO, Literal
+from typing import TYPE_CHECKING
 
 import anndata.utils
 import h5py
@@ -25,7 +25,12 @@ from matplotlib.image import imread
 from . import logging as logg
 from ._compat import old_positionals
 from ._settings import settings
-from ._utils import Empty, _empty
+from ._utils import _empty
+
+if TYPE_CHECKING:
+    from typing import BinaryIO, Literal
+
+    from ._utils import Empty
 
 # .gz and .bz2 suffixes are also allowed for text formats
 text_exts = {

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from pathlib import Path
 from string import ascii_letters
-from typing import Callable, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -16,6 +16,9 @@ from testing.scanpy._helpers import _check_check_values_warnings
 from testing.scanpy._helpers.data import pbmc3k, pbmc68k_reduced
 from testing.scanpy._pytest.marks import needs
 from testing.scanpy._pytest.params import ARRAY_TYPES
+
+if TYPE_CHECKING:
+    from typing import Callable, Literal
 
 FILE = Path(__file__).parent / Path("_scripts/seurat_hvg.csv")
 FILE_V3 = Path(__file__).parent / Path("_scripts/seurat_hvg_v3.csv.gz")

--- a/scanpy/tests/test_neighbors.py
+++ b/scanpy/tests/test_neighbors.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -14,6 +14,8 @@ from scanpy import Neighbors
 from testing.scanpy._helpers import anndata_v0_8_constructor_compat
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from pytest_mock import MockerFixture
 
 # the input data

--- a/scanpy/tests/test_neighbors_common.py
+++ b/scanpy/tests/test_neighbors_common.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -15,6 +15,7 @@ from scanpy.neighbors._common import (
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Literal
 
     from scipy import sparse
 

--- a/scanpy/tests/test_normalization.py
+++ b/scanpy/tests/test_normalization.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -22,6 +22,7 @@ from testing.scanpy._pytest.params import ARRAY_TYPES
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any
 
 X_total = np.array([[1, 0], [3, 0], [5, 6]])
 X_frac = np.array([[1, 0, 1], [3, 0, 1], [5, 6, 1]])

--- a/scanpy/tests/test_package_structure.py
+++ b/scanpy/tests/test_package_structure.py
@@ -4,7 +4,7 @@ import os
 from collections import defaultdict
 from inspect import Parameter, signature
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 import pytest
 from anndata import AnnData
@@ -15,6 +15,7 @@ from scanpy._utils import _import_name, descend_classes_and_funcs
 
 if TYPE_CHECKING:
     from types import FunctionType
+    from typing import Any
 
 mod_dir = Path(scanpy.__file__).parent
 proj_dir = mod_dir.parent

--- a/scanpy/tests/test_pca.py
+++ b/scanpy/tests/test_pca.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import Literal
+from typing import TYPE_CHECKING
 
 import anndata as ad
 import numpy as np
@@ -24,6 +24,9 @@ from testing.scanpy._pytest.params import (
     ARRAY_TYPES_SPARSE_DASK_UNSUPPORTED,
     param_with,
 )
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 A_list = np.array(
     [

--- a/scanpy/tests/test_preprocessing_distributed.py
+++ b/scanpy/tests/test_preprocessing_distributed.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy.testing as npt
 import pytest
-from anndata import AnnData, read_zarr
+from anndata import read_zarr
 
 from scanpy._compat import DaskArray, ZappyArray
 from scanpy.datasets._utils import filter_oldformatwarning
@@ -17,6 +18,9 @@ from scanpy.preprocessing import (
 )
 from scanpy.preprocessing._distributed import materialize_as_ndarray
 from testing.scanpy._pytest.marks import needs
+
+if TYPE_CHECKING:
+    from anndata import AnnData
 
 HERE = Path(__file__).parent / Path("_data/")
 input_file = Path(HERE, "10x-10k-subset.zarr")

--- a/scanpy/tests/test_rank_genes_groups.py
+++ b/scanpy/tests/test_rank_genes_groups.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import pickle
 from functools import partial
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -24,6 +24,7 @@ from testing.scanpy._pytest.params import ARRAY_TYPES, ARRAY_TYPES_MEM
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any
 
     from numpy.typing import NDArray
 

--- a/scanpy/tests/test_scrublet.py
+++ b/scanpy/tests/test_scrublet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -15,6 +15,7 @@ from testing.scanpy._pytest.marks import needs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Any
 
 pytestmark = [needs.skimage]
 

--- a/scanpy/tools/__init__.py
+++ b/scanpy/tools/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING
 
 from ._dendrogram import dendrogram
 from ._diffmap import diffmap
@@ -25,6 +25,9 @@ from ._score_genes import score_genes, score_genes_cell_cycle
 from ._sim import sim
 from ._tsne import tsne
 from ._umap import umap
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
 def __getattr__(name: str) -> Any:

--- a/scanpy/tools/_dendrogram.py
+++ b/scanpy/tools/_dendrogram.py
@@ -4,7 +4,7 @@ Computes a dendrogram based on a given categorical observation.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from pandas.api.types import CategoricalDtype
@@ -17,6 +17,7 @@ from ._utils import _choose_representation
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Any
 
     from anndata import AnnData
 

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import random
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, get_args
 
 import numpy as np
 
@@ -17,8 +17,8 @@ if TYPE_CHECKING:
 
     from .._utils import AnyRandom
 
-_LAYOUTS = ("fr", "drl", "kk", "grid_fr", "lgl", "rt", "rt_circular", "fa")
-_Layout = Literal[_LAYOUTS]
+_Layout = Literal["fr", "drl", "kk", "grid_fr", "lgl", "rt", "rt_circular", "fa"]
+_LAYOUTS = get_args(_Layout)
 
 
 @old_positionals(

--- a/scanpy/tools/_draw_graph.py
+++ b/scanpy/tools/_draw_graph.py
@@ -8,12 +8,14 @@ import numpy as np
 from .. import _utils
 from .. import logging as logg
 from .._compat import old_positionals
-from .._utils import AnyRandom, _choose_graph
+from .._utils import _choose_graph
 from ._utils import get_init_pos_from_paga
 
 if TYPE_CHECKING:
     from anndata import AnnData
     from scipy.sparse import spmatrix
+
+    from .._utils import AnyRandom
 
 _LAYOUTS = ("fr", "drl", "kk", "grid_fr", "lgl", "rt", "rt_circular", "fa")
 _Layout = Literal[_LAYOUTS]

--- a/scanpy/tools/_ingest.py
+++ b/scanpy/tools/_ingest.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable, MutableMapping
+from collections.abc import MutableMapping
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -14,10 +14,14 @@ from .._compat import old_positionals, pkg_version
 from .._settings import settings
 from .._utils import NeighborsView
 from .._utils._doctests import doctest_skip
-from ..neighbors import FlatTree, RPForestDict
+from ..neighbors import FlatTree
 
 if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+
     from anndata import AnnData
+
+    from ..neighbors import RPForestDict
 
 ANNDATA_MIN_VERSION = Version("0.7rc1")
 

--- a/scanpy/tools/_leiden.py
+++ b/scanpy/tools/_leiden.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -12,6 +12,7 @@ from ._utils_clustering import rename_groups, restrict_adjacency
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Literal
 
     from anndata import AnnData
     from scipy import sparse

--- a/scanpy/tools/_louvain.py
+++ b/scanpy/tools/_louvain.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -17,6 +17,7 @@ from ._utils_clustering import rename_groups, restrict_adjacency
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
+    from typing import Any, Literal
 
     from anndata import AnnData
     from scipy.sparse import spmatrix

--- a/scanpy/tools/_marker_gene_overlap.py
+++ b/scanpy/tools/_marker_gene_overlap.py
@@ -5,7 +5,7 @@ Calculate overlaps of rank_genes_groups marker genes with marker gene dictionari
 from __future__ import annotations
 
 import collections.abc as cabc
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
@@ -14,7 +14,11 @@ from .. import logging as logg
 from .._utils._doctests import doctest_needs
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
+
+    _Method = Literal["overlap_count", "overlap_coef", "jaccard"]
 
 
 def _calc_overlap_count(markers1: dict, markers2: dict):
@@ -71,9 +75,6 @@ def _calc_jaccard(markers1: dict, markers2: dict):
         jacc_results[j, :] = tmp
 
     return jacc_results
-
-
-_Method = Literal["overlap_count", "overlap_coef", "jaccard"]
 
 
 @doctest_needs("leidenalg")

--- a/scanpy/tools/_paga.py
+++ b/scanpy/tools/_paga.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple
 
 import numpy as np
 import scipy as sp
@@ -12,6 +12,8 @@ from .._compat import old_positionals
 from ..neighbors import Neighbors
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
 
 _AVAIL_MODELS = {"v1.0", "v1.2"}

--- a/scanpy/tools/_rank_genes_groups.py
+++ b/scanpy/tools/_rank_genes_groups.py
@@ -23,8 +23,10 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from scipy import sparse
 
+    _CorrMethod = Literal["benjamini-hochberg", "bonferroni"]
+
+# Used with get_args
 _Method = Literal["logreg", "t-test", "wilcoxon", "t-test_overestim_var"]
-_CorrMethod = Literal["benjamini-hochberg", "bonferroni"]
 
 
 def _select_top_n(scores: NDArray, n_top: int):

--- a/scanpy/tools/_sim.py
+++ b/scanpy/tools/_sim.py
@@ -16,7 +16,7 @@ import shutil
 import sys
 from pathlib import Path
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 import scipy as sp
@@ -28,6 +28,7 @@ from .._settings import settings
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
+    from typing import Literal
 
     from anndata import AnnData
 

--- a/scanpy/tools/_top_genes.py
+++ b/scanpy/tools/_top_genes.py
@@ -6,7 +6,7 @@ This modules provides all non-visualization tools for advanced gene ranking and 
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import pandas as pd
 from scipy.sparse import issparse
@@ -18,6 +18,7 @@ from .._utils import select_groups
 
 if TYPE_CHECKING:
     from collections.abc import Collection
+    from typing import Literal
 
     from anndata import AnnData
 

--- a/scanpy/tools/_tsne.py
+++ b/scanpy/tools/_tsne.py
@@ -8,12 +8,14 @@ from packaging.version import Version
 from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
-from .._utils import AnyRandom, _doc_params
+from .._utils import _doc_params
 from ..neighbors._doc import doc_n_pcs, doc_use_rep
 from ._utils import _choose_representation
 
 if TYPE_CHECKING:
     from anndata import AnnData
+
+    from .._utils import AnyRandom
 
 
 @old_positionals(

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -9,11 +9,13 @@ from sklearn.utils import check_array, check_random_state
 from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
-from .._utils import AnyRandom, NeighborsView
+from .._utils import NeighborsView
 from ._utils import _choose_representation, get_init_pos_from_paga
 
 if TYPE_CHECKING:
     from anndata import AnnData
+
+    from .._utils import AnyRandom
 
 _InitPos = Literal["paga", "spectral", "random"]
 

--- a/scanpy/tools/_umap.py
+++ b/scanpy/tools/_umap.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import warnings
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import numpy as np
 from sklearn.utils import check_array, check_random_state
@@ -13,11 +13,13 @@ from .._utils import NeighborsView
 from ._utils import _choose_representation, get_init_pos_from_paga
 
 if TYPE_CHECKING:
+    from typing import Literal
+
     from anndata import AnnData
 
     from .._utils import AnyRandom
 
-_InitPos = Literal["paga", "spectral", "random"]
+    _InitPos = Literal["paga", "spectral", "random"]
 
 
 @old_positionals(

--- a/src/testing/scanpy/_pytest/params.py
+++ b/src/testing/scanpy/_pytest/params.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import pytest
 from anndata.tests.helpers import asarray
@@ -16,6 +16,7 @@ from .._pytest.marks import needs
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+    from typing import Literal
 
     from _pytest.mark.structures import ParameterSet
 


### PR DESCRIPTION
this allows us to just import stuff from `typing` instead of `typing-extensions`, so we can use `Self` and friends