### PR TITLE
Updated Harmony Integrate Docs to better match interface to Harmonypy package

### DIFF
--- a/docs/release-notes/3362.doc.md
+++ b/docs/release-notes/3362.doc.md
@@ -1,0 +1,1 @@
+Improve {func}`~scanpy.external.pp.harmony_integrate` docs {smaller}`D Kühl`

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -44,8 +44,8 @@ def harmony_integrate(
         The annotated data matrix.
     key
         The name of the column in ``adata.obs`` that differentiates
-        among experiments/batches. To integrate over two or more covariates, 
-        you can pass multiple column names as a list. See ``vars_use`` 
+        among experiments/batches. To integrate over two or more covariates,
+        you can pass multiple column names as a list. See ``vars_use``
         parameter of the ``harmonypy`` package for more details.
     basis
         The name of the field in ``adata.obsm`` where the PCA table is

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -4,7 +4,7 @@ Use harmony to integrate cells from different experiments.
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Sequence # noqa: TCH003
 
 from typing import TYPE_CHECKING
 

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -46,7 +46,7 @@ def harmony_integrate(
         The name of the column in ``adata.obs`` that differentiates
         among experiments/batches. To integrate over two or more covariates, 
         you can pass multiple column names as a list. See ``vars_use`` 
-        parameter of the ``harmonypy`` pacakage for more details.
+        parameter of the ``harmonypy`` package for more details.
     basis
         The name of the field in ``adata.obsm`` where the PCA table is
         stored. Defaults to ``'X_pca'``, which is the default for

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 @doctest_needs("harmonypy")
 def harmony_integrate(
     adata: AnnData,
-    key: str,
+    key: str | Sequence[str],
     *,
     basis: str = "X_pca",
     adjusted_basis: str = "X_pca_harmony",
@@ -42,7 +42,9 @@ def harmony_integrate(
         The annotated data matrix.
     key
         The name of the column in ``adata.obs`` that differentiates
-        among experiments/batches.
+        among experiments/batches. To integrate over two or more covariates, 
+        you can pass multiple column names as a list. See ``vars_use`` 
+        parameter of the ``harmonypy`` pacakage for more details.
     basis
         The name of the field in ``adata.obsm`` where the PCA table is
         stored. Defaults to ``'X_pca'``, which is the default for

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -4,8 +4,7 @@ Use harmony to integrate cells from different experiments.
 
 from __future__ import annotations
 
-from collections.abc import Sequence # noqa: TCH003
-
+from collections.abc import Sequence  # noqa: TCH003
 from typing import TYPE_CHECKING
 
 import numpy as np

--- a/src/scanpy/external/pp/_harmony_integrate.py
+++ b/src/scanpy/external/pp/_harmony_integrate.py
@@ -4,6 +4,8 @@ Use harmony to integrate cells from different experiments.
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 from typing import TYPE_CHECKING
 
 import numpy as np


### PR DESCRIPTION
Fixed harmony documentation where a crucial feature of Harmony, namely the integration w.r.t. multiple covariates was not mentioned despite being supported by the interface. Harmony can take strings and lists of strings as its "vars_use" parameter which is named "key" in the Scanpy interface.

- [ ] Closes #
- [X] Tests included or not required because:

Small non-breaking change to docs. However, pre-commit throws: 
```
ruff.....................................................................Failed
- hook id: ruff
- files were modified by this hook
```
Will wait if some maintainer know an easy fix for this before trying to debug this myself. Guess its more related to incorrect flags somewhere than the code.
- [X] Release notes not necessary because:
Change docs to better reflect current code behaviour/features