### PR TITLE
refactor: `normalize_total` with Numba

### DIFF
--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -277,13 +277,14 @@ def normalize_total(  # noqa: PLR0912
     if x is None:
         msg = f"Layer {layer!r} not found in adata."
         raise ValueError(msg)
-    msg = "normalizing counts per cell"
     if isinstance(x, CSCBase):
         x = x.tocsr()
     if not inplace:
         x = x.copy()
     if issubclass(x.dtype.type, int | np.integer):
         x = x.astype(np.float32)  # TODO: Check if float64 should be used
+
+    start = logg.info("normalizing counts per cell")
 
     X, counts_per_cell, gene_subset = _normalize_total_helper(
         x,
@@ -293,11 +294,11 @@ def normalize_total(  # noqa: PLR0912
     )
 
     if exclude_highly_expressed:
-        msg += (
-            ". The following highly-expressed genes are not considered during "
-            f"normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}"
+        logg.info(
+            "The following highly-expressed genes are not considered during normalization factor computation:\n"
+            f"{adata.var_names[~gene_subset].tolist()}"
         )
-    start = logg.info(msg)
+
     cell_subset = counts_per_cell > 0
     if not isinstance(cell_subset, DaskArray) and not np.all(cell_subset):
         warn("Some cells have zero counts", UserWarning, stacklevel=2)

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -278,7 +278,6 @@ def normalize_total(  # noqa: PLR0912
         msg = f"Layer {layer!r} not found in adata."
         raise ValueError(msg)
     msg = "normalizing counts per cell"
-    start = logg.info(msg)
     if isinstance(x, CSCBase):
         x = x.tocsr()
     if not inplace:
@@ -294,11 +293,11 @@ def normalize_total(  # noqa: PLR0912
     )
 
     if exclude_highly_expressed:
-        msg = (
+        msg += (
             ". The following highly-expressed genes are not considered during "
             f"normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}"
         )
-        logg.info(msg)
+    start = logg.info(msg)
     cell_subset = counts_per_cell > 0
     if not isinstance(cell_subset, DaskArray) and not np.all(cell_subset):
         warn("Some cells have zero counts", UserWarning, stacklevel=2)

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -33,9 +33,6 @@ def _compute_nnz_median(counts: np.ndarray | DaskArray) -> np.floating:
 
 
 def _normalize_data(X, counts, after=None, *, copy: bool = False):
-    X = X.copy() if copy else X
-    if issubclass(X.dtype.type, int | np.integer):
-        X = X.astype(np.float32)  # TODO: Check if float64 should be used
     if after is None:
         after = _compute_nnz_median(counts)
     counts = counts / after
@@ -53,7 +50,6 @@ def _normalize_csr(
     *,
     rows,
     columns,
-    target_sum,
     exclude_highly_expressed: bool = False,
     max_fraction: float = 0.05,
     n_threads: int = 10,
@@ -84,13 +80,24 @@ def _normalize_csr(
                     count += data[j]
             counts_per_cell[i] = count
 
-    if target_sum == 0:
-        target_sum = np.median(counts_per_cell)
+    return counts_per_cell, counts_per_cols
+
+
+@njit
+def _divide_target_sum(
+    indptr,
+    indices,
+    data,
+    *,
+    rows,
+    columns,
+    target_sum,
+    counts_per_cell,
+):
     for i in numba.prange(rows):
         count = counts_per_cell[i] / target_sum
         for j in range(indptr[i], indptr[i + 1]):
             data[j] /= count
-    return counts_per_cell, target_sum, counts_per_cols
 
 
 @old_positionals(
@@ -227,52 +234,45 @@ def normalize_total(  # noqa: PLR0912, PLR0915
     view_to_actual(adata)
 
     x = _get_obs_rep(adata, layer=layer)
+    if x is None:
+        msg = f"Layer {layer!r} not found in adata."
+        raise ValueError(msg)
+    msg = "normalizing counts per cell"
+    start = logg.info(msg)
+    if isinstance(x, CSCBase):
+        x = x.tocsr()
+    if not inplace:
+        x = x.copy()
+    if issubclass(x.dtype.type, int | np.integer):
+        x = x.astype(np.float32)  # TODO: Check if float64 should be used
 
     if isinstance(x, CSBase):
-        msg = "normalizing counts per cell"
-        start = logg.info(msg)
-        if isinstance(x, CSCBase):
-            x = x.tocsr()
-        elif not inplace:
-            x = x.copy()
-        if issubclass(x.dtype.type, int | np.integer):
-            x = x.astype(np.float32)  # TODO: Check if float64 should be used
         n_threads = numba.get_num_threads()
+        counts_per_cell, counts_per_cols = _normalize_csr(
+            x.indptr,
+            x.indices,
+            x.data,
+            rows=x.shape[0],
+            columns=x.shape[1],
+            exclude_highly_expressed=exclude_highly_expressed,
+            max_fraction=max_fraction,
+            n_threads=n_threads,
+        )
         if target_sum is None:
-            target_sum = 0
-        counts_per_cell, target_sum, counts_per_cols = _normalize_csr(
+            target_sum = np.median(counts_per_cell)
+        _divide_target_sum(
             x.indptr,
             x.indices,
             x.data,
             rows=x.shape[0],
             columns=x.shape[1],
             target_sum=target_sum,
-            exclude_highly_expressed=exclude_highly_expressed,
-            max_fraction=max_fraction,
-            n_threads=n_threads,
+            counts_per_cell=counts_per_cell,
         )
         if exclude_highly_expressed:
-            gene_subset = np.where(counts_per_cols)
-            msg = (
-                "The following highly-expressed genes are not considered during "
-                f"normalization factor computation:\n{adata.var_names[gene_subset].tolist()}"
-            )
-            logg.info(msg)
-        if inplace:
-            if key_added is not None:
-                adata.obs[key_added] = counts_per_cell
-            _set_obs_rep(adata, x, layer=layer)
-        else:
-            # not recarray because need to support sparse
-            dat = dict(
-                X=x,
-                norm_factor=counts_per_cell,
-            )
+            gene_subset = np.where(counts_per_cols)[0]
 
     else:
-        gene_subset = None
-        msg = "normalizing counts per cell"
-
         counts_per_cell = axis_sum(x, axis=1)
         if exclude_highly_expressed:
             counts_per_cell = np.ravel(counts_per_cell)
@@ -283,31 +283,31 @@ def normalize_total(  # noqa: PLR0912, PLR0915
                 (x > counts_per_cell[:, None] * max_fraction), axis=0
             )
             gene_subset = np.asarray(np.ravel(gene_subset) == 0)
-
-            msg += (
-                ". The following highly-expressed genes are not considered during "
-                f"normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}"
-            )
             counts_per_cell = axis_sum(x[:, gene_subset], axis=1)
-        start = logg.info(msg)
         counts_per_cell = np.ravel(counts_per_cell)
 
-        cell_subset = counts_per_cell > 0
-        if not isinstance(cell_subset, DaskArray) and not np.all(cell_subset):
-            warn("Some cells have zero counts", UserWarning, stacklevel=2)
+    if exclude_highly_expressed:
+        msg = (
+            ". The following highly-expressed genes are not considered during "
+            f"normalization factor computation:\n{adata.var_names[~gene_subset].tolist()}"
+        )
+        logg.info(msg)
+    cell_subset = counts_per_cell > 0
+    if not isinstance(cell_subset, DaskArray) and not np.all(cell_subset):
+        warn("Some cells have zero counts", UserWarning, stacklevel=2)
 
-        if inplace:
-            if key_added is not None:
-                adata.obs[key_added] = counts_per_cell
-            _set_obs_rep(
-                adata, _normalize_data(x, counts_per_cell, target_sum), layer=layer
-            )
-        else:
-            # not recarray because need to support sparse
-            dat = dict(
-                X=_normalize_data(x, counts_per_cell, target_sum, copy=True),
-                norm_factor=counts_per_cell,
-            )
+    X = x
+    if not isinstance(x, CSBase):
+        X = _normalize_data(x, counts_per_cell, target_sum, copy=not inplace)
+
+    dat = dict(
+        X=X,
+        norm_factor=counts_per_cell,
+    )
+    if inplace:
+        if key_added is not None:
+            adata.obs[key_added] = dat["norm_factor"]
+        _set_obs_rep(adata, dat["X"], layer=layer)
 
     logg.info(
         "    finished ({time_passed})",


### PR DESCRIPTION
Hi this PR integrates the recent commits and refactors on https://github.com/scverse/scanpy/pull/3571.


Here I removed the division part from the numba code so that it is unified in the future with fast-array-utils elem_mult.

pinging bc I can't ask for reviews for some reason: @flying-sheep 