### PR TITLE
Skip COO matrix tests for newer anndata

### DIFF
--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -201,8 +201,8 @@ def adata_mito():
     return adata_dense, init_var
 
 
-skip_if_adata_0_11_4 = pytest.mark.skipif(
-    Version(version("anndata")) >= Version("0.11.4.dev2"),
+skip_if_adata_0_12 = pytest.mark.skipif(
+    Version(version("anndata")) >= Version("0.12.0.dev0"),
     reason="Newer AnnData removes implicit support for COO matrices",
 )
 
@@ -211,7 +211,7 @@ skip_if_adata_0_11_4 = pytest.mark.skipif(
     "cls",
     [
         *ARRAY_TYPES_MEM,
-        pytest.param(sparse.coo_matrix, marks=[skip_if_adata_0_11_4], id="scipy_coo"),
+        pytest.param(sparse.coo_matrix, marks=[skip_if_adata_0_12], id="scipy_coo"),
     ],
 )
 def test_qc_metrics_format(cls):

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -203,7 +203,7 @@ def adata_mito():
 
 skip_if_adata_0_11_4 = pytest.mark.skipif(
     Version(version("anndata")) >= Version("0.11.4.dev2"),
-    reason="Old AnnData doesn’t have sparse test helpers",
+    reason="Newer AnnData removes implicit support for COO matrices",
 )
 
 

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+from importlib.metadata import version
+
 import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
 from anndata.tests.helpers import assert_equal
+from packaging.version import Version
 from scipy import sparse
 
 import scanpy as sc
@@ -18,7 +21,7 @@ from scanpy.preprocessing._qc import (
 )
 from testing.scanpy._helpers import as_sparse_dask_array, maybe_dask_process_context
 from testing.scanpy._pytest.marks import needs
-from testing.scanpy._pytest.params import ARRAY_TYPES
+from testing.scanpy._pytest.params import ARRAY_TYPES, ARRAY_TYPES_MEM
 
 
 @pytest.fixture
@@ -198,8 +201,18 @@ def adata_mito():
     return adata_dense, init_var
 
 
+skip_if_adata_0_11_4 = pytest.mark.skipif(
+    Version(version("anndata")) >= Version("0.11.4.dev2"),
+    reason="Old AnnData doesn’t have sparse test helpers",
+)
+
+
 @pytest.mark.parametrize(
-    "cls", [np.asarray, sparse.csr_matrix, sparse.csc_matrix, sparse.coo_matrix]
+    "cls",
+    [
+        *ARRAY_TYPES_MEM,
+        pytest.param(sparse.coo_matrix, marks=[skip_if_adata_0_11_4], id="scipy_coo"),
+    ],
 )
 def test_qc_metrics_format(cls):
     adata_dense, init_var = adata_mito()


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3439, closes #3440
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: test-only fix

@ilan-gold there are more COO tests in scanpy that don’t get triggered.

Did https://github.com/scverse/anndata/pull/1829 disallow CS* matrices in all the spots it should have?