### PR TITLE
Move PSE outside try except

### DIFF
--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -753,8 +753,9 @@ def _regress_out_chunk(data):
             regres = np.c_[np.ones(regressors.shape[0]), regressors[:, col_index]]
         else:
             regres = regressors
+
+        err_classes = (sme.PerfectSeparationError,)
         try:
-            err_classes = (sme.PerfectSeparationError,)
             with warnings.catch_warnings():
                 if hasattr(sme, "PerfectSeparationWarning"):
                     # See issue #3260 - for statsmodels>=0.14.0


### PR DESCRIPTION
Follow up to https://github.com/scverse/scanpy/pull/3275#pullrequestreview-2392213666

I think that this woulda worked regardless because the `try` will define it initially anyways. However, it's best practice to only have code that can error in the `try` statement.

I'll allow myself to skip a release note etc because this is minor and there hasn't been a release yet with this fix.