### PR TITLE
(fix): remove filterwarning for `observed=False`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -187,7 +187,6 @@ filterwarnings = [
     "error:Observation names are not unique:UserWarning",
     "error:The dtype argument is deprecated and will be removed:FutureWarning",
     "error:The behavior of DataFrame\\.sum with axis=None is deprecated:FutureWarning",
-    "error:The default of observed=False is deprecated:FutureWarning",
     "error:Series\\.__getitem__ treating keys as positions is deprecated:FutureWarning",
     "error:The default value of 'ignore' for the `na_action` parameter in pandas\\.Categorical\\.map:FutureWarning",
     "error:The provided callable.* is currently using:FutureWarning",


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #2967
- [x] Tests included or not required because: Just removing a warning from the filter
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: just a dev change
