### PR TITLE
(fix): import `skimage` early in `scublets` without `threshold`

### DIFF
--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -178,7 +178,7 @@ def scrublet(
     """
 
     if threshold is None and not find_spec("skimage"):  # pragma: no cover
-        # Scrublet.call_doublets requires `skimage` with `threshold` but PCA
+        # Scrublet.call_doublets requires `skimage` with `threshold=None` but PCA
         # is called early, which is wasteful if there is not `skimage`
         msg = "threshold is None and thus scrublet requires skimage, but skimage is not installed."
         raise ValueError(msg)

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -177,7 +177,7 @@ def scrublet(
         scores for observed transcriptomes and simulated doublets.
     """
 
-    if threshold is None and not find_spec("skimage"):
+    if threshold is None and not find_spec("skimage"): # pragma: no cover
         # Scrublet.call_doublets requires `skimage` with `threshold` but PCA
         # is called early, which is wasteful if there is not `skimage`
         msg = "threshold is None and thus scrublet requires skimage, but skimage is not installed."

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from importlib.util import find_spec
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -175,6 +176,12 @@ def scrublet(
     :func:`~scanpy.pl.scrublet_score_distribution`: Plot histogram of doublet
         scores for observed transcriptomes and simulated doublets.
     """
+
+    if threshold is None and not find_spec("skimage"):
+        # Scrublet.call_doublets requires `skimage` with `threshold` but PCA
+        # is called early, which is wasteful if there is not `skimage`
+        msg = "threshold is None and thus scrublet requires skimage, but skimage is not installed."
+        raise ValueError(msg)
 
     if copy:
         adata = adata.copy()

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -177,7 +177,7 @@ def scrublet(
         scores for observed transcriptomes and simulated doublets.
     """
 
-    if threshold is None and not find_spec("skimage"): # pragma: no cover
+    if threshold is None and not find_spec("skimage"):  # pragma: no cover
         # Scrublet.call_doublets requires `skimage` with `threshold` but PCA
         # is called early, which is wasteful if there is not `skimage`
         msg = "threshold is None and thus scrublet requires skimage, but skimage is not installed."


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3459
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: No behavior change
