### PR TITLE
(fix): write out full PCA results when not run before neighbors

### DIFF
--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -17,6 +17,7 @@
 
 * Compatibility with `matplotlib` 3.9 {pr}`2999` {smaller}`I Virshup`
 * Add clear errors where `backed` mode-like matrices (i.e., from `sparse_dataset`) are not supported {pr}`3048` {smaller}`I gold`
+* Write out full pca results when `_choose_representation` is called i.e., `~sc.pp.neighbors` without `sc.pp.pca` {pr}`3078` {smaller}`I gold`
 
 ```{rubric} Performance
 ```

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -32,6 +32,12 @@ def test_neighbors_key_added(adata):
     )
 
 
+def test_neighbors_pca_keys_added(adata):
+    assert "pca" not in adata.uns
+    sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0)
+    assert "pca" in adata.uns
+
+
 # test functions with neighbors_key and obsp
 @needs.igraph
 @needs.leidenalg

--- a/scanpy/tests/test_neighbors_key_added.py
+++ b/scanpy/tests/test_neighbors_key_added.py
@@ -32,9 +32,13 @@ def test_neighbors_key_added(adata):
     )
 
 
-def test_neighbors_pca_keys_added(adata):
-    assert "pca" not in adata.uns
-    sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0)
+def test_neighbors_pca_keys_added_without_previous_pca_run(adata):
+    assert "pca" not in adata.uns and "X_pca" not in adata.obsm
+    with pytest.warns(
+        UserWarning,
+        match=r".*Falling back to preprocessing with `sc.pp.pca` and default params",
+    ):
+        sc.pp.neighbors(adata, n_neighbors=n_neighbors, random_state=0)
     assert "pca" in adata.uns
 
 

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -43,8 +43,8 @@ def _choose_representation(
                     "Falling back to preprocessing with `sc.pp.pca` and default params."
                 )
                 n_pcs_pca = n_pcs if n_pcs is not None else settings.N_PCS
-                X = pca(adata.X, n_comps=n_pcs_pca)
-                adata.obsm["X_pca"] = X
+                pca(adata, n_comps=n_pcs_pca)
+                X = adata.obsm["X_pca"]
         else:
             logg.info("    using data matrix X directly")
             X = adata.X

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -39,11 +39,9 @@ def _choose_representation(
                 logg.info(f"    using 'X_pca' with n_pcs = {X.shape[1]}")
             else:
                 warnings.warn(
-                    UserWarning(
-                        f"You’re trying to run this on {adata.n_vars} dimensions of `.X`, "
-                        "if you really want this, set `use_rep='X'`.\n         "
-                        "Falling back to preprocessing with `sc.pp.pca` and default params."
-                    )
+                    f"You’re trying to run this on {adata.n_vars} dimensions of `.X`, "
+                    "if you really want this, set `use_rep='X'`.\n         "
+                    "Falling back to preprocessing with `sc.pp.pca` and default params."
                 )
                 n_pcs_pca = n_pcs if n_pcs is not None else settings.N_PCS
                 pca(adata, n_comps=n_pcs_pca)

--- a/scanpy/tools/_utils.py
+++ b/scanpy/tools/_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -37,10 +38,12 @@ def _choose_representation(
                 X = adata.obsm["X_pca"][:, :n_pcs]
                 logg.info(f"    using 'X_pca' with n_pcs = {X.shape[1]}")
             else:
-                logg.warning(
-                    f"You’re trying to run this on {adata.n_vars} dimensions of `.X`, "
-                    "if you really want this, set `use_rep='X'`.\n         "
-                    "Falling back to preprocessing with `sc.pp.pca` and default params."
+                warnings.warn(
+                    UserWarning(
+                        f"You’re trying to run this on {adata.n_vars} dimensions of `.X`, "
+                        "if you really want this, set `use_rep='X'`.\n         "
+                        "Falling back to preprocessing with `sc.pp.pca` and default params."
+                    )
                 )
                 n_pcs_pca = n_pcs if n_pcs is not None else settings.N_PCS
                 pca(adata, n_comps=n_pcs_pca)


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
I think this is a better fix since we were already writing out `X_pca`.   The tests seem to pass and `pca` should be idempotent so this really shouldn't break anything (hopefully).
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3074 
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because:
