### PR TITLE
Run benchmarks for off axis

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -8,3 +8,14 @@ Benchmarks are run using the [benchmark bot][].
 [asv]: https://asv.readthedocs.io/
 [`benchmark.yml`]: ../.github/workflows/benchmark.yml
 [benchmark bot]: https://github.com/apps/scverse-benchmark
+
+## Data processing in benchmarks
+
+Each dataset is processed so it has
+
+- `.layers['counts']` (containing data in C/row-major format) and `.layers['counts-off-axis']` (containing data in FORTRAN/column-major format)
+- `.X` and `.layers['off-axis']` with log-transformed data (formats like above)
+- a `.var['mt']` boolean column indicating mitochondrial genes
+
+The benchmarks are set up so the `layer` parameter indicates the layer that will be moved into `.X` before the benchmark.
+That way, we don’t need to add `layer=layer` everywhere.

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -85,6 +85,7 @@
         // "psutil": [""]
         "pooch": [""],
         "scikit-image": [""],
+        "scikit-misc": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -85,7 +85,7 @@
         // "psutil": [""]
         "pooch": [""],
         "scikit-image": [""],
-        "scikit-misc": [""],
+        // "scikit-misc": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/benchmarks/_utils.py
+++ b/benchmarks/benchmarks/_utils.py
@@ -166,7 +166,22 @@ def get_count_dataset(
 def param_skipper(
     param_names: Sequence[str], params: tuple[Sequence[object], ...]
 ) -> ParamSkipper:
-    """Creates a decorator that will skip all combinations that contain any of the given parameters."""
+    """Creates a decorator that will skip all combinations that contain any of the given parameters.
+
+    Examples
+    --------
+
+    >>> param_names = ["letters", "numbers"]
+    >>> params = [["a", "b"], [3, 4, 5]]
+    >>> skip_when = param_skipper(param_names, params)
+
+    >>> @skip_when(letters={"a"}, numbers={3})
+    ... def func(a, b):
+    ...     print(a, b)
+    >>> run_as_asv_benchmark(func)
+    b 4
+    b 5
+    """
 
     def skip(**skipped: Set) -> Callable[[C], C]:
         skipped_combs = [

--- a/benchmarks/benchmarks/_utils.py
+++ b/benchmarks/benchmarks/_utils.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
 def _pbmc68k_reduced() -> AnnData:
     """A small datasets with a dense `.X`"""
     adata = sc.datasets.pbmc68k_reduced()
+    adata.var["mt"] = adata.var_names.str.startswith("MT-")
     assert isinstance(adata.X, np.ndarray)
     assert not np.isfortran(adata.X)
     adata.layers["off-axis"] = adata.X.copy(order="F")
@@ -49,11 +50,11 @@ def pbmc68k_reduced() -> AnnData:
 @cache
 def _pbmc3k() -> AnnData:
     adata = sc.datasets.pbmc3k()
-    assert isinstance(adata.X, sparse.csr_matrix)
     adata.var["mt"] = adata.var_names.str.startswith("MT-")
     sc.pp.calculate_qc_metrics(
         adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
     )
+    assert isinstance(adata.X, sparse.csr_matrix)
     adata.layers["counts"] = adata.X.astype(np.int32, copy=True)
     adata.layers["counts-off-axis"] = adata.layers["counts"].tocsc()
     sc.pp.log1p(adata)
@@ -93,8 +94,9 @@ def _bmmc(n_obs: int = 4000) -> AnnData:
     sc.pp.calculate_qc_metrics(
         adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
     )
+    assert isinstance(adata.X, sparse.csr_matrix)
     adata.obs["n_counts"] = adata.X.sum(axis=1).A1
-
+    adata.layers["off-axis"] = adata.X.tocsc()
     return adata
 
 
@@ -108,7 +110,10 @@ def _lung93k() -> AnnData:
         url="https://figshare.com/ndownloader/files/45788454",
         known_hash="md5:4f28af5ff226052443e7e0b39f3f9212",
     )
-    return sc.read_h5ad(path)
+    adata = sc.read_h5ad(path)
+    assert isinstance(adata.X, sparse.csr_matrix)
+    adata.layers["off-axis"] = adata.X.tocsc()
+    return adata
 
 
 def lung93k() -> AnnData:

--- a/benchmarks/benchmarks/_utils.py
+++ b/benchmarks/benchmarks/_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import itertools
-import sys
 import warnings
 from functools import cache
 from typing import TYPE_CHECKING
@@ -34,16 +33,13 @@ if TYPE_CHECKING:
 def _pbmc68k_reduced() -> AnnData:
     """A small datasets with a dense `.X`"""
     adata = sc.datasets.pbmc68k_reduced()
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
     assert isinstance(adata.X, np.ndarray)
     assert not np.isfortran(adata.X)
-    adata.layers["off-axis"] = adata.X.copy(order="F")
 
     # raw has the same number of genes, so we can use it for counts
     # it doesn’t actually contain counts for some reason, but close enough
     assert isinstance(adata.raw.X, sparse.csr_matrix)
     adata.layers["counts"] = adata.raw.X.toarray(order="C")
-    adata.layers["counts-off-axis"] = adata.layers["counts"].copy(order="F")
     mapper = dict(
         percent_mito="pct_counts_mt",
         n_counts="total_counts",
@@ -59,15 +55,9 @@ def pbmc68k_reduced() -> AnnData:
 @cache
 def _pbmc3k() -> AnnData:
     adata = sc.datasets.pbmc3k()
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
-    sc.pp.calculate_qc_metrics(
-        adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
-    )
     assert isinstance(adata.X, sparse.csr_matrix)
     adata.layers["counts"] = adata.X.astype(np.int32, copy=True)
-    adata.layers["counts-off-axis"] = adata.layers["counts"].tocsc()
     sc.pp.log1p(adata)
-    adata.layers["off-axis"] = adata.X.tocsc()
     return adata
 
 
@@ -99,13 +89,8 @@ def _bmmc(n_obs: int = 4000) -> AnnData:
         adata = concat(adatas, label="sample")
     adata.obs_names_make_unique()
 
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
-    sc.pp.calculate_qc_metrics(
-        adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
-    )
     assert isinstance(adata.X, sparse.csr_matrix)
     adata.obs["n_counts"] = adata.X.sum(axis=1).A1
-    adata.layers["off-axis"] = adata.X.tocsc()
     return adata
 
 
@@ -121,7 +106,6 @@ def _lung93k() -> AnnData:
     )
     adata = sc.read_h5ad(path)
     assert isinstance(adata.X, sparse.csr_matrix)
-    adata.layers["off-axis"] = adata.X.tocsc()
     return adata
 
 
@@ -129,19 +113,44 @@ def lung93k() -> AnnData:
     return _lung93k().copy()
 
 
-def _get_dataset_raw(dataset: Dataset) -> tuple[AnnData, str | None]:
-    if dataset == "pbmc68k_reduced":
-        return pbmc68k_reduced(), None
-    if dataset == "pbmc3k":
-        return pbmc3k(), None  # can’t use this with batches
-    if dataset == "bmmc":
-        # TODO: allow specifying bigger variant
-        return bmmc(400), "sample"
-    if dataset == "lung93k":
-        return lung93k(), "PatientNumber"
+def to_off_axis(x: np.ndarray | sparse.csr_matrix) -> np.ndarray | sparse.csc_matrix:
+    if isinstance(x, sparse.csr_matrix):
+        return x.tocsc()
+    if isinstance(x, np.ndarray):
+        assert not np.isfortran(x)
+        return x.copy(order="F")
+    msg = f"Unexpected type {type(x)}"
+    raise TypeError(msg)
 
-    msg = f"Unknown dataset {dataset}"
-    raise AssertionError(msg)
+
+def _get_dataset_raw(dataset: Dataset) -> tuple[AnnData, str | None]:
+    match dataset:
+        case "pbmc68k_reduced":
+            adata, batch_key = pbmc68k_reduced(), None
+        case "pbmc3k":
+            adata, batch_key = pbmc3k(), None  # can’t use this with batches
+        case "bmmc":
+            # TODO: allow specifying bigger variant
+            adata, batch_key = bmmc(400), "sample"
+        case "lung93k":
+            adata, batch_key = lung93k(), "PatientNumber"
+        case _:
+            msg = f"Unknown dataset {dataset}"
+            raise AssertionError(msg)
+
+    # add off-axis layers
+    adata.layers["off-axis"] = to_off_axis(adata.X)
+    if (counts := adata.layers.get("counts")) is not None:
+        adata.layers["counts-off-axis"] = to_off_axis(counts)
+
+    # add mitochondrial gene and pre-compute qc metrics
+    adata.var["mt"] = adata.var_names.str.startswith("MT-")
+    assert adata.var["mt"].sum() > 0, "no MT genes in dataset"
+    sc.pp.calculate_qc_metrics(
+        adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
+    )
+
+    return adata, batch_key
 
 
 def get_dataset(dataset: Dataset, *, layer: KeyX = None) -> tuple[AnnData, str | None]:
@@ -191,7 +200,7 @@ def param_skipper(
             )
             if any(v in skipped.get(n, set()) for n, v in record.items())
         ]
-        print(skipped_combs, file=sys.stderr)
+        # print(skipped_combs, file=sys.stderr)
         return skip_for_params(skipped_combs)
 
     return skip

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -62,6 +62,15 @@ def peakmem_scrublet(*_):
     sc.pp.scrublet(adata, batch_key=batch_key)
 
 
+def time_hvg_seurat_v3(*_):
+    # seurat v3 runs on counts
+    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
+
+
+def peakmem_hvg_seurat_v3(*_):
+    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
+
+
 class FastSuite:
     """Suite for fast preprocessing operations."""
 

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -38,18 +38,6 @@ params: tuple[list[Dataset], list[KeyCount]] = (
 param_names = ["dataset", "layer"]
 
 
-def time_calculate_qc_metrics(*_):
-    sc.pp.calculate_qc_metrics(
-        adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
-    )
-
-
-def peakmem_calculate_qc_metrics(*_):
-    sc.pp.calculate_qc_metrics(
-        adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
-    )
-
-
 def time_filter_cells(*_):
     sc.pp.filter_cells(adata, min_genes=100)
 
@@ -74,21 +62,37 @@ def peakmem_scrublet(*_):
     sc.pp.scrublet(adata, batch_key=batch_key)
 
 
-def time_normalize_total(*_):
-    sc.pp.normalize_total(adata, target_sum=1e4)
+class FastSuite:
+    """Suite for fast preprocessing operations."""
 
+    params: tuple[list[Dataset], list[KeyCount]] = (
+        ["pbmc3k", "pbmc68k_reduced", "bmmc", "lung93k"],
+        ["counts", "counts-off-axis"],
+    )
+    param_names = ["dataset", "layer"]
 
-def peakmem_normalize_total(*_):
-    sc.pp.normalize_total(adata, target_sum=1e4)
+    def time_calculate_qc_metrics(self, *_):
+        sc.pp.calculate_qc_metrics(
+            adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
+        )
 
+    def peakmem_calculate_qc_metrics(self, *_):
+        sc.pp.calculate_qc_metrics(
+            adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
+        )
 
-def time_log1p(*_):
-    # TODO: This would fail: assert "log1p" not in adata.uns, "ASV bug?"
-    # https://github.com/scverse/scanpy/issues/3052
-    adata.uns.pop("log1p", None)
-    sc.pp.log1p(adata)
+    def time_normalize_total(self, *_):
+        sc.pp.normalize_total(adata, target_sum=1e4)
 
+    def peakmem_normalize_total(self, *_):
+        sc.pp.normalize_total(adata, target_sum=1e4)
 
-def peakmem_log1p(*_):
-    adata.uns.pop("log1p", None)
-    sc.pp.log1p(adata)
+    def time_log1p(self, *_):
+        # TODO: This would fail: assert "log1p" not in adata.uns, "ASV bug?"
+        # https://github.com/scverse/scanpy/issues/3052
+        adata.uns.pop("log1p", None)
+        sc.pp.log1p(adata)
+
+    def peakmem_log1p(self, *_):
+        adata.uns.pop("log1p", None)
+        sc.pp.log1p(adata)

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -39,14 +39,12 @@ param_names = ["dataset", "layer"]
 
 
 def time_calculate_qc_metrics(*_):
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
     sc.pp.calculate_qc_metrics(
         adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
     )
 
 
 def peakmem_calculate_qc_metrics(*_):
-    adata.var["mt"] = adata.var_names.str.startswith("MT-")
     sc.pp.calculate_qc_metrics(
         adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
     )

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -62,6 +62,8 @@ def peakmem_scrublet(*_):
     sc.pp.scrublet(adata, batch_key=batch_key)
 
 
+# Can’t do seurat v3 yet: https://github.com/conda-forge/scikit-misc-feedstock/issues/17
+"""
 def time_hvg_seurat_v3(*_):
     # seurat v3 runs on counts
     sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
@@ -69,6 +71,7 @@ def time_hvg_seurat_v3(*_):
 
 def peakmem_hvg_seurat_v3(*_):
     sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
+"""
 
 
 class FastSuite:

--- a/benchmarks/benchmarks/preprocessing_log.py
+++ b/benchmarks/benchmarks/preprocessing_log.py
@@ -50,6 +50,7 @@ def peakmem_pca(*_):
 
 
 def time_highly_variable_genes(*_):
+    # the default flavor runs on log-transformed data
     sc.pp.highly_variable_genes(adata, min_mean=0.0125, max_mean=3, min_disp=0.5)
 
 

--- a/benchmarks/benchmarks/preprocessing_log.py
+++ b/benchmarks/benchmarks/preprocessing_log.py
@@ -17,7 +17,7 @@ from ._utils import get_dataset
 if TYPE_CHECKING:
     from anndata import AnnData
 
-    from ._utils import Dataset
+    from ._utils import Dataset, KeyX
 
 # setup variables
 
@@ -26,16 +26,19 @@ adata: AnnData
 batch_key: str | None
 
 
-def setup(dataset: Dataset, *_):
+def setup(dataset: Dataset, layer: KeyX, *_):
     """Setup global variables before each benchmark."""
     global adata, batch_key
-    adata, batch_key = get_dataset(dataset)
+    adata, batch_key = get_dataset(dataset, layer=layer)
 
 
 # ASV suite
 
-params: list[Dataset] = ["pbmc68k_reduced", "pbmc3k"]
-param_names = ["dataset"]
+params: tuple[list[Dataset], list[KeyX]] = (
+    ["pbmc68k_reduced", "pbmc3k"],
+    [None, "off-axis"],
+)
+param_names = ["dataset", "layer"]
 
 
 def time_pca(*_):
@@ -76,8 +79,11 @@ def peakmem_scale(*_):
 class FastSuite:
     """Suite for fast preprocessing operations."""
 
-    params: list[Dataset] = ["pbmc3k", "pbmc68k_reduced", "bmmc", "lung93k"]
-    param_names = ["dataset"]
+    params: tuple[list[Dataset], list[KeyX]] = (
+        ["pbmc3k", "pbmc68k_reduced", "bmmc", "lung93k"],
+        [None, "off-axis"],
+    )
+    param_names = ["dataset", "layer"]
 
     def time_mean_var(self, *_):
         _get_mean_var(adata.X)

--- a/benchmarks/benchmarks/preprocessing_log.py
+++ b/benchmarks/benchmarks/preprocessing_log.py
@@ -7,12 +7,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from asv_runner.benchmarks.mark import skip_for_params
-
 import scanpy as sc
 from scanpy.preprocessing._utils import _get_mean_var
 
-from ._utils import get_dataset
+from ._utils import get_dataset, param_skipper
 
 if TYPE_CHECKING:
     from anndata import AnnData
@@ -40,6 +38,8 @@ params: tuple[list[Dataset], list[KeyX]] = (
 )
 param_names = ["dataset", "layer"]
 
+skip_when = param_skipper(param_names, params)
+
 
 def time_pca(*_):
     sc.pp.pca(adata, svd_solver="arpack")
@@ -58,12 +58,12 @@ def peakmem_highly_variable_genes(*_):
 
 
 # regress_out is very slow for this dataset
-@skip_for_params([("pbmc3k",)])
+@skip_when(dataset={"pbmc3k"})
 def time_regress_out(*_):
     sc.pp.regress_out(adata, ["total_counts", "pct_counts_mt"])
 
 
-@skip_for_params([("pbmc3k",)])
+@skip_when(dataset={"pbmc3k"})
 def peakmem_regress_out(*_):
     sc.pp.regress_out(adata, ["total_counts", "pct_counts_mt"])
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:


@Intron7 

This adds benchmarks for the off axis for all parameters.

The off axis peak memory is lower since we `.pop` that layer. If you think that’s confusing I could change it.

Regarding big datasets for `_get_mean_var`, I already added that benchmark. You could maybe check if there’s anything else that should go into the `FastSuite`