### PR TITLE
(chore) upper bound zarr version in tests to <3

### DIFF
--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -78,7 +78,7 @@
         "natsort": [""],
         "pandas": [""],
         "memory_profiler": [""],
-        "zarr": [""],
+        "zarr": ["2.18.4"],
         "pytest": [""],
         "scanpy": [""],
         "python-igraph": [""],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,7 @@ test = [
     "scanpy[test-min]",
     # Optional but important dependencies
     "scanpy[leiden]",
-    "zarr",
+    "zarr<3",
     "scanpy[dask]",
     "scanpy[scrublet]",
 ]


### PR DESCRIPTION
Unlike https://github.com/scverse/anndata/pull/1819, this changes no runtime behavior, so no relnote