### PR TITLE
Replace spmatrix with _CSMatrix as appropriate

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,9 +227,6 @@ nitpick_ignore = [
     ("py:class", "scanpy._utils.Empty"),
     ("py:class", "numpy.random.mtrand.RandomState"),
     ("py:class", "scanpy.neighbors._types.KnnTransformerLike"),
-    # Will work once scipy 1.8 is released
-    ("py:class", "scipy.sparse.base.spmatrix"),
-    ("py:class", "scipy.sparse.csr.csr_matrix"),
 ]
 
 # Options for plot examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ test = [
     "scanpy[test-min]",
     # Optional but important dependencies
     "scanpy[leiden]",
-    "zarr",
+    "zarr<3",
     "scanpy[dask]",
     "scanpy[scrublet]",
 ]

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -841,7 +841,8 @@ def check_nonnegative_integers(X: _SupportedArray) -> bool | DaskArray:
 
 
 @check_nonnegative_integers.register(np.ndarray)
-@check_nonnegative_integers.register(sparse.spmatrix)
+@check_nonnegative_integers.register(sparse.csr_matrix)
+@check_nonnegative_integers.register(sparse.csc_matrix)
 def _check_nonnegative_integers_in_mem(X: _MemoryArray) -> bool:
     from numbers import Integral
 

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -629,14 +629,14 @@ def axis_mul_or_truediv(
 @axis_mul_or_truediv.register(sparse.csr_matrix)
 @axis_mul_or_truediv.register(sparse.csc_matrix)
 def _(
-    X: sparse.csr_matrix | sparse.csc_matrix,
+    X: _CSMatrix,
     scaling_array,
     axis: Literal[0, 1],
     op: Callable[[Any, Any], Any],
     *,
     allow_divide_by_zero: bool = True,
-    out: sparse.csr_matrix | sparse.csc_matrix | None = None,
-) -> sparse.csr_matrix | sparse.csc_matrix:
+    out: _CSMatrix | None = None,
+) -> _CSMatrix:
     check_op(op)
     if out is not None and X.data is not out.data:
         raise ValueError(

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     from typing import Any, TypeVar
 
     from anndata import AnnData
+    from igraph import Graph
     from numpy.typing import ArrayLike, DTypeLike, NDArray
 
     from .._compat import _LegacyRandom
@@ -285,7 +286,7 @@ def _check_use_raw(
 # --------------------------------------------------------------------------------
 
 
-def get_igraph_from_adjacency(adjacency, directed=None):
+def get_igraph_from_adjacency(adjacency: _CSMatrix, *, directed: bool = False) -> Graph:
     """Get igraph graph from adjacency matrix."""
     import igraph as ig
 
@@ -1136,8 +1137,10 @@ class NeighborsView:
             return key in self._neighbors_dict
 
 
-def _choose_graph(adata, obsp, neighbors_key):
-    """Choose connectivities from neighbbors or another obsp column"""
+def _choose_graph(
+    adata: AnnData, obsp: str | None, neighbors_key: str | None
+) -> _CSMatrix:
+    """Choose connectivities from neighbbors or another obsp entry."""
     if obsp is not None and neighbors_key is not None:
         raise ValueError(
             "You can't specify both obsp, neighbors_key. Please select only one."
@@ -1145,13 +1148,13 @@ def _choose_graph(adata, obsp, neighbors_key):
 
     if obsp is not None:
         return adata.obsp[obsp]
-    else:
-        neighbors = NeighborsView(adata, neighbors_key)
-        if "connectivities" not in neighbors:
-            raise ValueError(
-                "You need to run `pp.neighbors` first to compute a neighborhood graph."
-            )
-        return neighbors["connectivities"]
+
+    neighbors = NeighborsView(adata, neighbors_key)
+    if "connectivities" not in neighbors:
+        raise ValueError(
+            "You need to run `pp.neighbors` first to compute a neighborhood graph."
+        )
+    return neighbors["connectivities"]
 
 
 def _resolve_axis(

--- a/src/scanpy/_utils/compute/is_constant.py
+++ b/src/scanpy/_utils/compute/is_constant.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-from collections.abc import Callable
 from functools import partial, singledispatch, wraps
 from numbers import Integral
-from typing import TYPE_CHECKING, TypeVar, overload
+from typing import TYPE_CHECKING, overload
 
 import numba
 import numpy as np
@@ -12,11 +11,15 @@ from scipy import sparse
 from ..._compat import DaskArray, njit
 
 if TYPE_CHECKING:
-    from typing import Literal
+    from collections.abc import Callable
+    from typing import Literal, TypeVar
 
     from numpy.typing import NDArray
 
-C = TypeVar("C", bound=Callable)
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    _Array = NDArray | DaskArray | _CSMatrix
+
+    C = TypeVar("C", bound=Callable)
 
 
 def _check_axis_supported(wrapped: C) -> C:
@@ -33,11 +36,9 @@ def _check_axis_supported(wrapped: C) -> C:
 
 
 @overload
-def is_constant(a: NDArray, axis: None = None) -> bool: ...
-
-
+def is_constant(a: _Array, axis: None = None) -> bool: ...
 @overload
-def is_constant(a: NDArray, axis: Literal[0, 1]) -> NDArray[np.bool_]: ...
+def is_constant(a: _Array, axis: Literal[0, 1]) -> NDArray[np.bool_]: ...
 
 
 @_check_axis_supported

--- a/src/scanpy/_utils/compute/is_constant.py
+++ b/src/scanpy/_utils/compute/is_constant.py
@@ -16,7 +16,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import NDArray
 
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    from ..._utils import _CSMatrix
+
     _Array = NDArray | DaskArray | _CSMatrix
 
     C = TypeVar("C", bound=Callable)

--- a/src/scanpy/external/tl/_harmony_timeseries.py
+++ b/src/scanpy/external/tl/_harmony_timeseries.py
@@ -76,9 +76,9 @@ def harmony_timeseries(
 
     **X_harmony** - :class:`~numpy.ndarray` (:attr:`~anndata.AnnData.obsm`, dtype `float`)
         force directed layout
-    **harmony_aff** - :class:`~scipy.sparse.spmatrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
+    **harmony_aff** - :class:`~scipy.sparse.csr_matrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
         affinity matrix
-    **harmony_aff_aug** - :class:`~scipy.sparse.spmatrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
+    **harmony_aff_aug** - :class:`~scipy.sparse.csr_matrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
         augmented affinity matrix
     **harmony_timepoint_var** - `str` (:attr:`~anndata.AnnData.uns`)
         The name of the variable passed as `tp`

--- a/src/scanpy/external/tl/_palantir.py
+++ b/src/scanpy/external/tl/_palantir.py
@@ -94,7 +94,7 @@ def palantir(
             Array of Diffusion components.
         - palantir_EigenValues - :class:`~numpy.ndarray` (:attr:`~anndata.AnnData.uns`, dtype `float`)
             Array of corresponding eigen values.
-        - palantir_diff_op - :class:`~scipy.sparse.spmatrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
+        - palantir_diff_op - :class:`~scipy.sparse.csr_matrix` (:attr:`~anndata.AnnData.obsp`, dtype `float`)
             The diffusion operator matrix.
 
     **Multi scale space results**,

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -333,9 +333,10 @@ def aggregate_df(data, by, func, *, mask=None, dof=1):
 
 
 @_aggregate.register(np.ndarray)
-@_aggregate.register(sparse.spmatrix)
+@_aggregate.register(sparse.csr_matrix)
+@_aggregate.register(sparse.csc_matrix)
 def aggregate_array(
-    data,
+    data: Array,
     by: pd.Categorical,
     func: AggType | Iterable[AggType],
     *,

--- a/src/scanpy/get/get.py
+++ b/src/scanpy/get/get.py
@@ -9,7 +9,7 @@ import pandas as pd
 from anndata import AnnData
 from numpy.typing import NDArray
 from packaging.version import Version
-from scipy.sparse import spmatrix
+from scipy.sparse import csc_matrix, csr_matrix
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
@@ -17,11 +17,11 @@ if TYPE_CHECKING:
 
     from anndata._core.sparse_dataset import BaseCompressedSparseDataset
     from anndata._core.views import ArrayView
-    from scipy.sparse import csc_matrix, csr_matrix
 
     from .._compat import DaskArray
 
-    CSMatrix = csr_matrix | csc_matrix
+
+_CSMatrix = csr_matrix | csc_matrix
 
 # --------------------------------------------------------------------------------
 # Plotting data helpers
@@ -333,7 +333,7 @@ def obs_df(
         val = adata.obsm[k]
         if isinstance(val, np.ndarray):
             df[added_k] = np.ravel(val[:, idx])
-        elif isinstance(val, spmatrix):
+        elif isinstance(val, _CSMatrix):
             df[added_k] = np.ravel(val[:, idx].toarray())
         elif isinstance(val, pd.DataFrame):
             df[added_k] = val.loc[:, idx]
@@ -403,7 +403,7 @@ def var_df(
         val = adata.varm[k]
         if isinstance(val, np.ndarray):
             df[added_k] = np.ravel(val[:, idx])
-        elif isinstance(val, spmatrix):
+        elif isinstance(val, _CSMatrix):
             df[added_k] = np.ravel(val[:, idx].toarray())
         elif isinstance(val, pd.DataFrame):
             df[added_k] = val.loc[:, idx]
@@ -419,7 +419,7 @@ def _get_obs_rep(
     obsp: str | None = None,
 ) -> (
     np.ndarray
-    | spmatrix
+    | _CSMatrix
     | pd.DataFrame
     | ArrayView
     | BaseCompressedSparseDataset
@@ -494,7 +494,7 @@ M = TypeVar("M", bound=NDArray[np.bool_] | NDArray[np.floating] | pd.Series | No
 
 
 def _check_mask(
-    data: AnnData | np.ndarray | CSMatrix | DaskArray,
+    data: AnnData | np.ndarray | _CSMatrix | DaskArray,
     mask: str | M,
     dim: Literal["obs", "var"],
     *,

--- a/src/scanpy/get/get.py
+++ b/src/scanpy/get/get.py
@@ -9,7 +9,8 @@ import pandas as pd
 from anndata import AnnData
 from numpy.typing import NDArray
 from packaging.version import Version
-from scipy.sparse import csc_matrix, csr_matrix
+
+from .._utils import _CSMatrix
 
 if TYPE_CHECKING:
     from collections.abc import Collection, Iterable
@@ -20,8 +21,6 @@ if TYPE_CHECKING:
 
     from .._compat import DaskArray
 
-
-_CSMatrix = csr_matrix | csc_matrix
 
 # --------------------------------------------------------------------------------
 # Plotting data helpers

--- a/src/scanpy/metrics/_common.py
+++ b/src/scanpy/metrics/_common.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import warnings
 from functools import singledispatch
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, overload
 
 import numpy as np
 import pandas as pd
@@ -11,13 +11,24 @@ from scipy import sparse
 from .._compat import DaskArray
 
 if TYPE_CHECKING:
+    from typing import NoReturn, TypeVar
+
     from numpy.typing import NDArray
+
+    T_NonSparse = TypeVar("T_NonSparse", bound=NDArray | DaskArray)
+    V = TypeVar("V", bound=NDArray | sparse.csr_matrix)
+
+
+@overload
+def _resolve_vals(val: T_NonSparse) -> T_NonSparse: ...
+@overload
+def _resolve_vals(val: sparse.spmatrix) -> sparse.csr_matrix: ...
+@overload
+def _resolve_vals(val: pd.DataFrame | pd.Series) -> NDArray: ...
 
 
 @singledispatch
-def _resolve_vals(
-    val: NDArray | sparse.spmatrix | DaskArray,
-) -> NDArray | sparse.csr_matrix | DaskArray:
+def _resolve_vals(val: object) -> NoReturn:
     msg = f"Unsupported type {type(val)}"
     raise TypeError(msg)
 
@@ -38,16 +49,11 @@ def _(val: sparse.spmatrix) -> sparse.csr_matrix:
 
 @_resolve_vals.register(pd.DataFrame)
 @_resolve_vals.register(pd.Series)
-def _(val):
+def _(val: pd.DataFrame | pd.Series) -> NDArray:
     return val.to_numpy()
 
 
-V = TypeVar("V", np.ndarray, sparse.csr_matrix)
-
-
-def _check_vals(
-    vals: V,
-) -> tuple[V, NDArray[np.bool_] | slice, NDArray[np.float64]]:
+def _check_vals(vals: V) -> tuple[V, NDArray[np.bool_] | slice, NDArray[np.float64]]:
     """\
     Checks that values wont cause issues in computation.
 

--- a/src/scanpy/metrics/_common.py
+++ b/src/scanpy/metrics/_common.py
@@ -15,19 +15,24 @@ if TYPE_CHECKING:
 
 
 @singledispatch
-def _resolve_vals(val: NDArray | sparse.spmatrix) -> NDArray | sparse.csr_matrix:
-    return np.asarray(val)
+def _resolve_vals(
+    val: NDArray | sparse.spmatrix | DaskArray,
+) -> NDArray | sparse.csr_matrix | DaskArray:
+    msg = f"Unsupported type {type(val)}"
+    raise TypeError(msg)
 
 
 @_resolve_vals.register(np.ndarray)
 @_resolve_vals.register(sparse.csr_matrix)
 @_resolve_vals.register(DaskArray)
-def _(val):
+def _(
+    val: np.ndarray | sparse.csr_matrix | DaskArray,
+) -> np.ndarray | sparse.csr_matrix | DaskArray:
     return val
 
 
 @_resolve_vals.register(sparse.spmatrix)
-def _(val):
+def _(val: sparse.spmatrix) -> sparse.csr_matrix:
     return sparse.csr_matrix(val)
 
 

--- a/src/scanpy/metrics/_gearys_c.py
+++ b/src/scanpy/metrics/_gearys_c.py
@@ -15,13 +15,16 @@ from ._common import _check_vals, _resolve_vals
 
 if TYPE_CHECKING:
     from anndata import AnnData
+    from numpy.typing import NDArray
+
+    from .._compat import DaskArray
 
 
 @singledispatch
 def gearys_c(
     adata: AnnData,
     *,
-    vals: np.ndarray | sparse.spmatrix | None = None,
+    vals: NDArray | sparse.spmatrix | DaskArray | None = None,
     use_graph: str | None = None,
     layer: str | None = None,
     obsm: str | None = None,
@@ -289,7 +292,9 @@ def _gearys_c_mtx_csr(  # noqa: PLR0917
 
 
 @gearys_c.register(sparse.csr_matrix)
-def _gearys_c(g: sparse.csr_matrix, vals: np.ndarray | sparse.spmatrix) -> np.ndarray:
+def _gearys_c(
+    g: sparse.csr_matrix, vals: NDArray | sparse.spmatrix | DaskArray
+) -> np.ndarray:
     assert g.shape[0] == g.shape[1], "`g` should be a square adjacency matrix"
     vals = _resolve_vals(vals)
     g_data = g.data.astype(np.float64, copy=False)

--- a/src/scanpy/metrics/_morans_i.py
+++ b/src/scanpy/metrics/_morans_i.py
@@ -15,13 +15,16 @@ from ._common import _check_vals, _resolve_vals
 
 if TYPE_CHECKING:
     from anndata import AnnData
+    from numpy.typing import NDArray
+
+    from .._compat import DaskArray
 
 
 @singledispatch
 def morans_i(
     adata: AnnData,
     *,
-    vals: np.ndarray | sparse.spmatrix | None = None,
+    vals: NDArray | sparse.spmatrix | DaskArray | None = None,
     use_graph: str | None = None,
     layer: str | None = None,
     obsm: str | None = None,
@@ -225,7 +228,9 @@ def _morans_i_mtx_csr(  # noqa: PLR0917
 
 
 @morans_i.register(sparse.csr_matrix)
-def _morans_i(g: sparse.csr_matrix, vals: np.ndarray | sparse.spmatrix) -> np.ndarray:
+def _morans_i(
+    g: sparse.csr_matrix, vals: NDArray | sparse.spmatrix | DaskArray
+) -> np.ndarray:
     assert g.shape[0] == g.shape[1], "`g` should be a square adjacency matrix"
     vals = _resolve_vals(vals)
     g_data = g.data.astype(np.float64, copy=False)

--- a/src/scanpy/neighbors/_types.py
+++ b/src/scanpy/neighbors/_types.py
@@ -8,7 +8,7 @@ import numpy as np
 if TYPE_CHECKING:
     from typing import Any, Self
 
-    from scipy.sparse import spmatrix
+    from scipy.sparse import csr_matrix
 
 
 # These two are used with get_literal_vals elsewhere
@@ -49,10 +49,10 @@ class KnnTransformerLike(Protocol):
     """See :class:`~sklearn.neighbors.KNeighborsTransformer`."""
 
     def fit(self, X, y: None = None): ...
-    def transform(self, X) -> spmatrix: ...
+    def transform(self, X) -> csr_matrix: ...
 
     # from TransformerMixin
-    def fit_transform(self, X, y: None = None) -> spmatrix: ...
+    def fit_transform(self, X, y: None = None) -> csr_matrix: ...
 
     # from BaseEstimator
     def get_params(self, *, deep: bool = True) -> dict[str, Any]: ...

--- a/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -16,7 +16,9 @@ from .._utils import _get_mean_var
 if TYPE_CHECKING:
     from typing import Literal
 
-    from scipy.sparse import spmatrix
+    from scipy.sparse import csc_matrix, csr_matrix
+
+    _CSMatrix = csr_matrix | csc_matrix
 
 
 @deprecated("Use sc.pp.highly_variable_genes instead")
@@ -33,7 +35,7 @@ if TYPE_CHECKING:
     "copy",
 )
 def filter_genes_dispersion(
-    data: AnnData | spmatrix | np.ndarray,
+    data: AnnData | _CSMatrix | np.ndarray,
     *,
     flavor: Literal["seurat", "cell_ranger"] = "seurat",
     min_disp: float | None = None,

--- a/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -16,9 +16,7 @@ from .._utils import _get_mean_var
 if TYPE_CHECKING:
     from typing import Literal
 
-    from scipy.sparse import csc_matrix, csr_matrix
-
-    _CSMatrix = csr_matrix | csc_matrix
+    from .._utils import _CSMatrix
 
 
 @deprecated("Use sc.pp.highly_variable_genes instead")

--- a/src/scanpy/preprocessing/_deprecated/sampling.py
+++ b/src/scanpy/preprocessing/_deprecated/sampling.py
@@ -9,11 +9,9 @@ if TYPE_CHECKING:
     import numpy as np
     from anndata import AnnData
     from numpy.typing import NDArray
-    from scipy.sparse import csc_matrix, csr_matrix
 
     from ..._compat import _LegacyRandom
-
-    _CSMatrix = csr_matrix | csc_matrix
+    from ..._utils import _CSMatrix
 
 
 @old_positionals("n_obs", "random_state", "copy")

--- a/src/scanpy/preprocessing/_deprecated/sampling.py
+++ b/src/scanpy/preprocessing/_deprecated/sampling.py
@@ -13,18 +13,18 @@ if TYPE_CHECKING:
 
     from ..._compat import _LegacyRandom
 
-    CSMatrix = csr_matrix | csc_matrix
+    _CSMatrix = csr_matrix | csc_matrix
 
 
 @old_positionals("n_obs", "random_state", "copy")
 def subsample(
-    data: AnnData | np.ndarray | CSMatrix,
+    data: AnnData | np.ndarray | _CSMatrix,
     fraction: float | None = None,
     *,
     n_obs: int | None = None,
     random_state: _LegacyRandom = 0,
     copy: bool = False,
-) -> AnnData | tuple[np.ndarray | CSMatrix, NDArray[np.int64]] | None:
+) -> AnnData | tuple[np.ndarray | _CSMatrix, NDArray[np.int64]] | None:
     """\
     Subsample to a fraction of the number of observations.
 

--- a/src/scanpy/preprocessing/_highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_highly_variable_genes.py
@@ -104,7 +104,7 @@ def _highly_variable_genes_seurat_v3(
         vmax = np.sqrt(N)
         clip_val = reg_std * vmax + mean
         if sp_sparse.issparse(data_batch):
-            if sp_sparse.isspmatrix_csr(data_batch):
+            if isinstance(data_batch, sp_sparse.csr_matrix):
                 batch_counts = data_batch
             else:
                 batch_counts = sp_sparse.csr_matrix(data_batch)

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -27,12 +27,9 @@ if TYPE_CHECKING:
     import dask_ml.decomposition as dmld
     import sklearn.decomposition as skld
     from numpy.typing import DTypeLike, NDArray
-    from scipy import sparse
 
     from ..._compat import _LegacyRandom
-    from ..._utils import Empty
-
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    from ..._utils import Empty, _CSMatrix
 
     MethodDaskML = type[dmld.PCA | dmld.IncrementalPCA | dmld.TruncatedSVD]
     MethodSklearn = type[skld.PCA | skld.TruncatedSVD]

--- a/src/scanpy/preprocessing/_pca/_compat.py
+++ b/src/scanpy/preprocessing/_pca/_compat.py
@@ -20,11 +20,11 @@ if TYPE_CHECKING:
 
     from ..._compat import _LegacyRandom
 
-    CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 
 def _pca_compat_sparse(
-    x: CSMatrix,
+    x: _CSMatrix,
     n_pcs: int,
     *,
     solver: Literal["arpack", "lobpcg"],

--- a/src/scanpy/preprocessing/_pca/_compat.py
+++ b/src/scanpy/preprocessing/_pca/_compat.py
@@ -15,12 +15,10 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import NDArray
-    from scipy import sparse
     from sklearn.decomposition import PCA
 
     from ..._compat import _LegacyRandom
-
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    from .._utils import _CSMatrix
 
 
 def _pca_compat_sparse(

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
 
     from ..._compat import DaskArray
 
-    CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 
 @dataclass
@@ -120,7 +120,7 @@ class PCASparseDaskFit(PCASparseDask):
             import dask.array as da
 
         def transform_block(
-            x_part: CSMatrix,
+            x_part: _CSMatrix,
             mean_: NDArray[np.floating],
             components_: NDArray[np.floating],
         ):
@@ -191,8 +191,8 @@ def _cov_sparse_dask(
     else:
         dtype = np.dtype(dtype)
 
-    def gram_block(x_part: CSMatrix):
-        gram_matrix: CSMatrix = x_part.T @ x_part
+    def gram_block(x_part: _CSMatrix):
+        gram_matrix: _CSMatrix = x_part.T @ x_part
         return gram_matrix.toarray()[None, ...]  # need new axis for summing
 
     gram_matrix_dask: DaskArray = da.map_blocks(

--- a/src/scanpy/preprocessing/_pca/_dask_sparse.py
+++ b/src/scanpy/preprocessing/_pca/_dask_sparse.py
@@ -15,11 +15,9 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from numpy.typing import DTypeLike
-    from scipy import sparse
 
     from ..._compat import DaskArray
-
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    from .._utils import _CSMatrix
 
 
 @dataclass

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -28,6 +28,8 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
 
+_CSMatrix = csr_matrix | csc_matrix
+
 
 def _choose_mtx_rep(adata, *, use_raw: bool = False, layer: str | None = None):
     is_layer = layer is not None
@@ -102,9 +104,9 @@ def describe_obs(
     # Handle whether X is passed
     if X is None:
         X = _choose_mtx_rep(adata, use_raw=use_raw, layer=layer)
-        if isinstance(X, spmatrix) and not isinstance(X, csr_matrix | csc_matrix):
+        if isinstance(X, spmatrix) and not isinstance(X, _CSMatrix):
             X = csr_matrix(X)  # COO not subscriptable
-        if isinstance(X, csr_matrix | csc_matrix):
+        if isinstance(X, _CSMatrix):
             X.eliminate_zeros()
     obs_metrics = pd.DataFrame(index=adata.obs_names)
     obs_metrics[f"n_{var_type}_by_{expr_type}"] = materialize_as_ndarray(
@@ -189,9 +191,9 @@ def describe_var(
     # Handle whether X is passed
     if X is None:
         X = _choose_mtx_rep(adata, use_raw=use_raw, layer=layer)
-        if isinstance(X, spmatrix) and not isinstance(X, csr_matrix | csc_matrix):
+        if isinstance(X, spmatrix) and not isinstance(X, _CSMatrix):
             X = csr_matrix(X)  # COO not subscriptable
-        if isinstance(X, csr_matrix | csc_matrix):
+        if isinstance(X, _CSMatrix):
             X.eliminate_zeros()
     var_metrics = pd.DataFrame(index=adata.var_names)
     var_metrics[f"n_cells_by_{expr_type}"], var_metrics[f"mean_{expr_type}"] = (
@@ -298,9 +300,9 @@ def calculate_qc_metrics(
         )
     # Pass X so I only have to do it once
     X = _choose_mtx_rep(adata, use_raw=use_raw, layer=layer)
-    if isinstance(X, spmatrix) and not isinstance(X, csr_matrix | csc_matrix):
+    if isinstance(X, spmatrix) and not isinstance(X, _CSMatrix):
         X = csr_matrix(X)  # COO not subscriptable
-    if isinstance(X, csr_matrix | csc_matrix):
+    if isinstance(X, _CSMatrix):
         X.eliminate_zeros()
 
     # Convert qc_vars to list if str

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -7,7 +7,7 @@ from warnings import warn
 import numba
 import numpy as np
 import pandas as pd
-from scipy.sparse import coo_matrix, csr_matrix, issparse
+from scipy.sparse import coo_matrix, csc_matrix, csr_matrix, issparse
 
 from scanpy.preprocessing._distributed import materialize_as_ndarray
 from scanpy.preprocessing._utils import _get_mean_var
@@ -438,7 +438,7 @@ def _(mtx: DaskArray, ns: Collection[int]) -> DaskArray:
 
 
 @top_segment_proportions.register(csr_matrix)
-@top_segment_proportions.register(coo_matrix)
+@top_segment_proportions.register(csc_matrix)
 @top_segment_proportions.register(coo_matrix)
 @check_ns
 def _(mtx: _CSMatrix | coo_matrix, ns: Collection[int]) -> DaskArray:

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -7,13 +7,13 @@ from warnings import warn
 import numba
 import numpy as np
 import pandas as pd
-from scipy.sparse import csc_matrix, csr_matrix, issparse, spmatrix
+from scipy.sparse import csr_matrix, issparse, spmatrix
 
 from scanpy.preprocessing._distributed import materialize_as_ndarray
 from scanpy.preprocessing._utils import _get_mean_var
 
 from .._compat import DaskArray, njit
-from .._utils import _doc_params, axis_nnz, axis_sum
+from .._utils import _CSMatrix, _doc_params, axis_nnz, axis_sum
 from ._docs import (
     doc_adata_basic,
     doc_expr_reps,
@@ -27,8 +27,6 @@ if TYPE_CHECKING:
     from collections.abc import Collection
 
     from anndata import AnnData
-
-_CSMatrix = csr_matrix | csc_matrix
 
 
 def _choose_mtx_rep(adata, *, use_raw: bool = False, layer: str | None = None):

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -30,9 +30,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
-    from scipy import sparse as sp
 
-    _CSMatrix = sp.csr_matrix | sp.csc_matrix
+    from .._utils import _CSMatrix
 
 
 @njit

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
     from scipy import sparse as sp
 
-    CSMatrix = sp.csr_matrix | sp.csc_matrix
+    _CSMatrix = sp.csr_matrix | sp.csc_matrix
 
 
 @njit
@@ -66,7 +66,7 @@ def clip_array(
     return X
 
 
-def clip_set(x: CSMatrix, *, max_value: float, zero_center: bool = True) -> CSMatrix:
+def clip_set(x: _CSMatrix, *, max_value: float, zero_center: bool = True) -> _CSMatrix:
     x = x.copy()
     x[x > max_value] = max_value
     if zero_center:
@@ -78,7 +78,7 @@ def clip_set(x: CSMatrix, *, max_value: float, zero_center: bool = True) -> CSMa
 @old_positionals("zero_center", "max_value", "copy", "layer", "obsm")
 @singledispatch
 def scale(
-    data: AnnData | csr_matrix | csc_matrix | np.ndarray | DaskArray,
+    data: AnnData | _CSMatrix | np.ndarray | DaskArray,
     *,
     zero_center: bool = True,
     max_value: float | None = None,
@@ -86,7 +86,7 @@ def scale(
     layer: str | None = None,
     obsm: str | None = None,
     mask_obs: NDArray[np.bool_] | str | None = None,
-) -> AnnData | csr_matrix | csc_matrix | np.ndarray | DaskArray | None:
+) -> AnnData | _CSMatrix | np.ndarray | DaskArray | None:
     """\
     Scale data to unit variance and zero mean.
 
@@ -233,7 +233,7 @@ def scale_array(
 @scale.register(csr_matrix)
 @scale.register(csc_matrix)
 def scale_sparse(
-    X: csr_matrix | csc_matrix,
+    X: _CSMatrix,
     *,
     zero_center: bool = True,
     max_value: float | None = None,

--- a/src/scanpy/preprocessing/_scrublet/core.py
+++ b/src/scanpy/preprocessing/_scrublet/core.py
@@ -27,6 +27,9 @@ if TYPE_CHECKING:
 __all__ = ["Scrublet"]
 
 
+_CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
+
 @dataclass(kw_only=True)
 class Scrublet:
     """\
@@ -65,9 +68,7 @@ class Scrublet:
 
     # init fields
 
-    counts_obs: InitVar[sparse.csr_matrix | sparse.csc_matrix | NDArray[np.integer]] = (
-        field(kw_only=False)
-    )
+    counts_obs: InitVar[_CSMatrix | NDArray[np.integer]] = field(kw_only=False)
     total_counts_obs: InitVar[NDArray[np.integer] | None] = None
     sim_doublet_ratio: float = 2.0
     n_neighbors: InitVar[int | None] = None
@@ -82,15 +83,11 @@ class Scrublet:
 
     _counts_obs: sparse.csc_matrix = field(init=False, repr=False)
     _total_counts_obs: NDArray[np.integer] = field(init=False, repr=False)
-    _counts_obs_norm: sparse.csr_matrix | sparse.csc_matrix = field(
-        init=False, repr=False
-    )
+    _counts_obs_norm: _CSMatrix = field(init=False, repr=False)
 
-    _counts_sim: sparse.csr_matrix | sparse.csc_matrix = field(init=False, repr=False)
+    _counts_sim: _CSMatrix = field(init=False, repr=False)
     _total_counts_sim: NDArray[np.integer] = field(init=False, repr=False)
-    _counts_sim_norm: sparse.csr_matrix | sparse.csc_matrix | None = field(
-        default=None, init=False, repr=False
-    )
+    _counts_sim_norm: _CSMatrix | None = field(default=None, init=False, repr=False)
 
     # Fields set by methods
 
@@ -171,7 +168,7 @@ class Scrublet:
 
     def __post_init__(
         self,
-        counts_obs: sparse.csr_matrix | sparse.csc_matrix | NDArray[np.integer],
+        counts_obs: _CSMatrix | NDArray[np.integer],
         total_counts_obs: NDArray[np.integer] | None,
         n_neighbors: int | None,
         random_state: _LegacyRandom,

--- a/src/scanpy/preprocessing/_scrublet/core.py
+++ b/src/scanpy/preprocessing/_scrublet/core.py
@@ -23,11 +23,9 @@ if TYPE_CHECKING:
 
     from ..._compat import _LegacyRandom
     from ...neighbors import _Metric, _MetricFn
+    from .._utils import _CSMatrix
 
 __all__ = ["Scrublet"]
-
-
-_CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 
 @dataclass(kw_only=True)

--- a/src/scanpy/preprocessing/_scrublet/sparse_utils.py
+++ b/src/scanpy/preprocessing/_scrublet/sparse_utils.py
@@ -12,9 +12,8 @@ from ..._utils import _get_legacy_random
 if TYPE_CHECKING:
     from numpy.typing import NDArray
 
-    from .._compat import _LegacyRandom
-
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+    from ..._compat import _LegacyRandom
+    from ..._utils import _CSMatrix
 
 
 def sparse_multiply(

--- a/src/scanpy/preprocessing/_scrublet/sparse_utils.py
+++ b/src/scanpy/preprocessing/_scrublet/sparse_utils.py
@@ -14,11 +14,13 @@ if TYPE_CHECKING:
 
     from .._compat import _LegacyRandom
 
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
 
 def sparse_multiply(
-    E: sparse.csr_matrix | sparse.csc_matrix | NDArray[np.float64],
+    E: _CSMatrix | NDArray[np.float64],
     a: float | NDArray[np.float64],
-) -> sparse.csr_matrix | sparse.csc_matrix:
+) -> _CSMatrix:
     """multiply each row of E by a scalar"""
 
     nrow = E.shape[0]
@@ -30,11 +32,11 @@ def sparse_multiply(
 
 
 def sparse_zscore(
-    E: sparse.csr_matrix | sparse.csc_matrix,
+    E: _CSMatrix,
     *,
     gene_mean: NDArray[np.float64] | None = None,
     gene_stdev: NDArray[np.float64] | None = None,
-) -> sparse.csr_matrix | sparse.csc_matrix:
+) -> _CSMatrix:
     """z-score normalize each column of E"""
     if gene_mean is None or gene_stdev is None:
         gene_means, gene_stdevs = _get_mean_var(E, axis=0)
@@ -43,12 +45,12 @@ def sparse_zscore(
 
 
 def subsample_counts(
-    E: sparse.csr_matrix | sparse.csc_matrix,
+    E: _CSMatrix,
     *,
     rate: float,
     original_totals,
     random_seed: _LegacyRandom = 0,
-) -> tuple[sparse.csr_matrix | sparse.csc_matrix, NDArray[np.int64]]:
+) -> tuple[_CSMatrix, NDArray[np.int64]]:
     if rate < 1:
         random_seed = _get_legacy_random(random_seed)
         E.data = random_seed.binomial(np.round(E.data).astype(int), rate)

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -22,6 +22,7 @@ from .._compat import DaskArray, deprecated, njit, old_positionals
 from .._settings import settings as sett
 from .._utils import (
     _check_array_function_arguments,
+    _CSMatrix,
     _resolve_axis,
     axis_sum,
     is_backed_type,
@@ -50,8 +51,6 @@ if TYPE_CHECKING:
     from .._compat import _LegacyRandom
     from .._utils import RNGLike, SeedLike
 
-
-_CSMatrix = csr_matrix | csc_matrix
 
 A = TypeVar("A", bound=np.ndarray | _CSMatrix | DaskArray)
 

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -46,7 +46,6 @@ if TYPE_CHECKING:
 
     import pandas as pd
     from numpy.typing import NDArray
-    from scipy.sparse import spmatrix
 
     from .._compat import _LegacyRandom
     from .._utils import RNGLike, SeedLike
@@ -61,7 +60,7 @@ A = TypeVar("A", bound=np.ndarray | _CSMatrix | DaskArray)
     "min_counts", "min_genes", "max_counts", "max_genes", "inplace", "copy"
 )
 def filter_cells(
-    data: AnnData | spmatrix | np.ndarray | DaskArray,
+    data: AnnData | _CSMatrix | np.ndarray | DaskArray,
     *,
     min_counts: int | None = None,
     min_genes: int | None = None,
@@ -209,7 +208,7 @@ def filter_cells(
     "min_counts", "min_cells", "max_counts", "max_cells", "inplace", "copy"
 )
 def filter_genes(
-    data: AnnData | spmatrix | np.ndarray | DaskArray,
+    data: AnnData | _CSMatrix | np.ndarray | DaskArray,
     *,
     min_counts: int | None = None,
     min_cells: int | None = None,

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -14,7 +14,7 @@ import numba
 import numpy as np
 from anndata import AnnData
 from pandas.api.types import CategoricalDtype
-from scipy.sparse import csc_matrix, csr_matrix, issparse, isspmatrix_csr, spmatrix
+from scipy.sparse import csc_matrix, csr_matrix, issparse
 from sklearn.utils import check_array, sparsefuncs
 
 from .. import logging as logg
@@ -46,14 +46,15 @@ if TYPE_CHECKING:
 
     import pandas as pd
     from numpy.typing import NDArray
+    from scipy.sparse import spmatrix
 
     from .._compat import _LegacyRandom
     from .._utils import RNGLike, SeedLike
 
 
-CSMatrix = csr_matrix | csc_matrix
+_CSMatrix = csr_matrix | csc_matrix
 
-A = TypeVar("A", bound=np.ndarray | CSMatrix | DaskArray)
+A = TypeVar("A", bound=np.ndarray | _CSMatrix | DaskArray)
 
 
 @old_positionals(
@@ -320,7 +321,7 @@ def filter_genes(
 @renamed_arg("X", "data", pos_0=True)
 @singledispatch
 def log1p(
-    data: AnnData | np.ndarray | spmatrix,
+    data: AnnData | np.ndarray | _CSMatrix,
     *,
     base: Number | None = None,
     copy: bool = False,
@@ -328,7 +329,7 @@ def log1p(
     chunk_size: int | None = None,
     layer: str | None = None,
     obsm: str | None = None,
-) -> AnnData | np.ndarray | spmatrix | None:
+) -> AnnData | np.ndarray | _CSMatrix | None:
     """\
     Logarithmize the data matrix.
 
@@ -365,8 +366,9 @@ def log1p(
     return log1p_array(data, copy=copy, base=base)
 
 
-@log1p.register(spmatrix)
-def log1p_sparse(X: spmatrix, *, base: Number | None = None, copy: bool = False):
+@log1p.register(csr_matrix)
+@log1p.register(csc_matrix)
+def log1p_sparse(X: _CSMatrix, *, base: Number | None = None, copy: bool = False):
     X = check_array(
         X, accept_sparse=("csr", "csc"), dtype=(np.float64, np.float32), copy=copy
     )
@@ -433,12 +435,12 @@ def log1p_anndata(
 
 @old_positionals("copy", "chunked", "chunk_size")
 def sqrt(
-    data: AnnData | spmatrix | np.ndarray,
+    data: AnnData | _CSMatrix | np.ndarray,
     *,
     copy: bool = False,
     chunked: bool = False,
     chunk_size: int | None = None,
-) -> AnnData | spmatrix | np.ndarray | None:
+) -> AnnData | _CSMatrix | np.ndarray | None:
     """\
     Square root the data matrix.
 
@@ -488,7 +490,7 @@ def sqrt(
     "min_counts",
 )
 def normalize_per_cell(
-    data: AnnData | np.ndarray | spmatrix,
+    data: AnnData | np.ndarray | _CSMatrix,
     *,
     counts_per_cell_after: float | None = None,
     counts_per_cell: np.ndarray | None = None,
@@ -497,7 +499,7 @@ def normalize_per_cell(
     layers: Literal["all"] | Iterable[str] = (),
     use_rep: Literal["after", "X"] | None = None,
     min_counts: int = 1,
-) -> AnnData | np.ndarray | spmatrix | None:
+) -> AnnData | np.ndarray | _CSMatrix | None:
     """\
     Normalize total counts per cell.
 
@@ -865,7 +867,7 @@ def sample(
     p: str | NDArray[np.bool_] | NDArray[np.floating] | None = None,
 ) -> tuple[A, NDArray[np.int64]]: ...
 def sample(
-    data: AnnData | np.ndarray | CSMatrix | DaskArray,
+    data: AnnData | np.ndarray | _CSMatrix | DaskArray,
     fraction: float | None = None,
     *,
     n: int | None = None,
@@ -874,7 +876,7 @@ def sample(
     replace: bool = False,
     axis: Literal["obs", 0, "var", 1] = "obs",
     p: str | NDArray[np.bool_] | NDArray[np.floating] | None = None,
-) -> AnnData | None | tuple[np.ndarray | CSMatrix | DaskArray, NDArray[np.int64]]:
+) -> AnnData | None | tuple[np.ndarray | _CSMatrix | DaskArray, NDArray[np.int64]]:
     """\
     Sample observations or variables with or without replacement.
 
@@ -963,7 +965,7 @@ def sample(
         return subset.to_memory() if data.isbacked else subset.copy()
 
     # overload 3: return array and indices
-    assert isinstance(subset, np.ndarray | CSMatrix | DaskArray), type(subset)
+    assert isinstance(subset, np.ndarray | _CSMatrix | DaskArray), type(subset)
     if copy:
         subset = subset.copy()
     return subset, indices
@@ -1009,7 +1011,7 @@ def downsample_counts(
     -------
     Returns `None` if `copy=False`, else returns an `AnnData` object. Sets the following fields:
 
-    `adata.X` : :class:`numpy.ndarray` | :class:`scipy.sparse.spmatrix` (dtype `float`)
+    `adata.X` : :class:`~numpy.ndarray` | :class:`~scipy.sparse.csr_matrix` | :class:`~scipy.sparse.csc_matrix` (dtype `float`)
         Downsampled counts matrix.
     """
     raise_not_implemented_error_if_backed_type(adata.X, "downsample_counts")
@@ -1023,14 +1025,24 @@ def downsample_counts(
     if copy:
         adata = adata.copy()
     if total_counts_call:
-        adata.X = _downsample_total_counts(adata.X, total_counts, random_state, replace)
+        adata.X = _downsample_total_counts(
+            adata.X, total_counts, random_state=random_state, replace=replace
+        )
     elif counts_per_cell_call:
-        adata.X = _downsample_per_cell(adata.X, counts_per_cell, random_state, replace)
+        adata.X = _downsample_per_cell(
+            adata.X, counts_per_cell, random_state=random_state, replace=replace
+        )
     if copy:
         return adata
 
 
-def _downsample_per_cell(X, counts_per_cell, random_state, replace):
+def _downsample_per_cell(
+    X: _CSMatrix,
+    counts_per_cell: int,
+    *,
+    random_state: _LegacyRandom,
+    replace: bool,
+) -> _CSMatrix:
     n_obs = X.shape[0]
     if isinstance(counts_per_cell, int):
         counts_per_cell = np.full(n_obs, counts_per_cell)
@@ -1046,7 +1058,7 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
         )
     if issparse(X):
         original_type = type(X)
-        if not isspmatrix_csr(X):
+        if not isinstance(X, csr_matrix):
             X = csr_matrix(X)
         totals = np.ravel(axis_sum(X, axis=1))  # Faster for csr matrix
         under_target = np.nonzero(totals > counts_per_cell)[0]
@@ -1078,14 +1090,20 @@ def _downsample_per_cell(X, counts_per_cell, random_state, replace):
     return X
 
 
-def _downsample_total_counts(X, total_counts, random_state, replace):
+def _downsample_total_counts(
+    X: _CSMatrix,
+    total_counts: int,
+    *,
+    random_state: _LegacyRandom,
+    replace: bool,
+) -> _CSMatrix:
     total_counts = int(total_counts)
     total = X.sum()
     if total < total_counts:
         return X
     if issparse(X):
         original_type = type(X)
-        if not isspmatrix_csr(X):
+        if not isinstance(X, csr_matrix):
             X = csr_matrix(X)
         _downsample_array(
             X.data,

--- a/src/scanpy/preprocessing/_utils.py
+++ b/src/scanpy/preprocessing/_utils.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
     from .._compat import DaskArray, _LegacyRandom
     from .._utils import _SupportedArray
 
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
+_CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 
 @singledispatch

--- a/src/scanpy/preprocessing/_utils.py
+++ b/src/scanpy/preprocessing/_utils.py
@@ -9,7 +9,7 @@ from scipy import sparse
 from sklearn.random_projection import sample_without_replacement
 
 from .._compat import njit
-from .._utils import axis_sum, elem_mul
+from .._utils import _CSMatrix, axis_sum, elem_mul
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -18,9 +18,6 @@ if TYPE_CHECKING:
 
     from .._compat import DaskArray, _LegacyRandom
     from .._utils import _SupportedArray
-
-
-_CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 
 @singledispatch

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -15,11 +15,10 @@ if TYPE_CHECKING:
     from typing import Literal
 
     from anndata import AnnData
-    from scipy import sparse
 
     from .._compat import _LegacyRandom
+    from .._utils import _CSMatrix
 
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 try:
     from leidenalg.VertexPartition import MutableVertexPartition

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
     from .._compat import _LegacyRandom
 
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
 try:
     from leidenalg.VertexPartition import MutableVertexPartition
 except ImportError:
@@ -36,7 +38,7 @@ def leiden(
     restrict_to: tuple[str, Sequence[str]] | None = None,
     random_state: _LegacyRandom = 0,
     key_added: str = "leiden",
-    adjacency: sparse.spmatrix | None = None,
+    adjacency: _CSMatrix | None = None,
     directed: bool | None = None,
     use_weights: bool = True,
     n_iterations: int = -1,

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -20,11 +20,9 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from anndata import AnnData
-    from scipy.sparse import csc_matrix, csr_matrix
 
     from .._compat import _LegacyRandom
-
-    _CSMatrix = csr_matrix | csc_matrix
+    from .._utils import _CSMatrix
 
 try:
     from louvain.VertexPartition import MutableVertexPartition

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -20,9 +20,11 @@ if TYPE_CHECKING:
     from typing import Any, Literal
 
     from anndata import AnnData
-    from scipy.sparse import spmatrix
+    from scipy.sparse import csc_matrix, csr_matrix
 
     from .._compat import _LegacyRandom
+
+    _CSMatrix = csr_matrix | csc_matrix
 
 try:
     from louvain.VertexPartition import MutableVertexPartition
@@ -55,7 +57,7 @@ def louvain(
     random_state: _LegacyRandom = 0,
     restrict_to: tuple[str, Sequence[str]] | None = None,
     key_added: str = "louvain",
-    adjacency: spmatrix | None = None,
+    adjacency: _CSMatrix | None = None,
     flavor: Literal["vtraag", "igraph", "rapids"] = "vtraag",
     directed: bool = True,
     use_weights: bool = False,
@@ -143,9 +145,8 @@ def louvain(
     partition_kwargs = dict(partition_kwargs)
     start = logg.info("running Louvain clustering")
     if (flavor != "vtraag") and (partition_type is not None):
-        raise ValueError(
-            "`partition_type` is only a valid argument " 'when `flavour` is "vtraag"'
-        )
+        msg = '`partition_type` is only a valid argument when `flavour` is "vtraag"'
+        raise ValueError(msg)
     adata = adata.copy() if copy else adata
     if adjacency is None:
         adjacency = _choose_graph(adata, obsp, neighbors_key)

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     from scipy import sparse
 
     _CorrMethod = Literal["benjamini-hochberg", "bonferroni"]
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
 
 # Used with get_literal_vals
 _Method = Literal["logreg", "t-test", "wilcoxon", "t-test_overestim_var"]
@@ -45,7 +46,7 @@ def _select_top_n(scores: NDArray, n_top: int):
 
 
 def _ranks(
-    X: np.ndarray | sparse.csr_matrix | sparse.csc_matrix,
+    X: np.ndarray | _CSMatrix,
     mask_obs: NDArray[np.bool_] | None = None,
     mask_obs_rest: NDArray[np.bool_] | None = None,
 ) -> Generator[tuple[pd.DataFrame, int, int], None, None]:

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -24,10 +24,11 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
     from numpy.typing import NDArray
-    from scipy import sparse
+
+    from .._utils import _CSMatrix
 
     _CorrMethod = Literal["benjamini-hochberg", "bonferroni"]
-    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
 
 # Used with get_literal_vals
 _Method = Literal["logreg", "t-test", "wilcoxon", "t-test_overestim_var"]

--- a/src/scanpy/tools/_score_genes.py
+++ b/src/scanpy/tools/_score_genes.py
@@ -8,10 +8,9 @@ import numpy as np
 import pandas as pd
 from scipy.sparse import issparse
 
-from scanpy._utils import _check_use_raw, is_backed_type
-
 from .. import logging as logg
 from .._compat import old_positionals
+from .._utils import _check_use_raw, is_backed_type
 from ..get import _get_obs_rep
 
 if TYPE_CHECKING:
@@ -20,15 +19,14 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
     from numpy.typing import DTypeLike, NDArray
-    from scipy.sparse import csc_matrix, csr_matrix
 
     from .._compat import _LegacyRandom
+    from .._utils import _CSMatrix
 
     try:
         _StrIdx = pd.Index[str]
     except TypeError:  # Sphinx
         _StrIdx = pd.Index
-    _CSMatrix = csr_matrix | csc_matrix
     _GetSubset = Callable[[_StrIdx], np.ndarray | _CSMatrix]
 
 

--- a/src/scanpy/tools/_score_genes.py
+++ b/src/scanpy/tools/_score_genes.py
@@ -28,12 +28,11 @@ if TYPE_CHECKING:
         _StrIdx = pd.Index[str]
     except TypeError:  # Sphinx
         _StrIdx = pd.Index
-    _GetSubset = Callable[[_StrIdx], np.ndarray | csr_matrix | csc_matrix]
+    _CSMatrix = csr_matrix | csc_matrix
+    _GetSubset = Callable[[_StrIdx], np.ndarray | _CSMatrix]
 
 
-def _sparse_nanmean(
-    X: csr_matrix | csc_matrix, axis: Literal[0, 1]
-) -> NDArray[np.float64]:
+def _sparse_nanmean(X: _CSMatrix, axis: Literal[0, 1]) -> NDArray[np.float64]:
     """
     np.nanmean equivalent for sparse matrices
     """

--- a/src/scanpy/tools/_utils.py
+++ b/src/scanpy/tools/_utils.py
@@ -11,7 +11,7 @@ from .._utils import _choose_graph
 
 if TYPE_CHECKING:
     from anndata import AnnData
-    from scipy.sparse import csr_matrix
+    from scipy.sparse import csr_matrix, spmatrix
 
 
 def _choose_representation(
@@ -86,7 +86,7 @@ def preprocess_with_pca(adata, n_pcs: int | None = None, random_state=0):
         logg.info("    using data matrix X directly (no PCA)")
         return adata.X
     elif n_pcs is None and "X_pca" in adata.obsm_keys():
-        logg.info(f'    using \'X_pca\' with n_pcs = {adata.obsm["X_pca"].shape[1]}')
+        logg.info(f"    using 'X_pca' with n_pcs = {adata.obsm['X_pca'].shape[1]}")
         return adata.obsm["X_pca"]
     elif "X_pca" in adata.obsm_keys() and adata.obsm["X_pca"].shape[1] >= n_pcs:
         logg.info(f"    using 'X_pca' with n_pcs = {n_pcs}")
@@ -105,28 +105,33 @@ def preprocess_with_pca(adata, n_pcs: int | None = None, random_state=0):
 
 
 def get_init_pos_from_paga(
-    adata, adjacency=None, random_state=0, neighbors_key=None, obsp=None
+    adata: AnnData,
+    adjacency: spmatrix | None = None,
+    random_state=0,
+    neighbors_key: str | None = None,
+    obsp: str | None = None,
 ):
     np.random.seed(random_state)
     if adjacency is None:
         adjacency = _choose_graph(adata, obsp, neighbors_key)
-    if "paga" in adata.uns and "pos" in adata.uns["paga"]:
-        groups = adata.obs[adata.uns["paga"]["groups"]]
-        pos = adata.uns["paga"]["pos"]
-        connectivities_coarse = adata.uns["paga"]["connectivities"]
-        init_pos = np.ones((adjacency.shape[0], 2))
-        for i, group_pos in enumerate(pos):
-            subset = (groups == groups.cat.categories[i]).values
-            neighbors = connectivities_coarse[i].nonzero()
-            if len(neighbors[1]) > 0:
-                connectivities = connectivities_coarse[i][neighbors]
-                nearest_neighbor = neighbors[1][np.argmax(connectivities)]
-                noise = np.random.random((len(subset[subset]), 2))
-                dist = pos[i] - pos[nearest_neighbor]
-                noise = noise * dist
-                init_pos[subset] = group_pos - 0.5 * dist + noise
-            else:
-                init_pos[subset] = group_pos
-    else:
-        raise ValueError("Plot PAGA first, so that adata.uns['paga']" "with key 'pos'.")
+    if "pos" not in adata.uns.get("paga", {}):
+        msg = "Plot PAGA first, so that `adata.uns['paga']['pos']` exists."
+        raise ValueError(msg)
+
+    groups = adata.obs[adata.uns["paga"]["groups"]]
+    pos = adata.uns["paga"]["pos"]
+    connectivities_coarse = adata.uns["paga"]["connectivities"]
+    init_pos = np.ones((adjacency.shape[0], 2))
+    for i, group_pos in enumerate(pos):
+        subset = (groups == groups.cat.categories[i]).values
+        neighbors = connectivities_coarse[i].nonzero()
+        if len(neighbors[1]) > 0:
+            connectivities = connectivities_coarse[i][neighbors]
+            nearest_neighbor = neighbors[1][np.argmax(connectivities)]
+            noise = np.random.random((len(subset[subset]), 2))
+            dist = pos[i] - pos[nearest_neighbor]
+            noise = noise * dist
+            init_pos[subset] = group_pos - 0.5 * dist + noise
+        else:
+            init_pos[subset] = group_pos
     return init_pos

--- a/src/scanpy/tools/_utils_clustering.py
+++ b/src/scanpy/tools/_utils_clustering.py
@@ -9,9 +9,8 @@ if TYPE_CHECKING:
     import pandas as pd
     from anndata import AnnData
     from numpy.typing import NDArray
-    from scipy.sparse import csc_matrix, csr_matrix
 
-    _CSMatrix = csr_matrix | csc_matrix
+    from .._utils import _CSMatrix
 
 
 def rename_groups(

--- a/src/scanpy/tools/_utils_clustering.py
+++ b/src/scanpy/tools/_utils_clustering.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Sequence
 
     import numpy as np
     import pandas as pd
     from anndata import AnnData
     from numpy.typing import NDArray
-    from scipy.sparse import spmatrix
+    from scipy.sparse import csc_matrix, csr_matrix
+
+    _CSMatrix = csr_matrix | csc_matrix
 
 
 def rename_groups(
@@ -33,13 +35,12 @@ def restrict_adjacency(
     adata: AnnData,
     restrict_key: str,
     *,
-    restrict_categories: Iterable[str],
-    adjacency: spmatrix,
-) -> tuple[spmatrix, NDArray[np.bool_]]:
+    restrict_categories: Sequence[str],
+    adjacency: _CSMatrix,
+) -> tuple[_CSMatrix, NDArray[np.bool_]]:
     if not isinstance(restrict_categories[0], str):
-        raise ValueError(
-            "You need to use strings to label categories, " "e.g. '1' instead of 1."
-        )
+        msg = "You need to use strings to label categories, e.g. '1' instead of 1."
+        raise ValueError(msg)
     for c in restrict_categories:
         if c not in adata.obs[restrict_key].cat.categories:
             raise ValueError(f"'{c}' is not a valid category for '{restrict_key}'")

--- a/src/testing/scanpy/_pytest/fixtures/data.py
+++ b/src/testing/scanpy/_pytest/fixtures/data.py
@@ -36,6 +36,8 @@ if TYPE_CHECKING:
 
     from numpy.typing import DTypeLike
 
+    _CSMatrix = sparse.csr_matrix | sparse.csc_matrix
+
 
 @pytest.fixture(
     scope="session",
@@ -97,9 +99,7 @@ def backed_adata(
 
 def _prepare_pbmc_testdata(
     adata: AnnData,
-    sparsity_func: Callable[
-        [np.ndarray | sparse.spmatrix], np.ndarray | sparse.spmatrix
-    ],
+    sparsity_func: Callable[[np.ndarray | _CSMatrix], np.ndarray | _CSMatrix],
     dtype: DTypeLike,
     *,
     small: bool,

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -75,10 +75,13 @@ def test_segments_binary():
 
 
 @pytest.mark.parametrize(
-    "cls", [np.asarray, sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix]
+    "array_type", [*ARRAY_TYPES, pytest.param(sparse.coo_matrix, id="scipy_coo")]
 )
-def test_top_segments(cls):
-    a = cls(np.ones((300, 100)))
+def test_top_segments(request: pytest.FixtureRequest, array_type):
+    if "dask" in array_type.__name__:
+        reason = "DaskArray not yet supported"
+        request.applymarker(pytest.mark.xfail(reason=reason))
+    a = array_type(np.ones((300, 100)))
     seg = top_segment_proportions(a, [50, 100])
     assert (seg[:, 0] == 0.5).all()
     assert (seg[:, 1] == 1.0).all()

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -100,7 +100,7 @@ def test_qc_metrics(adata_prepared: AnnData):
         else adata_prepared.X
     )
     max_X = X.max(axis=0)
-    if isinstance(max_X, sparse.csr_matrix | sparse.csc_matrix):
+    if isinstance(max_X, sparse.coo_matrix):
         max_X = max_X.toarray()
     elif isinstance(max_X, DaskArray):
         max_X = max_X.compute()

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -100,7 +100,7 @@ def test_qc_metrics(adata_prepared: AnnData):
         else adata_prepared.X
     )
     max_X = X.max(axis=0)
-    if isinstance(max_X, sparse.spmatrix):
+    if isinstance(max_X, sparse.csr_matrix | sparse.csc_matrix):
         max_X = max_X.toarray()
     elif isinstance(max_X, DaskArray):
         max_X = max_X.compute()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 from anndata.tests.helpers import asarray
 from packaging.version import Version
-from scipy.sparse import csr_matrix, issparse
+from scipy.sparse import coo_matrix, csr_matrix, issparse
 
 from scanpy._compat import DaskArray, _legacy_numpy_gen, pkg_version
 from scanpy._utils import (
@@ -151,7 +151,9 @@ def test_elem_mul(array_type):
     np.testing.assert_array_equal(res, expd)
 
 
-@pytest.mark.parametrize("array_type", ARRAY_TYPES)
+@pytest.mark.parametrize(
+    "array_type", [*ARRAY_TYPES, pytest.param(coo_matrix, id="scipy_coo")]
+)
 def test_axis_sum(array_type):
     m1 = array_type(asarray([[0, 1, 1], [1, 0, 1]]))
     expd_0 = np.array([1, 1, 2])


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: The only user-facing change is some subtly typing fixes

Preparation for sparray support: make sure `spmatrix` is only used where it makes sense.

I checked every single instance of `spmatrix` and either tested that `coo_matrix` also works or replaced it with `_CSMatrix = csr_matrix | csc_matrix`.

TODO after this PR:
1. replace spmatrix with `_SpBase = sparray | spmatrix` and `_CSMatrix` with `_CSBase = cs{cr}_matrix | cs{cr}_array` and test
2. figure out `bsr_array`