### PR TITLE
Unpin numpy 2

### DIFF
--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -23,7 +23,6 @@
 * Fix deprecated use of `.A` with sparse matrices {pr}`3084` {smaller}`P Angerer`
 * Fix zappy support {pr}`3089` {smaller}`P Angerer`
 * Fix dotplot group order with {mod}`pandas` 1.x {pr}`3101` {smaller}`P Angerer`
-* Add compatibility with {mod}`numpy` 2.0 {pr}`3065` and {pr}`3115` {smaller}`P Angerer`
 
 ```{rubric} Performance
 ```

--- a/docs/release-notes/1.10.2.md
+++ b/docs/release-notes/1.10.2.md
@@ -23,6 +23,7 @@
 * Fix deprecated use of `.A` with sparse matrices {pr}`3084` {smaller}`P Angerer`
 * Fix zappy support {pr}`3089` {smaller}`P Angerer`
 * Fix dotplot group order with {mod}`pandas` 1.x {pr}`3101` {smaller}`P Angerer`
+* Add compatibility with {mod}`numpy` 2.0 {pr}`3065` and {pr}`3115` {smaller}`P Angerer`
 
 ```{rubric} Performance
 ```

--- a/docs/release-notes/1.10.3.md
+++ b/docs/release-notes/1.10.3.md
@@ -10,7 +10,7 @@
 ```
 
 * Fix `subset=True` of {func}`~scanpy.pp.highly_variable_genes` when `flavor` is `seurat` or `cell_ranger`, and `batch_key!=None` {pr}`3042` {smaller}`E Roellin`
-
+* Add compatibility with {mod}`numpy` 2.0 {pr}`3065` and {pr}`3115` {smaller}`P Angerer`
 
 ```{rubric} Performance
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,9 +48,7 @@ classifiers = [
 ]
 dependencies = [
     "anndata>=0.8",
-    # TODO: remove <2 requirement once PyNNDescent releases this fix:
-    # https://github.com/lmcinnes/pynndescent/issues/241
-    "numpy>=1.23,<2",
+    "numpy>=1.23",
     "matplotlib>=3.6",
     "pandas >=1.5",
     "scipy>=1.8",

--- a/src/scanpy/_utils/compute/is_constant.py
+++ b/src/scanpy/_utils/compute/is_constant.py
@@ -81,7 +81,7 @@ def is_constant(
 def _(a: NDArray, axis: Literal[0, 1] | None = None) -> bool | NDArray[np.bool_]:
     # Should eventually support nd, not now.
     if axis is None:
-        return (a == a.flat[0]).all()
+        return bool((a == a.flat[0]).all())
     if axis == 0:
         return _is_constant_rows(a.T)
     elif axis == 1:
@@ -116,9 +116,9 @@ def _is_constant_csr_rows(
     indptr: NDArray[np.integer],
     shape: tuple[int, int],
 ):
-    N = len(indptr) - 1
-    result = np.ones(N, dtype=np.bool_)
-    for i in range(N):
+    n = len(indptr) - 1
+    result = np.ones(n, dtype=np.bool_)
+    for i in range(n):
         start = indptr[i]
         stop = indptr[i + 1]
         if stop - start == shape[1]:

--- a/src/scanpy/plotting/_utils.py
+++ b/src/scanpy/plotting/_utils.py
@@ -230,7 +230,7 @@ def timeseries_as_heatmap(
 
     _, ax = plt.subplots(figsize=(1.5 * 4, 2 * 4))
     img = ax.imshow(
-        np.array(X, dtype=np.float_),
+        np.array(X, dtype=np.float64),
         aspect="auto",
         interpolation="nearest",
         cmap=color_map,

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -121,19 +121,19 @@ def filter_cells(
     >>> sc.pp.filter_cells(adata, min_genes=0)
     >>> adata.n_obs
     640
-    >>> adata.obs['n_genes'].min()
+    >>> int(adata.obs['n_genes'].min())
     1
     >>> # filter manually
     >>> adata_copy = adata[adata.obs['n_genes'] >= 3]
     >>> adata_copy.n_obs
     554
-    >>> adata_copy.obs['n_genes'].min()
+    >>> int(adata_copy.obs['n_genes'].min())
     3
     >>> # actually do some filtering
     >>> sc.pp.filter_cells(adata, min_genes=3)
     >>> adata.n_obs
     554
-    >>> adata.obs['n_genes'].min()
+    >>> int(adata.obs['n_genes'].min())
     3
     """
     if copy:

--- a/src/testing/scanpy/_pytest/__init__.py
+++ b/src/testing/scanpy/_pytest/__init__.py
@@ -99,12 +99,11 @@ def _modify_doctests(request: pytest.FixtureRequest) -> None:
 
     func = _import_name(request.node.name)
     needs_mod: str | None
-    if needs_mod := getattr(func, "_doctest_needs", None):
-        needs_marker = needs[needs_mod]
-        if needs_marker.mark.args[0]:
-            pytest.skip(reason=needs_marker.mark.kwargs["reason"])
     skip_reason: str | None
-    if skip_reason := getattr(func, "_doctest_skip_reason", None):
+    if (
+        (needs_mod := getattr(func, "_doctest_needs", None))
+        and (skip_reason := needs[needs_mod].skip_reason)
+    ) or (skip_reason := getattr(func, "_doctest_skip_reason", None)):
         pytest.skip(reason=skip_reason)
     if getattr(func, "_doctest_internet", False) and not request.config.getoption(
         "--internet-tests"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -173,7 +173,7 @@ DS_MARKS = defaultdict(list, moignard15=[needs.openpyxl])
                 *DS_MARKS[ds],
             ],
         )
-        for ds in set(sc.datasets.__all__) - DS_DYNAMIC
+        for ds in sorted(set(sc.datasets.__all__) - DS_DYNAMIC)
     ],
 )
 def test_doc_shape(ds_name):


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3114
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:

Other things done:

- Rename some variables and reorder functions so the diff between the metrics is minimal for a future unification
- Skip seurat v3 tests with numpy 2 because skmisc isn’t ready: https://github.com/has2k1/scikit-misc/issues/34

  This will skip the seurat v3 tests for all but the minimum versions test job for now, but I think that’s OK?