### PR TITLE
Fix `pp.scale` returning a Dask Array with `np.matrix` chunks

### DIFF
--- a/docs/release-notes/3597.bugfix.md
+++ b/docs/release-notes/3597.bugfix.md
@@ -1,1 +1,1 @@
-Prevent {func}`scanpy.pp.scale` from creating a dask {class}`~dask.arrays.Array` with {class}`numpy.matrix` chunks {smaller}`P Angerer`
+Prevent {func}`scanpy.pp.scale` from creating a dask {class}`~dask.array.Array` with {class}`numpy.matrix` chunks {smaller}`P Angerer`

--- a/docs/release-notes/3597.bugfix.md
+++ b/docs/release-notes/3597.bugfix.md
@@ -1,0 +1,1 @@
+Prevent {func}`scanpy.pp.scale` from creating a dask {class}`~dask.arrays.Array` with {class}`numpy.matrix` chunks {smaller}`P Angerer`

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -200,6 +200,8 @@ def scale_array(  # noqa: PLR0912
                 stacklevel=2,
             )
         X -= mean
+        if isinstance(X, DaskArray) and isinstance(X._meta, np.matrix):
+            X = X.map_blocks(lambda x: x.A, dtype=X.dtype)
 
     out = X if isinstance(X, np.ndarray | CSBase) else None
     X = axis_mul_or_truediv(X, std, op=truediv, out=out, axis=1)

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -201,7 +201,7 @@ def scale_array(  # noqa: PLR0912
             )
         X -= mean
         if isinstance(X, DaskArray) and isinstance(X._meta, np.matrix):
-            X = X.map_blocks(lambda x: x.A, dtype=X.dtype)
+            X = X.map_blocks(np.matrix.__array__, meta=np.array([], X.dtype))
 
     out = X if isinstance(X, np.ndarray | CSBase) else None
     X = axis_mul_or_truediv(X, std, op=truediv, out=out, axis=1)

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -298,8 +298,10 @@ def test_sample_copy_backed_error(tmp_path):
 
 
 @pytest.mark.parametrize("array_type", ARRAY_TYPES)
-@pytest.mark.parametrize("zero_center", [True, False])
-@pytest.mark.parametrize("max_value", [None, 1.0])
+@pytest.mark.parametrize(
+    "zero_center", [True, False], ids=["zero_center", "no_zero_center"]
+)
+@pytest.mark.parametrize("max_value", [None, 1.0], ids=["no_clip", "clip"])
 def test_scale_matrix_types(array_type, zero_center, max_value):
     adata = pbmc68k_reduced()
     adata.X = adata.raw.X
@@ -310,6 +312,7 @@ def test_scale_matrix_types(array_type, zero_center, max_value):
         sc.pp.scale(adata_casted, zero_center=zero_center, max_value=max_value)
     X = adata_casted.X
     if "dask" in array_type.__name__:
+        assert not isinstance(X._meta, np.matrix)
         X = X.compute()
     if isinstance(X, CSBase):
         X = X.todense()

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -73,46 +73,36 @@ X_scaled_for_mask_clipped = [
     [np.array, sparse.csr_matrix, sparse.csc_matrix],  # noqa: TID251
     ids=lambda x: x.__name__,
 )
-@pytest.mark.parametrize("dtype", ["float32", "int64"])
+@pytest.mark.parametrize("container", ["anndata", "array"])
+@pytest.mark.parametrize("dtype", [np.float32, np.int64])
+@pytest.mark.parametrize("zero_center", [True, False], ids=["center", "no_center"])
 @pytest.mark.parametrize(
-    ("mask_obs", "X", "X_centered", "X_scaled"),
+    ("mask_obs", "x", "x_centered", "x_scaled"),
     [
-        (None, X_original, X_centered_original, X_scaled_original),
-        (
+        pytest.param(
+            None, X_original, X_centered_original, X_scaled_original, id="no_mask"
+        ),
+        pytest.param(
             np.array((0, 0, 1, 1, 1, 0, 0), dtype=bool),
             X_for_mask,
             X_centered_for_mask,
             X_scaled_for_mask,
+            id="mask",
         ),
     ],
 )
-def test_scale(*, typ, dtype, mask_obs, X, X_centered, X_scaled):
-    # test AnnData arguments
-    # test scaling with default zero_center == True
-    adata0 = AnnData(typ(X).astype(dtype))
-    sc.pp.scale(adata0, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(adata0.X).toarray(), X_centered)  # noqa: TID251
-    # test scaling with explicit zero_center == True
-    adata1 = AnnData(typ(X).astype(dtype))
-    sc.pp.scale(adata1, zero_center=True, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(adata1.X).toarray(), X_centered)  # noqa: TID251
-    # test scaling with explicit zero_center == False
-    adata2 = AnnData(typ(X).astype(dtype))
-    sc.pp.scale(adata2, zero_center=False, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(adata2.X).toarray(), X_scaled)  # noqa: TID251
-    # test bare count arguments, for simplicity only with explicit copy=True
-    # test scaling with default zero_center == True
-    data0 = typ(X, dtype=dtype)
-    cdata0 = sc.pp.scale(data0, copy=True, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(cdata0).toarray(), X_centered)  # noqa: TID251
-    # test scaling with explicit zero_center == True
-    data1 = typ(X, dtype=dtype)
-    cdata1 = sc.pp.scale(data1, zero_center=True, copy=True, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(cdata1).toarray(), X_centered)  # noqa: TID251
-    # test scaling with explicit zero_center == False
-    data2 = typ(X, dtype=dtype)
-    cdata2 = sc.pp.scale(data2, zero_center=False, copy=True, mask_obs=mask_obs)
-    assert np.allclose(sparse.csr_matrix(cdata2).toarray(), X_scaled)  # noqa: TID251
+def test_scale(
+    *, typ, container, zero_center, dtype, mask_obs, x, x_centered, x_scaled
+):
+    x = AnnData(typ(x, dtype=dtype)) if container == "anndata" else typ(x, dtype=dtype)
+    scaled = sc.pp.scale(
+        x, zero_center=zero_center, copy=container == "array", mask_obs=mask_obs
+    )
+    received = sparse.csr_matrix(  # noqa: TID251
+        x.X if scaled is None else scaled
+    ).toarray()
+    expected = x_centered if zero_center else x_scaled
+    assert np.allclose(received, expected)
 
 
 def test_mask_string():
@@ -135,22 +125,23 @@ def test_clip(zero_center):
 
 
 @pytest.mark.parametrize(
-    ("mask_obs", "X", "X_scaled", "X_clipped"),
+    ("mask_obs", "x", "x_scaled", "x_clipped"),
     [
-        (None, X_original, X_scaled_original, X_scaled_original_clipped),
-        (
+        pytest.param(
+            None, X_original, X_scaled_original, X_scaled_original_clipped, id="no_mask"
+        ),
+        pytest.param(
             np.array((0, 0, 1, 1, 1, 0, 0), dtype=bool),
             X_for_mask,
             X_scaled_for_mask,
             X_scaled_for_mask_clipped,
+            id="mask",
         ),
     ],
 )
-def test_scale_sparse(*, mask_obs, X, X_scaled, X_clipped):
-    adata0 = AnnData(sparse.csr_matrix(X).astype(np.float32))  # noqa: TID251
-    sc.pp.scale(adata0, mask_obs=mask_obs, zero_center=False)
-    assert np.allclose(sparse.csr_matrix(adata0.X).toarray(), X_scaled)  # noqa: TID251
-    # test scaling with explicit zero_center == True
-    adata1 = AnnData(sparse.csr_matrix(X).astype(np.float32))  # noqa: TID251
-    sc.pp.scale(adata1, zero_center=False, mask_obs=mask_obs, max_value=1)
-    assert np.allclose(sparse.csr_matrix(adata1.X).toarray(), X_clipped)  # noqa: TID251
+@pytest.mark.parametrize("clip", [False, True], ids=["no_clip", "clip"])
+def test_scale_sparse(*, mask_obs, x, x_scaled, x_clipped, clip):
+    max_value, expected = (1, x_clipped) if clip else (None, x_scaled)
+    adata = AnnData(sparse.csr_matrix(x).astype(np.float32))  # noqa: TID251
+    sc.pp.scale(adata, mask_obs=mask_obs, zero_center=False, max_value=max_value)
+    assert np.allclose(sparse.csr_matrix(adata.X).toarray(), expected)  # noqa: TID251


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3594
- [x] Tests included
<!-- Only check the following box if you did not include release notes -->
- [ ] Release notes not necessary because:
