### PR TITLE
(fix): dont use `np.ndarray` argument for `obs`

### DIFF
--- a/tests/external/test_hashsolo.py
+++ b/tests/external/test_hashsolo.py
@@ -24,7 +24,7 @@ def test_cell_demultiplexing():
         col_pos = (idx % 10) - 1
         x[idx, col_pos] = signal_count
 
-    test_data = AnnData(np.random.randint(0, 100, size=x.shape), obs=x)
+    test_data = AnnData(np.random.randint(0, 100, size=x.shape), obs=pd.DataFrame(x))
     sce.pp.hashsolo(test_data, test_data.obs.columns)
 
     doublets = ["Doublet"] * 10


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Preferred to https://github.com/scverse/anndata/pull/1912 and closes #3505 and closes #3506
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: testing change
