### PR TITLE
Fix release note building and check

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -49,13 +49,13 @@ jobs:
         with:
           fetch-depth: 0
           filter: blob:none
-      - name: Find out if relevant release notes are modified
-        uses: dorny/paths-filter@v2
+      - name: Find out if a relevant release fragment is added
+        uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: | # this is intentionally a string
-            relnotes: 'docs/release-notes/${{ github.event.pull_request.milestone.title }}.md'
-      - name: Check if relevant release notes are modified
+            relnotes: 'docs/release-notes/${{ github.event.pull_request.number }}.*.md'
+      - name: Check if a relevant release fragment is added
         uses: flying-sheep/check@v1
         with:
           success: ${{ steps.changes.outputs.relnotes }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -21,4 +21,5 @@ python:
     path: .
     extra_requirements:
     - doc
+    - dev  # for towncrier
     - leiden

--- a/docs/release-notes/3239.bugfix.md
+++ b/docs/release-notes/3239.bugfix.md
@@ -1,0 +1,1 @@
+Fix release note check {user}`flying-sheep`

--- a/docs/release-notes/3239.bugfix.md
+++ b/docs/release-notes/3239.bugfix.md
@@ -1,1 +1,0 @@
-Fix release note check {user}`flying-sheep`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,6 +157,7 @@ dask-ml = ["dask-ml", "scanpy[dask]"]  # Dask-ML for sklearn-like API
 packages = ["src/testing", "src/scanpy"]
 [tool.hatch.version]
 source = "vcs"
+raw-options.version_scheme = "release-branch-semver"
 [tool.hatch.build.hooks.vcs]
 version-file = "src/scanpy/_version.py"
 


### PR DESCRIPTION
See https://setuptools-scm.readthedocs.io/en/latest/extending/#setuptools_scmversion_scheme:

> Semantic versioning for projects with release branches. The same as `guess-next-dev` (incrementing the pre-release or micro segment) however when on a release branch: a branch whose name (ignoring namespace) parses as a version that matches the most recent tag up to the minor segment. Otherwise if on a non-release branch, increments the minor segment and sets the micro segment to zero, then appends `.devN`

Apparently the “ignoring namespace” makes it work with our `<major>.<minor>.x` branch names

I checked if the new check works:

![grafik](https://github.com/user-attachments/assets/a2620352-f688-47d3-9481-f621783f4ecf)
