### PR TITLE
fix `.A` removal

### DIFF
--- a/.azure-pipelines.yml
+++ b/.azure-pipelines.yml
@@ -72,9 +72,6 @@ jobs:
     displayName: 'Install dependencies minimum version'
     condition: eq(variables['DEPENDENCIES_VERSION'], 'minimum-version')
 
-  - script: uv pip list
-    displayName: 'Display installed versions'
-
   - script: pytest
     displayName: 'PyTest'
     condition: eq(variables['TEST_TYPE'], 'standard')

--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -17,6 +17,7 @@
 
 * Compatibility with `matplotlib` 3.9 {pr}`2999` {smaller}`I Virshup`
 * Add clear errors where `backed` mode-like matrices (i.e., from `sparse_dataset`) are not supported {pr}`3048` {smaller}`I gold`
+* Fix deprecated use of `.A` with sparse matrices {pr}`3084` {smaller}`P Angerer`
 
 ```{rubric} Performance
 ```

--- a/scanpy/_utils/__init__.py
+++ b/scanpy/_utils/__init__.py
@@ -580,34 +580,14 @@ def check_op(op):
 
 @singledispatch
 def axis_mul_or_truediv(
-    X: np.ndarray,
-    scaling_array: np.ndarray,
+    X: sparse.spmatrix,
+    scaling_array,
     axis: Literal[0, 1],
     op: Callable[[Any, Any], Any],
     *,
     allow_divide_by_zero: bool = True,
-    out: np.ndarray | None = None,
-) -> np.ndarray:
-    check_op(op)
-    scaling_array = broadcast_axis(scaling_array, axis)
-    if op is mul:
-        return np.multiply(X, scaling_array, out=out)
-    if not allow_divide_by_zero:
-        scaling_array = scaling_array.copy() + (scaling_array == 0)
-    return np.true_divide(X, scaling_array, out=out)
-
-
-@axis_mul_or_truediv.register(sparse.csr_matrix)
-@axis_mul_or_truediv.register(sparse.csc_matrix)
-def _(
-    X: sparse.csr_matrix | sparse.csc_matrix,
-    scaling_array: np.ndarray,
-    axis: Literal[0, 1],
-    op: Callable[[Any, Any], Any],
-    *,
-    allow_divide_by_zero: bool = True,
-    out: sparse.csr_matrix | sparse.csc_matrix | None = None,
-) -> sparse.csr_matrix | sparse.csc_matrix:
+    out: sparse.spmatrix | None = None,
+) -> sparse.spmatrix:
     check_op(op)
     if out is not None:
         if X.data is not out.data:
@@ -621,12 +601,12 @@ def _(
     column_scale = axis == 1
     if row_scale:
 
-        def new_data_op(x: sparse.csr_matrix | sparse.csc_matrix):
+        def new_data_op(x):
             return op(x.data, np.repeat(scaling_array, np.diff(x.indptr)))
 
     elif column_scale:
 
-        def new_data_op(x: sparse.csr_matrix | sparse.csc_matrix):
+        def new_data_op(x):
             return op(x.data, scaling_array.take(x.indices, mode="clip"))
 
     if X.format == "csr":
@@ -647,6 +627,25 @@ def _(
         out=transposed,
         allow_divide_by_zero=allow_divide_by_zero,
     ).T
+
+
+@axis_mul_or_truediv.register(np.ndarray)
+def _(
+    X: np.ndarray,
+    scaling_array: np.ndarray,
+    axis: Literal[0, 1],
+    op: Callable[[Any, Any], Any],
+    *,
+    allow_divide_by_zero: bool = True,
+    out: np.ndarray | None = None,
+) -> np.ndarray:
+    check_op(op)
+    scaling_array = broadcast_axis(scaling_array, axis)
+    if op is mul:
+        return np.multiply(X, scaling_array, out=out)
+    if not allow_divide_by_zero:
+        scaling_array = scaling_array.copy() + (scaling_array == 0)
+    return np.true_divide(X, scaling_array, out=out)
 
 
 def make_axis_chunks(

--- a/scanpy/external/exporting.py
+++ b/scanpy/external/exporting.py
@@ -285,7 +285,7 @@ def write_hdf5_genes(E, gene_list, filename):
     hf.attrs["ngenes"] = E.shape[1]
 
     for iG, g in enumerate(gene_list):
-        counts = E[:, iG].A.squeeze()
+        counts = E[:, iG].toarray().squeeze()
         cell_ix = np.nonzero(counts)[0]
         counts = counts[cell_ix]
         counts_group.create_dataset(g, data=counts)
@@ -307,7 +307,7 @@ def write_hdf5_cells(E, filename):
     hf.attrs["ngenes"] = E.shape[1]
 
     for iC in range(E.shape[0]):
-        counts = E[iC, :].A.squeeze()
+        counts = E[iC, :].toarray().squeeze()
         gene_ix = np.nonzero(counts)[0]
         counts = counts[gene_ix]
         counts_group.create_dataset(str(iC), data=counts)

--- a/scanpy/plotting/_qc.py
+++ b/scanpy/plotting/_qc.py
@@ -78,7 +78,7 @@ def highest_expr_genes(
     if issparse(norm_dict["X"]):
         mean_percent = norm_dict["X"].mean(axis=0).A1
         top_idx = np.argsort(mean_percent)[::-1][:n_top]
-        counts_top_genes = norm_dict["X"][:, top_idx].A
+        counts_top_genes = norm_dict["X"][:, top_idx].toarray()
     else:
         mean_percent = norm_dict["X"].mean(axis=0)
         top_idx = np.argsort(mean_percent)[::-1][:n_top]

--- a/scanpy/plotting/_tools/paga.py
+++ b/scanpy/plotting/_tools/paga.py
@@ -1224,7 +1224,7 @@ def paga_path(
             values = (
                 adata.obs[key].values if key in adata.obs_keys() else adata_X[:, key].X
             )[idcs]
-            x += (values.A if issparse(values) else values).tolist()
+            x += (values.toarray() if issparse(values) else values).tolist()
             if ikey == 0:
                 groups += [group] * len(idcs)
                 x_tick_locs.append(len(x))

--- a/scanpy/preprocessing/_combat.py
+++ b/scanpy/preprocessing/_combat.py
@@ -197,7 +197,7 @@ def combat(
 
     # only works on dense matrices so far
     if issparse(adata.X):
-        X = adata.X.A.T
+        X = adata.X.toarray().T
     else:
         X = adata.X.T
     data = pd.DataFrame(data=X, index=adata.var_names, columns=adata.obs_names)

--- a/scanpy/preprocessing/_pca.py
+++ b/scanpy/preprocessing/_pca.py
@@ -415,7 +415,7 @@ def _pca_with_sparse(
     X = check_array(X, accept_sparse=["csr", "csc"])
 
     if mu is None:
-        mu = X.mean(0).A.flatten()[None, :]
+        mu = np.asarray(X.mean(0)).flatten()[None, :]
     mdot = mu.dot
     mmat = mdot
     mhdot = mu.T.dot

--- a/scanpy/preprocessing/_scrublet/core.py
+++ b/scanpy/preprocessing/_scrublet/core.py
@@ -185,7 +185,7 @@ class Scrublet:
     ) -> None:
         self._counts_obs = sparse.csc_matrix(counts_obs)
         self._total_counts_obs = (
-            self._counts_obs.sum(1).A.squeeze()
+            np.asarray(self._counts_obs.sum(1)).squeeze()
             if total_counts_obs is None
             else total_counts_obs
         )

--- a/scanpy/preprocessing/_scrublet/sparse_utils.py
+++ b/scanpy/preprocessing/_scrublet/sparse_utils.py
@@ -52,7 +52,7 @@ def subsample_counts(
     if rate < 1:
         random_seed = get_random_state(random_seed)
         E.data = random_seed.binomial(np.round(E.data).astype(int), rate)
-        current_totals = E.sum(1).A.squeeze()
+        current_totals = np.asarray(E.sum(1)).squeeze()
         unsampled_orig_totals = original_totals - current_totals
         unsampled_downsamp_totals = np.random.binomial(
             np.round(unsampled_orig_totals).astype(int), rate

--- a/scanpy/tests/test_highly_variable_genes.py
+++ b/scanpy/tests/test_highly_variable_genes.py
@@ -127,7 +127,7 @@ def test_keep_layer(base, flavor):
     else:
         assert False
 
-    assert np.allclose(X_orig.A, adata.X.A)
+    assert np.allclose(X_orig.toarray(), adata.X.toarray())
 
 
 def _check_pearson_hvg_columns(output_df: pd.DataFrame, n_top_genes: int):

--- a/scanpy/tests/test_score_genes.py
+++ b/scanpy/tests/test_score_genes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pickle
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import numpy as np
 import pytest
@@ -10,6 +11,9 @@ from scipy.sparse import csr_matrix
 
 import scanpy as sc
 from testing.scanpy._helpers.data import paul15
+
+if TYPE_CHECKING:
+    from typing import Literal
 
 HERE = Path(__file__).parent / Path("_data/")
 
@@ -102,16 +106,20 @@ def test_sparse_nanmean():
     # sparse matrix, no NaN
     S = _create_sparse_nan_matrix(R, C, percent_zero=0.3, percent_nan=0)
     # col/col sum
-    np.testing.assert_allclose(S.A.mean(0), np.array(_sparse_nanmean(S, 0)).flatten())
-    np.testing.assert_allclose(S.A.mean(1), np.array(_sparse_nanmean(S, 1)).flatten())
+    np.testing.assert_allclose(
+        S.toarray().mean(0), np.array(_sparse_nanmean(S, 0)).flatten()
+    )
+    np.testing.assert_allclose(
+        S.toarray().mean(1), np.array(_sparse_nanmean(S, 1)).flatten()
+    )
 
     # sparse matrix with nan
     S = _create_sparse_nan_matrix(R, C, percent_zero=0.3, percent_nan=0.3)
     np.testing.assert_allclose(
-        np.nanmean(S.A, 1), np.array(_sparse_nanmean(S, 1)).flatten()
+        np.nanmean(S.toarray(), 1), np.array(_sparse_nanmean(S, 1)).flatten()
     )
     np.testing.assert_allclose(
-        np.nanmean(S.A, 0), np.array(_sparse_nanmean(S, 0)).flatten()
+        np.nanmean(S.toarray(), 0), np.array(_sparse_nanmean(S, 0)).flatten()
     )
 
     # edge case of only NaNs per row
@@ -138,7 +146,7 @@ def test_score_genes_sparse_vs_dense():
     adata_sparse = _create_adata(100, 1000, p_zero=0.3, p_nan=0.3)
 
     adata_dense = adata_sparse.copy()
-    adata_dense.X = adata_dense.X.A
+    adata_dense.X = adata_dense.X.toarray()
 
     gene_set = adata_dense.var_names[:10]
 
@@ -161,7 +169,7 @@ def test_score_genes_deplete():
     adata_sparse = _create_adata(100, 1000, p_zero=0.3, p_nan=0.3)
 
     adata_dense = adata_sparse.copy()
-    adata_dense.X = adata_dense.X.A
+    adata_dense.X = adata_dense.X.toarray()
 
     # here's an arbitary gene set
     gene_set = adata_dense.var_names[:10]
@@ -194,8 +202,8 @@ def test_npnanmean_vs_sparsemean(monkeypatch):
     sparse_scores = adata.obs["Test"].values.tolist()
 
     # now patch _sparse_nanmean by np.nanmean inside sc.tools
-    def mock_fn(x, axis):
-        return np.nanmean(x.A, axis, dtype="float64")
+    def mock_fn(x: csr_matrix, axis: Literal[0, 1]):
+        return np.nanmean(x.toarray(), axis, dtype="float64")
 
     monkeypatch.setattr(sc.tl._score_genes, "_sparse_nanmean", mock_fn)
     sc.tl.score_genes(adata, gene_list=gene_set, score_name="Test")

--- a/scanpy/tests/test_utils.py
+++ b/scanpy/tests/test_utils.py
@@ -240,5 +240,5 @@ def test_is_constant_dask(axis, expected, block_type):
         [0, 0, 0, 0],
     ]
     x = da.from_array(np.array(x_data), chunks=2).map_blocks(block_type)
-
-    np.testing.assert_array_equal(expected, is_constant(x, axis=axis))
+    result = is_constant(x, axis=axis).compute()
+    np.testing.assert_array_equal(expected, result)

--- a/scanpy/tools/_score_genes.py
+++ b/scanpy/tools/_score_genes.py
@@ -15,13 +15,18 @@ from .._compat import old_positionals
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
+    from typing import Literal
 
     from anndata import AnnData
+    from numpy.typing import NDArray
+    from scipy.sparse import csc_matrix, csr_matrix
 
     from .._utils import AnyRandom
 
 
-def _sparse_nanmean(X, axis):
+def _sparse_nanmean(
+    X: csr_matrix | csc_matrix, axis: Literal[0, 1]
+) -> NDArray[np.float64]:
     """
     np.nanmean equivalent for sparse matrices
     """


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3083
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:

Two different fixes:

1. The `np.asarray` cases are when we e.g. had `spmat.sum(axis=1).A` (i.e. a dense matrix). I could also leave these as `.A`.
2. the `.toarray()` cases are when we converted a sparse matrix to dense directly.