### PR TITLE
Finish `scale`→`density_norm` deprecation

### DIFF
--- a/docs/release-notes/3244.bugfix.md
+++ b/docs/release-notes/3244.bugfix.md
@@ -1,1 +1,1 @@
-Use `density_norm` instead of of `scale` (cont. from {pr}`2844`) {smaller}`P Angerer`
+Use `density_norm` instead of of `scale` (cont. from {pr}`2844`) in {func}`~scanpy.pl.violin` and {func}`~scanpy.pl.stacked_violin` {smaller}`P Angerer`

--- a/docs/release-notes/3244.bugfix.md
+++ b/docs/release-notes/3244.bugfix.md
@@ -1,0 +1,1 @@
+Use `density_norm` instead of of `scale` (cont. from {pr}`2844`) {smaller}`P Angerer`

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -687,7 +687,9 @@ def stacked_violin(
     stripplot: bool = StackedViolin.DEFAULT_STRIPPLOT,
     jitter: float | bool = StackedViolin.DEFAULT_JITTER,
     size: int = StackedViolin.DEFAULT_JITTER_SIZE,
-    density_norm: Literal["area", "count", "width"] | Empty = _empty,
+    density_norm: Literal[
+        "area", "count", "width"
+    ] = StackedViolin.DEFAULT_DENSITY_NORM,
     yticklabels: bool | None = StackedViolin.DEFAULT_PLOT_YTICKLABELS,
     order: Sequence[str] | None = None,
     swap_axes: bool = False,
@@ -838,7 +840,9 @@ def stacked_violin(
         jitter=jitter,
         jitter_size=size,
         row_palette=row_palette,
-        density_norm=_deprecated_scale(density_norm, scale),
+        density_norm=_deprecated_scale(
+            density_norm, scale, default=StackedViolin.DEFAULT_DENSITY_NORM
+        ),
         yticklabels=yticklabels,
         linewidth=kwds.get("linewidth", StackedViolin.DEFAULT_LINE_WIDTH),
     ).legend(title=colorbar_title)

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
-from .._utils import _doc_params
+from .._utils import _doc_params, _empty
 from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
 from ._utils import (
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.colors import Normalize
 
+    from .._utils import Empty
     from ._baseplot_class import _VarNames
     from ._utils import _AxesSubplot
 
@@ -276,7 +277,7 @@ class StackedViolin(BasePlot):
         x_padding: float | None = DEFAULT_PLOT_X_PADDING,
         y_padding: float | None = DEFAULT_PLOT_Y_PADDING,
         # deprecated
-        scale: Literal["area", "count", "width"] | None = None,
+        scale: Literal["area", "count", "width"] | Empty = _empty,
     ) -> Self:
         r"""\
         Modifies plot visual parameters
@@ -686,7 +687,7 @@ def stacked_violin(
     stripplot: bool = StackedViolin.DEFAULT_STRIPPLOT,
     jitter: float | bool = StackedViolin.DEFAULT_JITTER,
     size: int = StackedViolin.DEFAULT_JITTER_SIZE,
-    scale: Literal["area", "count", "width"] = StackedViolin.DEFAULT_DENSITY_NORM,
+    density_norm: Literal["area", "count", "width"] | Empty = _empty,
     yticklabels: bool | None = StackedViolin.DEFAULT_PLOT_YTICKLABELS,
     order: Sequence[str] | None = None,
     swap_axes: bool = False,
@@ -700,6 +701,8 @@ def stacked_violin(
     vmax: float | None = None,
     vcenter: float | None = None,
     norm: Normalize | None = None,
+    # deprecated
+    scale: Literal["area", "count", "width"] | Empty = _empty,
     **kwds,
 ) -> StackedViolin | dict | None:
     """\
@@ -731,7 +734,7 @@ def stacked_violin(
         Order in which to show the categories. Note: if `dendrogram=True`
         the categories order will be given by the dendrogram and `order`
         will be ignored.
-    scale
+    density_norm
         The method used to scale the width of each violin.
         If 'width' (the default), each violin will have the same width.
         If 'area', each violin will have the same area.
@@ -835,7 +838,7 @@ def stacked_violin(
         jitter=jitter,
         jitter_size=size,
         row_palette=row_palette,
-        density_norm=kwds.get("density_norm", scale),
+        density_norm=_deprecated_scale(density_norm, scale),
         yticklabels=yticklabels,
         linewidth=kwds.get("linewidth", StackedViolin.DEFAULT_LINE_WIDTH),
     ).legend(title=colorbar_title)

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
 
     from .._utils import Empty
     from ._baseplot_class import _VarNames
-    from ._utils import _AxesSubplot
+    from ._utils import DensityNorm, _AxesSubplot
 
 
 @_doc_params(common_plot_args=doc_common_plot_args)
@@ -119,7 +119,7 @@ class StackedViolin(BasePlot):
     DEFAULT_JITTER_SIZE = 1
     DEFAULT_LINE_WIDTH = 0.2
     DEFAULT_ROW_PALETTE = None
-    DEFAULT_DENSITY_NORM: Literal["area", "count", "width"] = "width"
+    DEFAULT_DENSITY_NORM: DensityNorm = "width"
     DEFAULT_PLOT_YTICKLABELS = False
     DEFAULT_YLIM = None
     DEFAULT_PLOT_X_PADDING = 0.5  # a unit is the distance between two x-axis ticks
@@ -271,13 +271,13 @@ class StackedViolin(BasePlot):
         jitter_size: int | None = DEFAULT_JITTER_SIZE,
         linewidth: float | None = DEFAULT_LINE_WIDTH,
         row_palette: str | None = DEFAULT_ROW_PALETTE,
-        density_norm: Literal["area", "count", "width"] = DEFAULT_DENSITY_NORM,
+        density_norm: DensityNorm = DEFAULT_DENSITY_NORM,
         yticklabels: bool | None = DEFAULT_PLOT_YTICKLABELS,
         ylim: tuple[float, float] | None = DEFAULT_YLIM,
         x_padding: float | None = DEFAULT_PLOT_X_PADDING,
         y_padding: float | None = DEFAULT_PLOT_Y_PADDING,
         # deprecated
-        scale: Literal["area", "count", "width"] | Empty = _empty,
+        scale: DensityNorm | Empty = _empty,
     ) -> Self:
         r"""\
         Modifies plot visual parameters
@@ -687,9 +687,7 @@ def stacked_violin(
     stripplot: bool = StackedViolin.DEFAULT_STRIPPLOT,
     jitter: float | bool = StackedViolin.DEFAULT_JITTER,
     size: int = StackedViolin.DEFAULT_JITTER_SIZE,
-    density_norm: Literal[
-        "area", "count", "width"
-    ] = StackedViolin.DEFAULT_DENSITY_NORM,
+    density_norm: DensityNorm = StackedViolin.DEFAULT_DENSITY_NORM,
     yticklabels: bool | None = StackedViolin.DEFAULT_PLOT_YTICKLABELS,
     order: Sequence[str] | None = None,
     swap_axes: bool = False,
@@ -704,7 +702,7 @@ def stacked_violin(
     vcenter: float | None = None,
     norm: Normalize | None = None,
     # deprecated
-    scale: Literal["area", "count", "width"] | Empty = _empty,
+    scale: DensityNorm | Empty = _empty,
     **kwds,
 ) -> StackedViolin | dict | None:
     """\

--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -15,7 +15,7 @@ from scanpy.get import obs_df
 from ... import logging as logg
 from ..._compat import old_positionals
 from ..._settings import settings
-from ..._utils import _doc_params, sanitize_anndata, subsample
+from ..._utils import _doc_params, _empty, sanitize_anndata, subsample
 from ...get import rank_genes_groups_df
 from .._anndata import ranking
 from .._docs import (
@@ -46,6 +46,9 @@ if TYPE_CHECKING:
     from matplotlib.axes import Axes
     from matplotlib.colors import Colormap, Normalize
     from matplotlib.figure import Figure
+
+    from ..._utils import Empty
+    from .._utils import DensityNorm
 
 # ------------------------------------------------------------------------------
 # PCA
@@ -1213,7 +1216,7 @@ def rank_genes_groups_violin(
     use_raw: bool | None = None,
     key: str | None = None,
     split: bool = True,
-    density_norm: Literal["area", "count", "width"] = "width",
+    density_norm: DensityNorm = "width",
     strip: bool = True,
     jitter: int | float | bool = True,
     size: int = 1,
@@ -1221,7 +1224,7 @@ def rank_genes_groups_violin(
     show: bool | None = None,
     save: bool | None = None,
     # deprecated
-    scale: Literal["area", "count", "width"] | None = None,
+    scale: DensityNorm | Empty = _empty,
 ):
     """\
     Plot ranking of genes for all tested comparisons.

--- a/src/scanpy/plotting/_utils.py
+++ b/src/scanpy/plotting/_utils.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import collections.abc as cabc
 import warnings
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Callable, Literal, TypedDict, Union
+from typing import TYPE_CHECKING, Callable, Literal, TypedDict, Union, overload
 
 import matplotlib as mpl
 import numpy as np
@@ -19,7 +19,7 @@ from matplotlib.patches import Circle
 from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
-from .._utils import NeighborsView
+from .._utils import NeighborsView, _empty
 from . import palettes
 
 if TYPE_CHECKING:
@@ -31,6 +31,8 @@ if TYPE_CHECKING:
     from matplotlib.typing import MarkerType
     from numpy.typing import ArrayLike
     from PIL.Image import Image
+
+    from .._utils import Empty
 
     # TODO: more
     DensityNorm = Literal["area", "count", "width"]
@@ -1309,10 +1311,31 @@ def check_colornorm(vmin=None, vmax=None, vcenter=None, norm=None):
     return norm
 
 
+@overload
 def _deprecated_scale(
-    density_norm: DensityNorm, scale: DensityNorm | None, *, default: DensityNorm
-) -> DensityNorm:
-    if scale is None:
+    density_norm: DensityNorm,
+    scale: DensityNorm | Empty,
+    *,
+    default: DensityNorm,
+) -> DensityNorm: ...
+
+
+@overload
+def _deprecated_scale(
+    density_norm: DensityNorm | Empty,
+    scale: DensityNorm | Empty,
+    *,
+    default: DensityNorm | Empty = _empty,
+) -> DensityNorm | Empty: ...
+
+
+def _deprecated_scale(
+    density_norm: DensityNorm | Empty,
+    scale: DensityNorm | Empty,
+    *,
+    default: DensityNorm | Empty = _empty,
+) -> DensityNorm | Empty:
+    if scale is _empty:
         return density_norm
     if density_norm != default:
         msg = "can’t specify both `scale` and `density_norm`"


### PR DESCRIPTION
`sc.pl.violin` and  `sc.pl.stacked_violin` were missed in #2844