### PR TITLE
Deduplicate _reorder_categories_after_dendrogram and _plot_var_groups_brackets

### DIFF
--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -2148,6 +2148,7 @@ def _plot_var_groups_brackets(
     right_adjustment: float = 0.3,
     rotation: float | None = None,
     orientation: Literal["top", "right"] = "top",
+    wide: bool = False,
 ) -> None:
     """Draw brackets that represent groups of genes on the give axis.
 
@@ -2187,7 +2188,6 @@ def _plot_var_groups_brackets(
     from matplotlib.path import Path
 
     # get the 'brackets' coordinates as lists of start and end positions
-
     left = [x[0] + left_adjustment for x in var_groups.positions]
     right = [x[1] + right_adjustment for x in var_groups.positions]
 
@@ -2209,25 +2209,22 @@ def _plot_var_groups_brackets(
             codes.append(Path.LINETO)
             codes.append(Path.LINETO)
 
-            try:
-                group_x_center = left[idx] + float(right[idx] - left[idx]) / 2
-                var_groups_ax.text(
-                    group_x_center,
-                    1.1,
-                    var_groups.labels[idx],
-                    ha="center",
-                    va="bottom",
-                    rotation=rotation,
-                )
-            except Exception:  # TODO catch the correct exception
-                pass
+            group_x_center = left[idx] + float(right[idx] - left[idx]) / 2
+            var_groups_ax.text(
+                group_x_center,
+                1.1,
+                var_groups.labels[idx],
+                ha="center",
+                va="bottom",
+                rotation=rotation,
+            )
     else:
         top = left
         bottom = right
         for idx in range(len(top)):
             verts.append((0, top[idx]))  # upper-left
-            verts.append((0.15, top[idx]))  # upper-right
-            verts.append((0.15, bottom[idx]))  # lower-right
+            verts.append((0.4 if wide else 0.15, top[idx]))  # upper-right
+            verts.append((0.4 if wide else 0.15, bottom[idx]))  # lower-right
             verts.append((0, bottom[idx]))  # lower-left
 
             codes.append(Path.MOVETO)
@@ -2235,27 +2232,23 @@ def _plot_var_groups_brackets(
             codes.append(Path.LINETO)
             codes.append(Path.LINETO)
 
-            try:
-                diff = bottom[idx] - top[idx]
-                group_y_center = top[idx] + float(diff) / 2
-                # cut label to fit available space
-                label = (
-                    var_groups.labels[idx][: int(diff * 2)] + "."
-                    if diff * 2 < len(var_groups.labels[idx])
-                    else var_groups.labels[idx]
-                )
-                var_groups_ax.text(
-                    0.6,
-                    group_y_center,
-                    label,
-                    ha="right",
-                    va="center",
-                    rotation=270,
-                    fontsize="small",
-                )
-            except Exception as e:
-                print(f"problems {e}")
-                pass
+            diff = bottom[idx] - top[idx]
+            group_y_center = top[idx] + float(diff) / 2
+            # cut label to fit available space
+            label = (
+                var_groups.labels[idx][: int(diff * 2)] + "."
+                if diff * 2 < len(var_groups.labels[idx])
+                else var_groups.labels[idx]
+            )
+            var_groups_ax.text(
+                1.1 if wide else 0.6,
+                group_y_center,
+                label,
+                ha="right",
+                va="center",
+                rotation=270,
+                fontsize="small",
+            )
 
     path = Path(verts, codes)
 

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -1475,7 +1475,7 @@ def heatmap(
             gene_groups_ax = fig.add_subplot(axs[1, 1])
             arr = []
             for idx, (label, pos) in enumerate(
-                zip(var_groups.labels, var_groups.positions)
+                zip(*var_groups)
             ):
                 label_code = label2code[label] if var_groups_subset_of_groupby else idx
                 arr += [label_code] * (pos[1] + 1 - pos[0])

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -1474,9 +1474,7 @@ def heatmap(
         if var_groups is not None:
             gene_groups_ax = fig.add_subplot(axs[1, 1])
             arr = []
-            for idx, (label, pos) in enumerate(
-                zip(*var_groups)
-            ):
+            for idx, (label, pos) in enumerate(zip(*var_groups)):
                 label_code = label2code[label] if var_groups_subset_of_groupby else idx
                 arr += [label_code] * (pos[1] + 1 - pos[0])
             gene_groups_ax.imshow(

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -1171,11 +1171,9 @@ def heatmap(
     )
 
     # check if var_group_labels are a subset of categories:
-    if var_groups is not None:
-        if set(var_groups.labels).issubset(categories):
-            var_groups_subset_of_groupby = True
-        else:
-            var_groups_subset_of_groupby = False
+    var_groups_subset_of_groupby = var_groups is not None and set(
+        var_groups.labels
+    ).issubset(categories)
 
     if standard_scale == "obs":
         obs_tidy = obs_tidy.sub(obs_tidy.min(1), axis=0)
@@ -1225,8 +1223,7 @@ def heatmap(
             categories=categories,
         )
 
-        var_group_labels = dendro_data["var_group_labels"]
-        var_group_positions = dendro_data["var_group_positions"]
+        var_groups = dendro_data["var_groups"]
 
         # reorder obs_tidy
         if dendro_data["var_names_idx_ordered"] is not None:
@@ -1279,7 +1276,7 @@ def heatmap(
             width, height = figsize
             heatmap_width = width - (dendro_width + groupby_width)
 
-        if var_group_positions is not None and len(var_group_positions) > 0:
+        if var_groups is not None and len(var_groups.positions) > 0:
             # add some space in case 'brackets' want to be plotted on top of the image
             height_ratios = [0.15, height]
         else:
@@ -1354,12 +1351,12 @@ def heatmap(
             )
 
         # plot group legends on top of heatmap_ax (if given)
-        if var_group_positions is not None and len(var_group_positions) > 0:
+        if var_groups is not None and len(var_groups.positions) > 0:
             gene_groups_ax = fig.add_subplot(axs[0, 1], sharex=heatmap_ax)
             _plot_gene_groups_brackets(
                 gene_groups_ax,
-                group_positions=var_group_positions,
-                group_labels=var_group_labels,
+                group_positions=var_groups.positions,
+                group_labels=var_groups.labels,
                 rotation=var_group_rotation,
                 left_adjustment=-0.3,
                 right_adjustment=0.3,
@@ -1386,7 +1383,7 @@ def heatmap(
 
         height_ratios = [dendro_height, heatmap_height, groupby_height]
 
-        if var_group_positions is not None and len(var_group_positions) > 0:
+        if var_groups is not None and len(var_groups.positions) > 0:
             # add some space in case 'brackets' want to be plotted on top of the image
             width_ratios = [width, 0.14, colorbar_width]
         else:
@@ -1456,11 +1453,11 @@ def heatmap(
             )
 
         # plot group legends next to the heatmap_ax (if given)
-        if var_group_positions is not None and len(var_group_positions) > 0:
+        if var_groups is not None and len(var_groups.positions) > 0:
             gene_groups_ax = fig.add_subplot(axs[1, 1])
             arr = []
             for idx, (label, pos) in enumerate(
-                zip(var_group_labels, var_group_positions)
+                zip(var_groups.labels, var_groups.positions)
             ):
                 label_code = label2code[label] if var_groups_subset_of_groupby else idx
                 arr += [label_code] * (pos[1] + 1 - pos[0])
@@ -1477,7 +1474,7 @@ def heatmap(
         return_ax_dict["groupby_ax"] = groupby_ax
     if dendrogram:
         return_ax_dict["dendrogram_ax"] = dendro_ax
-    if var_group_positions is not None and len(var_group_positions) > 0:
+    if var_groups is not None and len(var_groups.positions) > 0:
         return_ax_dict["gene_groups_ax"] = gene_groups_ax
 
     _utils.savefig_or_show("heatmap", show=show, save=save)

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -13,7 +13,12 @@ from matplotlib import pyplot as plt
 from .. import logging as logg
 from .._compat import old_positionals
 from .._utils import _empty
-from ._anndata import VarGroups, _plot_dendrogram, _prepare_dataframe
+from ._anndata import (
+    VarGroups,
+    _plot_dendrogram,
+    _prepare_dataframe,
+    _reorder_categories_after_dendrogram,
+)
 from ._utils import check_colornorm, make_grid_spec
 
 if TYPE_CHECKING:
@@ -888,12 +893,10 @@ class BasePlot:
         Returns
         -------
         `None`, internally updates
-        'categories_idx_ordered', 'var_group_names_idx_ordered',
-        'var_group_labels' and 'var_group_positions'
+        `categories_idx_ordered`, `var_group_names_idx_ordered`,
+        `var_group_labels`, `var_group_positions`, and `var_groups`
 
         """
-        from ._anndata import _reorder_categories_after_dendrogram
-
         rv = _reorder_categories_after_dendrogram(
             self.adata,
             self.groupby,

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -790,6 +790,7 @@ class BasePlot:
                 left_adjustment=0.2,
                 right_adjustment=0.7,
                 orientation=var_group_orientation,
+                wide=True,
             )
             return_ax_dict["gene_group_ax"] = gene_groups_ax
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3489
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: dev change

Only change should be that `BasePlot._reorder_categories_after_dendrogram` sets `self.var_groups` which can be reordered