### PR TITLE
Change default matplotlib.rcParams["axes.grid"] from True to False

### DIFF
--- a/src/scanpy/plotting/_rcmod.py
+++ b/src/scanpy/plotting/_rcmod.py
@@ -61,7 +61,7 @@ def set_rcParams_scanpy(fontsize=14, color_map=None):
     rcParams["ytick.labelsize"] = fontsize
 
     # axes grid
-    rcParams["axes.grid"] = True
+    rcParams["axes.grid"] = False
     rcParams["grid.color"] = ".8"
 
     # color map


### PR DESCRIPTION
# Description

When creating heatmaps, matrices, and various graphs using large datasets with seaborn, `scanpy.set_figure_params()` provides helpful default configurations for the plot. However, one default, caused by `matplotlib.rcParams["axes.grid"] = True`, provides no benefit to the vast majority of plots, making them unreadable and confusing (especially with very large plots). Below is a simple example; evidently, the distortion increases with graph complexity.

# Images
### Graph with default grid:
<img width="500" alt="graph_with_grid" src="https://github.com/user-attachments/assets/9b7751e6-7a6e-4b9e-b536-efd926fff6e4"><br>
### Graph without default grid:
<img width="500" alt="graph_without_grid" src="https://github.com/user-attachments/assets/d801b1b1-b4be-47f7-9630-da694b781f08">

# Conclusion
This change simply modifies `matplotlib.rcParams["axes.grid"]` from `True` to `False`, not affecting any other components of the module. We believe this adjusted default would benefit the majority of graphs compared to the original. If one would like to use the grid lines for any reason (which we believe is a niche use case), they may run `matplotlib.pyplot.rcParams["axes.grid"] = True`.