### PR TITLE
fix bug for partial_fit when the number of batch samples is less than n_comp

### DIFF
--- a/src/scanpy/preprocessing/_pca.py
+++ b/src/scanpy/preprocessing/_pca.py
@@ -263,7 +263,10 @@ def pca(
 
         for chunk, _, _ in adata_comp.chunked_X(chunk_size):
             chunk = chunk.toarray() if issparse(chunk) else chunk
-            pca_.partial_fit(chunk)
+            try:
+                pca_.partial_fit(chunk)
+            except:
+                continue
 
         for chunk, start, end in adata_comp.chunked_X(chunk_size):
             chunk = chunk.toarray() if issparse(chunk) else chunk

--- a/src/scanpy/preprocessing/_pca.py
+++ b/src/scanpy/preprocessing/_pca.py
@@ -263,9 +263,9 @@ def pca(
 
         for chunk, _, _ in adata_comp.chunked_X(chunk_size):
             chunk = chunk.toarray() if issparse(chunk) else chunk
-            try:
+            if n_comps <= chunk.shape[0]:
                 pca_.partial_fit(chunk)
-            except:
+            else:
                 continue
 
         for chunk, start, end in adata_comp.chunked_X(chunk_size):


### PR DESCRIPTION
For incremental PCA: `sc.tl.pca(adata, n_comps=ndim, chunked=True)`
sometimes, the number of samples for the last chunk is smaller than ndim, an error would be throw:
```pytb
File /anvil/projects/x-mcb130189/Wubin/Software/miniconda3/envs/m3c/lib/python3.9/site-packages/pym3c/clustering.py:377, in run_dimension_reduction(***failed resolving arguments***)
    375 if not downsample or obs_chunk_size > downsample or adata.n_obs < downsample:
    376         logger.info(f"Running IncrementalPCA without downsampling")
--> 377         sc.tl.pca(adata, n_comps=ndim, chunked=True,
    378                           chunk_size=obs_chunk_size)
    379 else: # downsample
    380         logger.info(f"Running IncrementalPCA with downsample = {downsample}")

File /anvil/projects/x-mcb130189/Wubin/Software/miniconda3/envs/m3c/lib/python3.9/site-packages/scanpy/preprocessing/_pca.py:255, in pca(***failed resolving arguments***)
    253 for chunk, _, _ in adata_comp.chunked_X(chunk_size):
    254     chunk = chunk.toarray() if issparse(chunk) else chunk
--> 255     pca_.partial_fit(chunk)
    257 for chunk, start, end in adata_comp.chunked_X(chunk_size):
    258     chunk = chunk.toarray() if issparse(chunk) else chunk

File /anvil/projects/x-mcb130189/Wubin/Software/miniconda3/envs/m3c/lib/python3.9/site-packages/sklearn/base.py:1473, in _fit_context.<locals>.decorator.<locals>.wrapper(estimator, *args, **kwargs)
   1466     estimator._validate_params()
   1468 with config_context(
   1469     skip_parameter_validation=(
   1470         prefer_skip_nested_validation or global_skip_validation
   1471     )
   1472 ):
-> 1473     return fit_method(estimator, *args, **kwargs)

File /anvil/projects/x-mcb130189/Wubin/Software/miniconda3/envs/m3c/lib/python3.9/site-packages/sklearn/decomposition/_incremental_pca.py:304, in IncrementalPCA.partial_fit(self, X, y, check_input)
    298     raise ValueError(
    299         "n_components=%r invalid for n_features=%d, need "
    300         "more rows than columns for IncrementalPCA "
    301         "processing" % (self.n_components, n_features)
    302     )
    303 elif not self.n_components <= n_samples:
--> 304     raise ValueError(
    305         "n_components=%r must be less or equal to "
    306         "the batch number of samples "
    307         "%d." % (self.n_components, n_samples)
    308     )
    309 else:
    310     self.n_components_ = self.n_components

ValueError: n_components=100 must be less or equal to the batch number of samples 77
```

To fix this bug, I added a `try` and `except` to line 255 of _pca.py.

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:
