### PR TITLE
(fix): correct anndata release for `io` usage

### DIFF
--- a/src/scanpy/__init__.py
+++ b/src/scanpy/__init__.py
@@ -33,7 +33,7 @@ set_figure_params = settings.set_figure_params
 
 import anndata
 
-if Version(anndata.__version__) >= Version("0.11.0rc0"):
+if Version(anndata.__version__) >= Version("0.11.0rc2"):
     from anndata.io import (
         read_csv,
         read_excel,

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -12,7 +12,7 @@ import numpy as np
 import pandas as pd
 from packaging.version import Version
 
-if Version(anndata.__version__) >= Version("0.11.0rc0"):
+if Version(anndata.__version__) >= Version("0.11.0rc2"):
     from anndata.io import (
         read_csv,
         read_excel,

--- a/src/testing/scanpy/_pytest/fixtures/data.py
+++ b/src/testing/scanpy/_pytest/fixtures/data.py
@@ -17,7 +17,7 @@ if Version(anndata_version) >= Version("0.10.0"):
         BaseCompressedSparseDataset as SparseDataset,
     )
 
-    if Version(anndata_version) >= Version("0.11.0rc0"):
+    if Version(anndata_version) >= Version("0.11.0rc2"):
         from anndata.io import sparse_dataset
     else:
         from anndata.experimental import sparse_dataset


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] See https://anndata.readthedocs.io/en/latest/release-notes/index.html#rc2-2024-09-24, introduced by #3289.  This `io` package did not exist previously
- [x] Tests included or not required because: Tested locally, no way to really test this
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: This is a bug fix of a warning suppression
