### PR TITLE
Add `str` as a valid option for the `save` argument in `scanpy.pl.rank_genes_groups`

### DIFF
--- a/scanpy/plotting/_tools/__init__.py
+++ b/scanpy/plotting/_tools/__init__.py
@@ -329,7 +329,7 @@ def rank_genes_groups(
     ncols: int = 4,
     sharey: bool = True,
     show: bool | None = None,
-    save: bool | None = None,
+    save: bool | str | None = None,
     ax: Axes | None = None,
     **kwds,
 ):


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

This is a very small pull request to add `str` to the possible arguments for saving a figure from [`scanpy.pl.rank_genes_groups`][rank-genes-groups]. This addition matches other `save=` arguments, such as from [`scanpy.plotting.highly_variable_genes`][highly-variable-genes], [`sc.plotting.pca_variance_ratio`][pca-variance-ratio], and [`scanpy.plotting.umap`][umap]

[rank-genes-groups]: https://github.com/scverse/scanpy/blob/main/scanpy/plotting/_tools/__init__.py
[highly-variable-genes]: https://github.com/scverse/scanpy/blob/main/scanpy/plotting/_preprocessing.py
[pca-variance-ratio]: https://github.com/scverse/scanpy/blob/main/scanpy/plotting/_tools/__init__.py
[umap]: https://github.com/scverse/scanpy/blob/main/scanpy/plotting/_tools/scatterplots.py

I have not included tests or release notes due to the single-line change nature of this pull request