### PR TITLE
Fix compat typing and old_positionals usage

### DIFF
--- a/docs/release-notes/3264.bugfix.md
+++ b/docs/release-notes/3264.bugfix.md
@@ -1,0 +1,1 @@
+Switched all compatibility adapters for positional parameters to {exc}`FutureWarning`. {user}`flying-sheep`

--- a/docs/release-notes/3264.bugfix.md
+++ b/docs/release-notes/3264.bugfix.md
@@ -1,1 +1,1 @@
-Switched all compatibility adapters for positional parameters to {exc}`FutureWarning`. {user}`flying-sheep`
+Switched all compatibility adapters for positional parameters to {exc}`FutureWarning` {smaller}`P Angerer`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -259,6 +259,7 @@ required-imports = ["from __future__ import annotations"]
 "pytest.importorskip".msg = "Use the “@needs” decorator/mark instead"
 "pandas.api.types.is_categorical_dtype".msg = "Use isinstance(s.dtype, CategoricalDtype) instead"
 "pandas.value_counts".msg = "Use pd.Series(a).value_counts() instead"
+"legacy_api_wrap.legacy_api".msg = "Use scanpy._compat.old_positionals instead"
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = []
 strict = true

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -3,22 +3,31 @@ from __future__ import annotations
 import sys
 from dataclasses import dataclass, field
 from functools import cache, partial
+from importlib.util import find_spec
 from pathlib import Path
+from typing import TYPE_CHECKING
 
-from legacy_api_wrap import legacy_api
+from legacy_api_wrap import legacy_api  # noqa: TID251
 from packaging.version import Version
 
-try:
+if TYPE_CHECKING:
+    from importlib.metadata import PackageMetadata
+
+
+if TYPE_CHECKING:
+    # type checkers are confused and can only see …core.Array
+    from dask.array.core import Array as DaskArray
+elif find_spec("dask"):
     from dask.array import Array as DaskArray
-except ImportError:
+else:
 
     class DaskArray:
         pass
 
 
-try:
+if find_spec("zappy") or TYPE_CHECKING:
     from zappy.base import ZappyArray
-except ImportError:
+else:
 
     class ZappyArray:
         pass
@@ -60,14 +69,14 @@ else:
             os.chdir(self._old_cwd.pop())
 
 
-def pkg_metadata(package):
+def pkg_metadata(package: str) -> PackageMetadata:
     from importlib.metadata import metadata
 
     return metadata(package)
 
 
 @cache
-def pkg_version(package):
+def pkg_version(package: str) -> Version:
     from importlib.metadata import version
 
     return Version(version(package))

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -7,7 +7,6 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from legacy_api_wrap import legacy_api  # noqa: TID251
 from packaging.version import Version
 
 if TYPE_CHECKING:
@@ -82,4 +81,12 @@ def pkg_version(package: str) -> Version:
     return Version(version(package))
 
 
-old_positionals = partial(legacy_api, category=FutureWarning)
+if find_spec("legacy_api_wrap") or TYPE_CHECKING:
+    from legacy_api_wrap import legacy_api  # noqa: TID251
+
+    old_positionals = partial(legacy_api, category=FutureWarning)
+else:
+    # legacy_api_wrap is currently a hard dependency,
+    # but this code makes it possible to run scanpy without it.
+    def old_positionals(*old_positionals: str):
+        return lambda func: func

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -9,7 +9,6 @@ from warnings import warn
 
 import numpy as np
 import scipy
-from legacy_api_wrap import legacy_api
 from scipy.sparse import issparse
 from sklearn.utils import check_random_state
 
@@ -711,7 +710,7 @@ class Neighbors:
         # else `transformer` is probably an instance
         return conn_method, transformer, shortcut
 
-    @legacy_api("density_normalize")
+    @old_positionals("density_normalize")
     def compute_transitions(self, *, density_normalize: bool = True):
         """\
         Compute transition matrix.

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, NamedTuple
 from warnings import warn
 
 import numpy as np
-from legacy_api_wrap import legacy_api
 from matplotlib import gridspec
 from matplotlib import pyplot as plt
 
@@ -206,7 +205,7 @@ class BasePlot:
         self.ax_dict = None
         self.ax = ax
 
-    @legacy_api("swap_axes")
+    @old_positionals("swap_axes")
     def swap_axes(self, *, swap_axes: bool | None = True) -> Self:
         """
         Plots a transposed image.
@@ -234,7 +233,7 @@ class BasePlot:
         self.are_axes_swapped = swap_axes
         return self
 
-    @legacy_api("show", "dendrogram_key", "size")
+    @old_positionals("show", "dendrogram_key", "size")
     def add_dendrogram(
         self,
         *,
@@ -321,7 +320,7 @@ class BasePlot:
         }
         return self
 
-    @legacy_api("show", "sort", "size", "color")
+    @old_positionals("show", "sort", "size", "color")
     def add_totals(
         self,
         *,

--- a/src/scanpy/plotting/_preprocessing.py
+++ b/src/scanpy/plotting/_preprocessing.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import numpy as np
 import pandas as pd
 from anndata import AnnData
-from legacy_api_wrap import legacy_api
 from matplotlib import pyplot as plt
 from matplotlib import rcParams
 
@@ -104,7 +103,7 @@ def highly_variable_genes(
 
 
 # backwards compat
-@legacy_api("log", "show", "save")
+@old_positionals("log", "show", "save")
 def filter_genes_dispersion(
     result: np.recarray,
     *,

--- a/src/scanpy/preprocessing/_deprecated/__init__.py
+++ b/src/scanpy/preprocessing/_deprecated/__init__.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import numpy as np
-from legacy_api_wrap import legacy_api
 from scipy.sparse import csr_matrix, issparse
 
+from ..._compat import old_positionals
 
-@legacy_api("max_fraction", "mult_with_mean")
+
+@old_positionals("max_fraction", "mult_with_mean")
 def normalize_per_cell_weinreb16_deprecated(
     x: np.ndarray,
     *,

--- a/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -6,10 +6,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 from anndata import AnnData
-from legacy_api_wrap import legacy_api
 from scipy.sparse import issparse
 
 from ... import logging as logg
+from ..._compat import old_positionals
 from .._distributed import materialize_as_ndarray
 from .._utils import _get_mean_var
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from scipy.sparse import spmatrix
 
 
-@legacy_api(
+@old_positionals(
     "flavor",
     "min_disp",
     "max_disp",

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -13,7 +13,6 @@ import numba
 import numpy as np
 import scipy as sp
 from anndata import AnnData
-from legacy_api_wrap import legacy_api
 from pandas.api.types import CategoricalDtype
 from scipy.sparse import csr_matrix, issparse, isspmatrix_csr, spmatrix
 from sklearn.utils import check_array, sparsefuncs
@@ -474,7 +473,7 @@ def sqrt(
         return X.sqrt()
 
 
-@legacy_api(
+@old_positionals(
     "counts_per_cell_after",
     "counts_per_cell",
     "key_n_counts",

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -576,7 +576,11 @@ def normalize_per_cell(
             adata.obs[key_n_counts] = counts_per_cell
             adata._inplace_subset_obs(cell_subset)
             counts_per_cell = counts_per_cell[cell_subset]
-        normalize_per_cell(adata.X, counts_per_cell_after, counts_per_cell)
+        normalize_per_cell(
+            adata.X,
+            counts_per_cell_after=counts_per_cell_after,
+            counts_per_cell=counts_per_cell,
+        )
 
         layers = adata.layers.keys() if layers == "all" else layers
         if use_rep == "after":

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -20,7 +20,6 @@ from anndata import (
     read_mtx,
     read_text,
 )
-from legacy_api_wrap import legacy_api
 from matplotlib.image import imread
 
 from . import logging as logg
@@ -673,7 +672,7 @@ def write(
 # -------------------------------------------------------------------------------
 
 
-@legacy_api("as_header")
+@old_positionals("as_header")
 def read_params(
     filename: Path | str, *, as_header: bool = False
 ) -> dict[str, int | float | bool | str | None]:

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -153,7 +153,7 @@ def ingest(
             ing.map_labels(col, labeling_method[i])
 
     logg.info("    finished", time=start)
-    return ing.to_adata(inplace)
+    return ing.to_adata(inplace=inplace)
 
 
 def _rp_forest_generate(

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-from legacy_api_wrap import legacy_api
 from packaging.version import Version
 from scipy.sparse import issparse
 from sklearn.utils import check_random_state
@@ -464,7 +463,7 @@ class Ingest:
         else:
             raise NotImplementedError("Ingest supports knn labeling for now.")
 
-    @legacy_api("inplace")
+    @old_positionals("inplace")
     def to_adata(self, *, inplace: bool = False) -> AnnData | None:
         """\
         Returns `adata_new` with mapped embeddings and labels.


### PR DESCRIPTION
This PR overhauls the `_compat` submodule

1. it fixes the typing exactly like scverse/anndata#1692
2. it switches all functions and methods to a `legacy_api` wrapper that raises a `FutureWarning`, and paves the way for a potential making-optional of `legacy-api-wrap`