### PR TITLE
(chore): generate 1.10.4 release notes

### DIFF
--- a/ci/scripts/min-deps.py
+++ b/ci/scripts/min-deps.py
@@ -1,4 +1,11 @@
 #!/usr/bin/env python3
+# /// script
+# dependencies = [
+#   "tomli; python_version < '3.11'",
+#   "packaging",
+# ]
+# ///
+
 from __future__ import annotations
 
 import argparse
@@ -33,12 +40,15 @@ def min_dep(req: Requirement) -> Requirement:
     if req.extras:
         req_name = f"{req_name}[{','.join(req.extras)}]"
 
-    if not req.specifier:
+    filter_specs = [
+        spec for spec in req.specifier if spec.operator in {"==", "~=", ">=", ">"}
+    ]
+    if not filter_specs:
         return Requirement(req_name)
 
     min_version = Version("0.0.0.a1")
-    for spec in req.specifier:
-        if spec.operator in [">", ">=", "~="]:
+    for spec in filter_specs:
+        if spec.operator in {">", ">=", "~="}:
             min_version = max(min_version, Version(spec.version))
         elif spec.operator == "==":
             min_version = Version(spec.version)

--- a/docs/release-notes/1.10.4.md
+++ b/docs/release-notes/1.10.4.md
@@ -1,0 +1,17 @@
+(v1.10.4)=
+### 1.10.4 {small}`2024-11-12`
+
+### Breaking changes
+
+- Remove Python 3.9 support {smaller}`P Angerer` ({pr}`3283`)
+
+### Bug fixes
+
+- Fix {meth}`scanpy.pl.DotPlot.style`, {meth}`scanpy.pl.MatrixPlot.style`, and {meth}`scanpy.pl.StackedViolin.style` resetting all non-specified parameters {smaller}`P Angerer` ({pr}`3206`)
+- Accept `'group'` instead of `'obs'` for `standard_scale` parameter in {func}`~scanpy.pl.stacked_violin` {smaller}`P Angerer` ({pr}`3243`)
+- Use `density_norm` instead of of `scale` (cont. from {pr}`2844`) in {func}`~scanpy.pl.violin` and {func}`~scanpy.pl.stacked_violin` {smaller}`P Angerer` ({pr}`3244`)
+- Switched all compatibility adapters for positional parameters to {exc}`FutureWarning` {smaller}`P Angerer` ({pr}`3264`)
+- Catch `PerfectSeparationWarning` during {func}`~scanpy.pp.regress_out` {smaller}`J Wagner` ({pr}`3275`)
+- Fix {func}`scanpy.pp.highly_variable_genes` for batches of size 1 {smaller}`P Angerer` ({pr}`3286`)
+- Fix {func}`scanpy.pl.scatter`’s `color` parameter to take collections as advertised {smaller}`P Angerer` ({pr}`3299`)
+- Fix {func}`scanpy.pl.highest_expr_genes` when used with a categorical gene symbol column {smaller}`P Angerer` ({pr}`3302`)

--- a/docs/release-notes/3206.bugfix.md
+++ b/docs/release-notes/3206.bugfix.md
@@ -1,1 +1,0 @@
-Fix {meth}`scanpy.pl.DotPlot.style`, {meth}`scanpy.pl.MatrixPlot.style`, and {meth}`scanpy.pl.StackedViolin.style` resetting all non-specified parameters {smaller}`P Angerer`

--- a/docs/release-notes/3243.bugfix.md
+++ b/docs/release-notes/3243.bugfix.md
@@ -1,1 +1,0 @@
-Accept `'group'` instead of `'obs'` for `standard_scale` parameter in {func}`~scanpy.pl.stacked_violin` {smaller}`P Angerer`

--- a/docs/release-notes/3244.bugfix.md
+++ b/docs/release-notes/3244.bugfix.md
@@ -1,1 +1,0 @@
-Use `density_norm` instead of of `scale` (cont. from {pr}`2844`) in {func}`~scanpy.pl.violin` and {func}`~scanpy.pl.stacked_violin` {smaller}`P Angerer`

--- a/docs/release-notes/3264.bugfix.md
+++ b/docs/release-notes/3264.bugfix.md
@@ -1,1 +1,0 @@
-Switched all compatibility adapters for positional parameters to {exc}`FutureWarning` {smaller}`P Angerer`

--- a/docs/release-notes/3275.bugfix.md
+++ b/docs/release-notes/3275.bugfix.md
@@ -1,1 +1,0 @@
-Catch `PerfectSeparationWarning` during {func}`~scanpy.pp.regress_out` {smaller}`J Wagner`

--- a/docs/release-notes/3283.breaking.md
+++ b/docs/release-notes/3283.breaking.md
@@ -1,1 +1,0 @@
-Remove Python 3.9 support {smaller}`P Angerer`

--- a/docs/release-notes/3286.bugfix.md
+++ b/docs/release-notes/3286.bugfix.md
@@ -1,1 +1,0 @@
-Fix {func}`scanpy.pp.highly_variable_genes` for batches of size 1 {smaller}`P Angerer`

--- a/docs/release-notes/3299.bugfix.md
+++ b/docs/release-notes/3299.bugfix.md
@@ -1,1 +1,0 @@
-Fix {func}`scanpy.pl.scatter`’s `color` parameter to take collections as advertised {smaller}`P Angerer`

--- a/docs/release-notes/3302.bugfix.md
+++ b/docs/release-notes/3302.bugfix.md
@@ -1,1 +1,0 @@
-Fix {func}`scanpy.pl.highest_expr_genes` when used with a categorical gene symbol column {smaller}`P Angerer`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
     "h5py>=3.6",
     "tqdm",
     "scikit-learn>=1.1",
-    "statsmodels>=0.13", # https://github.com/pydata/patsy/issues/215
-    "patsy!=1.0.0",
+    "statsmodels>=0.13",
+    "patsy!=1.0.0", # https://github.com/pydata/patsy/issues/215
     "networkx>=2.7",
     "natsort",
     "joblib",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ dependencies = [
     "h5py>=3.6",
     "tqdm",
     "scikit-learn>=1.1",
-    "statsmodels>=0.13",
-    "patsy",
+    "statsmodels>=0.13", # https://github.com/pydata/patsy/issues/215
+    "patsy!=1.0.0",
     "networkx>=2.7",
     "natsort",
     "joblib",
@@ -66,7 +66,6 @@ dependencies = [
     "packaging>=21.3",
     "session-info",
     "legacy-api-wrap>=1.4",  # for positional API deprecations
-    "get-annotations; python_version < '3.10'",
 ]
 dynamic = ["version"]
 
@@ -124,7 +123,7 @@ doc = [
     "ipython>=7.20",  # for nbsphinx code highlighting
     "matplotlib!=3.6.1",
     "sphinxcontrib-bibtex",
-    "setuptools",
+    "setuptools", # undeclared dependency of sphinxcontrib-bibtex→pybtex
     # TODO: remove necessity for being able to import doc-linked classes
     "dask",
     "scanpy[paga]",


### PR DESCRIPTION
Making a release because of the `anndata.io` compat fix in #3289

Also
- pins `patsy!=1.0.0` because of https://github.com/pydata/patsy/issues/215
- fixes `ci/scripts/min-deps.py` to handle deps with just an `!=` dependency spec
- removes the `get-annotations; python_version < '3.10'` dependency since we missed that in #3283

@meeseeksmachine backport to main