### PR TITLE
Remove old bounds

### DIFF
--- a/docs/release-notes/3611.bugfix.md
+++ b/docs/release-notes/3611.bugfix.md
@@ -1,1 +1,1 @@
-Allow using {mod}`sklearn` ≥1.6, {mod}`dask` ≥2024.8, and `sphinx` ≥8.2.1 {smaller}`P Angerer`
+Allow using {mod}`sklearn` ≥1.6, {doc}`dask:index` ≥2024.8, and `sphinx` ≥8.2.1 {smaller}`P Angerer`

--- a/docs/release-notes/3611.bugfix.md
+++ b/docs/release-notes/3611.bugfix.md
@@ -1,0 +1,1 @@
+Allow using {mod}`sklearn` ≥1.6, {mod}`dask` ≥2024.8, and `sphinx` ≥8.2.1 {smaller}`P Angerer`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,7 @@ test-full = [
     "scanpy[dask-ml]",
 ]
 doc = [
-    # https://github.com/sphinx-doc/sphinx/issues/13366
-    "sphinx>=7,<8.2.0",
+    "sphinx >=7, !=8.2.0",
     "sphinx-book-theme>=1.1.0",
     "scanpydoc>=0.15.3",
     "sphinx-autodoc-typehints>=1.25.2",
@@ -150,7 +149,7 @@ scanorama = [ "scanorama" ]                      # Scanorama dataset integration
 scrublet = [ "scikit-image>=0.20" ]              # Doublet detection with automatic thresholds
 # Acceleration
 rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ] # GPU accelerated calculation of neighbors
-dask = [ "dask[array]>=2023.5.1,<2024.8.0" ]          # Use the Dask parallelization engine
+dask = [ "dask[array]>=2023.5.1" ]                    # Use the Dask parallelization engine
 dask-ml = [ "dask-ml", "scanpy[dask]" ]               # Dask-ML for sklearn-like API
 
 [tool.hatch.build.targets.wheel]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
     "seaborn>=0.13",
     "h5py>=3.8",
     "tqdm",
-    "scikit-learn>=1.1,<1.6",
+    "scikit-learn>=1.1",
     "statsmodels>=0.14",
     "patsy!=1.0.0",                               # https://github.com/pydata/patsy/issues/215
     "networkx>=2.8",


### PR DESCRIPTION
- sphinx≠8.2.0 is OK: https://github.com/sphinx-doc/sphinx/pull/13382
- dask>=2024.8 is OK with anndata ≥0.11.1: https://github.com/scverse/anndata/pull/1745
- scikit-learn≥1.6 is OK with `dask-ml` ≥2025.1: https://github.com/dask/dask-ml/pull/1008