### PR TITLE
Catch all exceptions getting version from VCS, fallback to `importlib`

### DIFF
--- a/src/scanpy/_version.py
+++ b/src/scanpy/_version.py
@@ -5,12 +5,19 @@ See <https://github.com/maresb/hatch-vcs-footgun-example>.
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 
 __all__ = ["__version__"]
 
+_PROJECT_NAME = "scanpy"
 
-def _get_version_from_vcs() -> str:  # pragma: no cover
+
+class GetVersionError(Exception):
+    pass
+
+
+def _get_version_from_vcs(project_name: str) -> str:  # pragma: no cover
     from hatchling.metadata.core import ProjectMetadata
     from hatchling.plugin.exceptions import UnknownPluginError
     from hatchling.plugin.manager import PluginManager
@@ -23,15 +30,33 @@ def _get_version_from_vcs() -> str:  # pragma: no cover
     metadata = ProjectMetadata(root=str(root), plugin_manager=PluginManager())
     try:
         # Version can be either statically set in pyproject.toml or computed dynamically:
-        return metadata.core.version or metadata.hatch.version.cached
+        version = metadata.core.version or metadata.hatch.version.cached
     except UnknownPluginError as e:
         msg = "Unable to import hatch plugin."
         raise ImportError(msg) from e
+    except ValueError as e:
+        msg = f"Could not find hatchling project data in TOML file, {pyproject_toml}"
+        raise GetVersionError(msg) from e
+    except TypeError as e:
+        msg = "Could not parse build configuration."
+        raise GetVersionError(msg) from e
+    except Exception as e:
+        msg = (
+            f"Unknown error getting version from hatchling config for '{project_name}'."
+        )
+        warnings.warn(f"{msg}: {e}", stacklevel=1)
+        raise GetVersionError(msg) from e
+
+    # We found a hatchling environment, but is it ours?
+    if metadata.core.name != project_name:
+        msg = f"Data in pyproject.toml is not related to {project_name}."
+        raise GetVersionError(msg)
+    return version
 
 
 try:
-    __version__ = _get_version_from_vcs()
-except (ImportError, LookupError):
+    __version__ = _get_version_from_vcs(_PROJECT_NAME)
+except (ImportError, LookupError, GetVersionError):
     import importlib.metadata
 
-    __version__ = importlib.metadata.version("scanpy")
+    __version__ = importlib.metadata.version(_PROJECT_NAME)


### PR DESCRIPTION
`scanpy` has the same issue reported for `anndata` here https://github.com/scverse/anndata/issues/1960 and fixed here https://github.com/scverse/anndata/pull/1972

Mainly, the `_get_version_from_vcs()` function in `src/scanpy/_version.py` breaks when the user has `hatchling` installed and a `pyproject.toml` file is found, but cannot be parsed by `hatch`/`hatchling`.

This fix is a replicate of https://github.com/scverse/anndata/pull/1972, with `_PROJECT_NAME = "scanpy"`

- [X] "Closes" `scanpy` replicate of https://github.com/scverse/anndata/issues/1960
- [ ] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [X] Release notes not necessary because:
