### PR TITLE
(fix): clarify sparse pca usage

### DIFF
--- a/docs/release-notes/3267.feature.md
+++ b/docs/release-notes/3267.feature.md
@@ -1,1 +1,1 @@
-Use upstreamed {class}`~sklearn.decomposition.PCA` implementation for {class}`~scipy.sparse.sparray` and {class}`~scipy.sparse.spmatrix` (see {ref}`sklearn:changes_1_4`) {smaller}`P Angerer`
+Use upstreamed {class}`~sklearn.decomposition.PCA` implementation for {class}`~scipy.sparse.csr_array` and {class}`~scipy.sparse.csr_matrix` (see {ref}`sklearn:changes_1_4`) {smaller}`P Angerer`

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -125,6 +125,7 @@ def pca(
             Not available with *dask* arrays.
         `'covariance_eigh'`
             Classic eigendecomposition of the covariance matrix, suited for tall-and-skinny matrices.
+            With dask, array must be CSR and chunked as (N, adata.shape[1]).
         `'randomized'`
             for the randomized algorithm due to Halko (2009). For *dask* arrays,
             this will use :func:`~dask.array.linalg.svd_compressed`.

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -50,14 +50,14 @@ class PCASparseDask:
         """
         if x._meta.format != "csr":
             msg = (
-                "Only dask arrays with CSR-meta format are supported."
-                f" Got {x._meta.format} as meta."
+                "Only dask arrays with CSR-meta format are supported. "
+                f"Got {x._meta.format} as meta."
             )
             raise ValueError(msg)
         if x.chunksize[1] != x.shape[1]:
             msg = (
-                "Only dask arrays with chunking along the first axis are supported."
-                f" Got chunksize {x.chunksize} with shape {x.shape}."
+                "Only dask arrays with chunking along the first axis are supported. "
+                f"Got chunksize {x.chunksize} with shape {x.shape}. "
                 "Rechunking should be simple and cost nothing from AnnData's on-disk format the on-disk layout has this chunking."
             )
             raise ValueError(msg)

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -58,7 +58,7 @@ class PCASparseDask:
             msg = (
                 "Only dask arrays with chunking along the first axis are supported. "
                 f"Got chunksize {x.chunksize} with shape {x.shape}. "
-                "Rechunking should be simple and cost nothing from AnnData's on-disk format the on-disk layout has this chunking."
+                "Rechunking should be simple and cost nothing from AnnData's on-disk format when the on-disk layout has this chunking."
             )
             raise ValueError(msg)
         self.__class__ = PCASparseDaskFit

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -56,7 +56,7 @@ class PCASparseDask:
             raise ValueError(msg)
         if x.chunksize[1] != x.shape[1]:
             msg = (
-                "Only dask arrays with chunking along the first axis format are supported."
+                "Only dask arrays with chunking along the first axis are supported."
                 f" Got chunksize {x.chunksize} with shape {x.shape}."
                 "Rechunking should be simple and cost nothing from AnnData's on-disk format the on-disk layout has this chunking."
             )

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -48,6 +48,19 @@ class PCASparseDask:
         >>> pca_fit.transform(x)
         dask.array<transform_block, shape=(100, 100), dtype=float32, chunksize=(10, 100), chunktype=numpy.ndarray>
         """
+        if x._meta.format != "csr":
+            msg = (
+                "Only dask arrays with CSR-meta format are supported."
+                f" Got {x._meta.format} as meta."
+            )
+            raise ValueError(msg)
+        if x.chunksize[1] != x.shape[1]:
+            msg = (
+                "Only dask arrays with chunking along the first axis format are supported."
+                f" Got chunksize {x.chunksize} with shape {x.shape}."
+                "Rechunking should be simple and cost nothing from AnnData's on-disk format the on-disk layout has this chunking."
+            )
+            raise ValueError(msg)
         self.__class__ = PCASparseDaskFit
         self = cast(PCASparseDaskFit, self)
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

This PR clarifies the docs/handling to make it clear we _only_ support this for correctly chunked CSR-dask.  I think that not handling the other case is fine for a few reasons:

1. CSC chunking would basically require multiple passes at the data.  Every chunk (of size `(adata.shape[0], N)`) would need to be `X.T @ Y`-ed over the entire matrix where `X` is the chunk and `Y` is any given column-chunk from the matrix.  I can't think of a way around this
2. Given the above, I don't think there is any reason why we should implement this algorithm.  People should just re-write their data to disk as CSR.  I can't imagine its worse than this modulo the fact that you need to load the whole matrix into memory.  This might be a good reason to change our on-disk format but at the moment, this is about all I think we should do.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Just remembered that this fact needs to be stated clearly.  @Intron7 please update the RSC PR as well if you haven't already!
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: edited
