### PR TITLE
Grammar fixes in `sc.tl` docstrings

### DIFF
--- a/src/scanpy/tools/_dendrogram.py
+++ b/src/scanpy/tools/_dendrogram.py
@@ -61,9 +61,9 @@ def dendrogram(
 
     The hierarchical clustering can be visualized using
     :func:`scanpy.pl.dendrogram` or multiple other visualizations
-    including a dendrogram: :func:`~scanpy.pl.matrixplot`,
+    that can include a dendrogram: :func:`~scanpy.pl.matrixplot`,
     :func:`~scanpy.pl.heatmap`, :func:`~scanpy.pl.dotplot`,
-    or :func:`~scanpy.pl.stacked_violin`.
+    and :func:`~scanpy.pl.stacked_violin`.
 
     .. note::
         The computation of the hierarchical clustering is based on predefined

--- a/src/scanpy/tools/_dendrogram.py
+++ b/src/scanpy/tools/_dendrogram.py
@@ -60,10 +60,10 @@ def dendrogram(
     to compute a correlation matrix.
 
     The hierarchical clustering can be visualized using
-    :func:`scanpy.pl.dendrogram` or multiple other visualizations that can
-    include a dendrogram: :func:`~scanpy.pl.matrixplot`,
+    :func:`scanpy.pl.dendrogram` or multiple other visualizations
+    including a dendrogram: :func:`~scanpy.pl.matrixplot`,
     :func:`~scanpy.pl.heatmap`, :func:`~scanpy.pl.dotplot`,
-    and :func:`~scanpy.pl.stacked_violin`.
+    or :func:`~scanpy.pl.stacked_violin`.
 
     .. note::
         The computation of the hierarchical clustering is based on predefined
@@ -78,15 +78,15 @@ def dendrogram(
     {use_rep}
     var_names
         List of var_names to use for computing the hierarchical clustering.
-        If `var_names` is given, then `use_rep` and `n_pcs` is ignored.
+        If `var_names` is given, then `use_rep` and `n_pcs` are ignored.
     use_raw
         Only when `var_names` is not None.
         Use `raw` attribute of `adata` if present.
     cor_method
-        correlation method to use.
+        Correlation method to use.
         Options are 'pearson', 'kendall', and 'spearman'
     linkage_method
-        linkage method to use. See :func:`scipy.cluster.hierarchy.linkage`
+        Linkage method to use. See :func:`scipy.cluster.hierarchy.linkage`
         for more information.
     optimal_ordering
         Same as the optimal_ordering argument of :func:`scipy.cluster.hierarchy.linkage`

--- a/src/scanpy/tools/_diffmap.py
+++ b/src/scanpy/tools/_diffmap.py
@@ -23,9 +23,9 @@ def diffmap(
     """\
     Diffusion Maps :cite:p:`Coifman2005,Haghverdi2015,Wolf2018`.
 
-    Diffusion maps :cite:p:`Coifman2005` has been proposed for visualizing single-cell
-    data by :cite:t:`Haghverdi2015`. The tool uses the adapted Gaussian kernel suggested
-    by :cite:t:`Haghverdi2016` in the implementation of :cite:t:`Wolf2018`.
+    Diffusion maps :cite:p:`Coifman2005` have been proposed for visualizing single-cell
+    data by :cite:t:`Haghverdi2015`. This tool uses the adapted Gaussian kernel suggested
+    by :cite:t:`Haghverdi2016` with the implementation of :cite:t:`Wolf2018`.
 
     The width ("sigma") of the connectivity kernel is implicitly determined by
     the number of neighbors used to compute the single-cell graph in
@@ -42,12 +42,12 @@ def diffmap(
     n_comps
         The number of dimensions of the representation.
     neighbors_key
-        If not specified, diffmap looks .uns['neighbors'] for neighbors settings
-        and .obsp['connectivities'], .obsp['distances'] for connectivities and
-        distances respectively (default storage places for pp.neighbors).
-        If specified, diffmap looks .uns[neighbors_key] for neighbors settings and
-        .obsp[.uns[neighbors_key]['connectivities_key']],
-        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
+        If not specified, diffmap looks in .uns['neighbors'] for neighbors settings
+        and .obsp['connectivities'] and .obsp['distances'] for connectivities and
+        distances, respectively (default storage places for pp.neighbors).
+        If specified, diffmap looks in .uns[neighbors_key] for neighbors settings and
+        .obsp[.uns[neighbors_key]['connectivities_key']] and
+        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances,
         respectively.
     random_state
         A numpy random seed

--- a/src/scanpy/tools/_dpt.py
+++ b/src/scanpy/tools/_dpt.py
@@ -53,7 +53,7 @@ def dpt(
     :cite:p:`Haghverdi2016,Wolf2019`.
 
     Reconstruct the progression of a biological process from snapshot
-    data. `Diffusion Pseudotime` has been introduced by :cite:t:`Haghverdi2016` and
+    data. `Diffusion Pseudotime` was introduced by :cite:t:`Haghverdi2016` and
     implemented within Scanpy :cite:p:`Wolf2018`. Here, we use a further developed
     version, which is able to deal with disconnected graphs :cite:p:`Wolf2019` and can
     be run in a `hierarchical` mode by setting the parameter
@@ -64,9 +64,9 @@ def dpt(
 
         adata.uns['iroot'] = np.flatnonzero(adata.obs['cell_types'] == 'Stem')[0]
 
-    This requires to run :func:`~scanpy.pp.neighbors`, first. In order to
-    reproduce the original implementation of DPT, use `method=='gauss'` in
-    this. Using the default `method=='umap'` only leads to minor quantitative
+    This requires running :func:`~scanpy.pp.neighbors`, first. In order to
+    reproduce the original implementation of DPT, use `method=='gauss'`.
+    Using the default `method=='umap'` only leads to minor quantitative
     differences, though.
 
     .. versionadded:: 1.1
@@ -96,12 +96,12 @@ def dpt(
         maximum correlation in Kendall tau criterion of :cite:t:`Haghverdi2016` to
         stabilize the splitting.
     neighbors_key
-        If not specified, dpt looks .uns['neighbors'] for neighbors settings
-        and .obsp['connectivities'], .obsp['distances'] for connectivities and
-        distances respectively (default storage places for pp.neighbors).
-        If specified, dpt looks .uns[neighbors_key] for neighbors settings and
-        .obsp[.uns[neighbors_key]['connectivities_key']],
-        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances
+        If not specified, dpt looks in .uns['neighbors'] for neighbors settings
+        and .obsp['connectivities'] and .obsp['distances'] for connectivities and
+        distances, respectively (default storage places for pp.neighbors).
+        If specified, dpt looks in .uns[neighbors_key] for neighbors settings and
+        .obsp[.uns[neighbors_key]['connectivities_key']] and
+        .obsp[.uns[neighbors_key]['distances_key']] for connectivities and distances,
         respectively.
     copy
         Copy instance before computation and return a copy.

--- a/src/scanpy/tools/_draw_graph.py
+++ b/src/scanpy/tools/_draw_graph.py
@@ -56,14 +56,14 @@ def draw_graph(
     Force-directed graph drawing :cite:p:`Islam2011,Jacomy2014,Chippada2018`.
 
     An alternative to tSNE that often preserves the topology of the data
-    better. This requires to run :func:`~scanpy.pp.neighbors`, first.
+    better. This requires running :func:`~scanpy.pp.neighbors`, first.
 
     The default layout ('fa', `ForceAtlas2`, :cite:t:`Jacomy2014`) uses the package |fa2-modified|_
     :cite:p:`Chippada2018`, which can be installed via `pip install fa2-modified`.
 
     `Force-directed graph drawing`_ describes a class of long-established
     algorithms for visualizing graphs.
-    It has been suggested for visualizing single-cell data by :cite:t:`Islam2011`.
+    It was suggested for visualizing single-cell data by :cite:t:`Islam2011`.
     Many other layouts as implemented in igraph :cite:p:`Csardi2006` are available.
     Similar approaches have been used by :cite:t:`Zunder2015` or :cite:t:`Weinreb2017`.
 
@@ -98,9 +98,9 @@ def draw_graph(
         Use precomputed coordinates for initialization.
         If `False`/`None` (the default), initialize randomly.
     neighbors_key
-        If not specified, draw_graph looks .obsp['connectivities'] for connectivities
+        If not specified, draw_graph looks at .obsp['connectivities'] for connectivities
         (default storage place for pp.neighbors).
-        If specified, draw_graph looks
+        If specified, draw_graph looks at
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
     obsp
         Use .obsp[obsp] as adjacency. You can't specify both

--- a/src/scanpy/tools/_embedding_density.py
+++ b/src/scanpy/tools/_embedding_density.py
@@ -70,7 +70,7 @@ def embedding_density(
         The annotated data matrix.
     basis
         The embedding over which the density will be calculated. This embedded
-        representation should be found in `adata.obsm['X_[basis]']``.
+        representation is found in `adata.obsm['X_[basis]']``.
     groupby
         Key for categorical observation/cell annotation for which densities
         are calculated per category.

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -91,10 +91,10 @@ def ingest(
         The method to map labels in `adata_ref.obs` to `adata.obs`.
         The only supported value is 'knn'.
     neighbors_key
-        If not specified, ingest looks adata_ref.uns['neighbors']
+        If not specified, ingest looks at adata_ref.uns['neighbors']
         for neighbors settings and adata_ref.obsp['distances'] for
         distances (default storage places for pp.neighbors).
-        If specified, ingest looks adata_ref.uns[neighbors_key] for
+        If specified, ingest looks at adata_ref.uns[neighbors_key] for
         neighbors settings and
         adata_ref.obsp[adata_ref.uns[neighbors_key]['distances_key']] for distances.
     inplace

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -52,9 +52,9 @@ def leiden(
 
     Cluster cells using the Leiden algorithm :cite:p:`Traag2019`,
     an improved version of the Louvain algorithm :cite:p:`Blondel2008`.
-    It has been proposed for single-cell analysis by :cite:t:`Levine2015`.
+    It was proposed for single-cell analysis by :cite:t:`Levine2015`.
 
-    This requires having ran :func:`~scanpy.pp.neighbors` or
+    This requires having run :func:`~scanpy.pp.neighbors` or
     :func:`~scanpy.external.pp.bbknn` first.
 
     Parameters
@@ -92,9 +92,9 @@ def leiden(
         :func:`~leidenalg.find_partition`.
     neighbors_key
         Use neighbors connectivities as adjacency.
-        If not specified, leiden looks .obsp['connectivities'] for connectivities
+        If not specified, leiden looks at .obsp['connectivities'] for connectivities
         (default storage place for pp.neighbors).
-        If specified, leiden looks
+        If specified, leiden looks at
         .obsp[.uns[neighbors_key]['connectivities_key']] for connectivities.
     obsp
         Use .obsp[obsp] as adjacency. You can't specify both

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -69,10 +69,10 @@ def louvain(
     Cluster cells into subgroups :cite:p:`Blondel2008,Levine2015,Traag2017`.
 
     Cluster cells using the Louvain algorithm :cite:p:`Blondel2008` in the implementation
-    of :cite:t:`Traag2017`. The Louvain algorithm has been proposed for single-cell
+    of :cite:t:`Traag2017`. The Louvain algorithm was proposed for single-cell
     analysis by :cite:t:`Levine2015`.
 
-    This requires having ran :func:`~scanpy.pp.neighbors` or
+    This requires having run :func:`~scanpy.pp.neighbors` or
     :func:`~scanpy.external.pp.bbknn` first,
     or explicitly passing a ``adjacency`` matrix.
 

--- a/src/scanpy/tools/_marker_gene_overlap.py
+++ b/src/scanpy/tools/_marker_gene_overlap.py
@@ -88,7 +88,7 @@ def marker_gene_overlap(
     inplace: bool = False,
 ):
     """\
-    Calculate an overlap score between data-deriven marker genes and
+    Calculate an overlap score between data-derived marker genes and
     provided markers
 
     Marker gene overlap scores can be quoted as overlap counts, overlap

--- a/src/scanpy/tools/_score_genes.py
+++ b/src/scanpy/tools/_score_genes.py
@@ -79,8 +79,8 @@ def score_genes(
     """\
     Score a set of genes :cite:p:`Satija2015`.
 
-    The score is the average expression of a set of genes subtracted with the
-    average expression of a reference set of genes. The reference set is
+    The score is the average expression of a set of genes after subtraction by 
+    the average expression of a reference set of genes. The reference set is
     randomly sampled from the `gene_pool` for each binned expression value.
 
     This reproduces the approach in Seurat :cite:p:`Satija2015` and has been implemented

--- a/src/scanpy/tools/_score_genes.py
+++ b/src/scanpy/tools/_score_genes.py
@@ -79,7 +79,7 @@ def score_genes(
     """\
     Score a set of genes :cite:p:`Satija2015`.
 
-    The score is the average expression of a set of genes after subtraction by 
+    The score is the average expression of a set of genes after subtraction by
     the average expression of a reference set of genes. The reference set is
     randomly sampled from the `gene_pool` for each binned expression value.
 

--- a/src/scanpy/tools/_sim.py
+++ b/src/scanpy/tools/_sim.py
@@ -62,7 +62,7 @@ def sim(
 
     Sample from a stochastic differential equation model built from
     literature-curated boolean gene regulatory networks, as suggested by
-    :cite:t:`Wittmann2009`. The Scanpy implementation is due to :cite:t:`Wolf2018`.
+    :cite:t:`Wittmann2009`. The Scanpy implementation can be found in :cite:t:`Wolf2018`.
 
     Parameters
     ----------

--- a/src/scanpy/tools/_top_genes.py
+++ b/src/scanpy/tools/_top_genes.py
@@ -38,7 +38,7 @@ def correlation_matrix(
     """\
     Calculate correlation matrix.
 
-    Calculate a correlation matrix for genes strored in sample annotation
+    Calculate a correlation matrix for genes stored in sample annotation
     using :func:`~scanpy.tl.rank_genes_groups`.
 
     Parameters
@@ -73,7 +73,7 @@ def correlation_matrix(
         spearman
             Spearman rank correlation
     annotation_key
-        Allows to define the name of the anndata entry where results are stored.
+        Allows defining the name of the anndata entry where results are stored.
     """
 
     # TODO: At the moment, only works for int identifiers

--- a/src/scanpy/tools/_tsne.py
+++ b/src/scanpy/tools/_tsne.py
@@ -47,7 +47,7 @@ def tsne(
     """\
     t-SNE :cite:p:`vanDerMaaten2008,Amir2013,Pedregosa2011`.
 
-    t-distributed stochastic neighborhood embedding (tSNE, :cite:t:`vanDerMaaten2008`) has been
+    t-distributed stochastic neighborhood embedding (tSNE, :cite:t:`vanDerMaaten2008`) was
     proposed for visualizating single-cell data by :cite:t:`Amir2013`. Here, by default,
     we use the implementation of *scikit-learn* :cite:p:`Pedregosa2011`. You can achieve
     a huge speedup and better convergence if you install Multicore-tSNE_


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

Been working with scanpy for a bit now and really appreciate all the work you're all doing. Noticed a few grammar mistakes in docstrings. If it's helpful I figured I could submit a couple PRs to fix up docstrings :) . As a demonstration this is just a quick rundown of the `tools` submodule. If this isn't desired just let me know.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes # NA
- [x] Tests included or not required because: I was just updating some docstrings to be slightly more idiomatic English so no api or meaning changes.
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: Same as above. Meaning not changed for anything. Just grammar fixes. Although if you want something here let me know.
