### PR TITLE
Updated Harmony Integrate Docs to better match interface to Harmonypy package

### DIFF
--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 @doctest_needs("harmonypy")
 def harmony_integrate(
     adata: AnnData,
-    key: str,
+    key: str | Sequence[str],
     *,
     basis: str = "X_pca",
     adjusted_basis: str = "X_pca_harmony",
@@ -42,7 +42,9 @@ def harmony_integrate(
         The annotated data matrix.
     key
         The name of the column in ``adata.obs`` that differentiates
-        among experiments/batches.
+        among experiments/batches. To integrate over two or more covariates, 
+        you can pass multiple column names as a list. See ``vars_use`` 
+        parameter of the ``harmonypy`` pacakage for more details.
     basis
         The name of the field in ``adata.obsm`` where the PCA table is
         stored. Defaults to ``'X_pca'``, which is the default for


### PR DESCRIPTION
Fixed harmony documentation where a crucial feature of Harmony, namely the integration w.r.t. multiple covariates was not mentioned despite being supported by the interface. Harmony can take strings and lists of strings as its "vars_use" parameter which is named "key" in the Scanpy interface.

- [ ] Closes #
- [X] Tests included or not required because:
Small non-breaking change to docs
- [X Release notes not necessary because:
Change docs to better reflect current code behaviour/features