### PR TITLE
Cache data for subsequent test runs

### DIFF
--- a/src/testing/scanpy/_pytest/__init__.py
+++ b/src/testing/scanpy/_pytest/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 @pytest.fixture(autouse=True)
 def _global_test_context(
     request: pytest.FixtureRequest,
+    cache: pytest.Cache,
     tmp_path_factory: pytest.TempPathFactory,
 ) -> Generator[None, None, None]:
     """Switch to agg backend, reset settings, and close all figures at teardown."""
@@ -33,7 +34,9 @@ def _global_test_context(
     sc.settings.logfile = sys.stderr
     sc.settings.verbosity = "hint"
     sc.settings.autoshow = True
-    sc.settings.datasetdir = tmp_path_factory.mktemp("scanpy_data")
+    # reuse data files between test runs (unless overwritten in the test)
+    sc.settings.datasetdir = cache.mkdir("scanpy-data")
+    # create new writedir for each test run
     sc.settings.writedir = tmp_path_factory.mktemp("scanpy_write")
 
     if isinstance(request.node, pytest.DoctestItem):

--- a/src/testing/scanpy/_pytest/fixtures/__init__.py
+++ b/src/testing/scanpy/_pytest/fixtures/__init__.py
@@ -39,7 +39,6 @@ def float_dtype(request):
 
 @pytest.fixture()
 def _doctest_env(cache: pytest.Cache, tmp_path: Path) -> Generator[None, None, None]:
-    from scanpy import settings
     from scanpy._compat import chdir
 
     showwarning_orig = warnings.showwarning
@@ -61,8 +60,6 @@ def _doctest_env(cache: pytest.Cache, tmp_path: Path) -> Generator[None, None, N
     ] + [("ignore", None, Warning, None, 0)]
 
     warnings.showwarning = showwarning
-    old_dd, settings.datasetdir = settings.datasetdir, cache.mkdir("scanpy-data")
     with chdir(tmp_path):
         yield
     warnings.showwarning = showwarning_orig
-    settings.datasetdir = old_dd

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -24,6 +24,15 @@ if TYPE_CHECKING:
     from anndata import AnnData
 
 
+@pytest.fixture(autouse=True)
+def _tmp_dataset_dir(tmp_path: Path) -> None:
+    """Make sure that datasets are downloaded during the test run.
+
+    The default test environment stores them in a cached location.
+    """
+    sc.settings.datasetdir = tmp_path / "scanpy_data"
+
+
 @pytest.mark.internet
 def test_burczynski06():
     with pytest.warns(UserWarning, match=r"Variable names are not unique"):


### PR DESCRIPTION
This makes local test runs using e.g. pbmc3k faster