### PR TITLE
 Update numpy array comparisons to use isin

### DIFF
--- a/docs/release-notes/3685.bugfix.md
+++ b/docs/release-notes/3685.bugfix.md
@@ -1,0 +1,1 @@
+Replace deprecated `np.in1d` with `np.isin` to silence deprecation warnings. {smaller}`E Ferdman`

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -470,7 +470,7 @@ def moving_average(a: np.ndarray, n: int):
     a
         One-dimensional array.
     n
-        Number of entries to average over. n=2 means averaging over the currrent
+        Number of entries to average over. n=2 means averaging over the current
         the previous entry.
 
     Returns
@@ -788,7 +788,7 @@ def select_groups(
         if len(groups_ids) == 0:
             # fallback to index retrieval
             groups_ids = np.where(
-                np.in1d(
+                np.isin(
                     np.arange(len(adata.obs[key].cat.categories)).astype(str),
                     np.array(groups_order_subset),
                 )
@@ -971,7 +971,7 @@ class NeighborsView:
 def _choose_graph(
     adata: AnnData, obsp: str | None, neighbors_key: str | None
 ) -> CSBase:
-    """Choose connectivities from neighbbors or another obsp entry."""
+    """Choose connectivities from neighbors or another obsp entry."""
     if obsp is not None and neighbors_key is not None:
         msg = "You can't specify both obsp, neighbors_key. Please select only one."
         raise ValueError(msg)

--- a/src/scanpy/datasets/_datasets.py
+++ b/src/scanpy/datasets/_datasets.py
@@ -205,7 +205,7 @@ def moignard15() -> AnnData:
     backup_url = "https://static-content.springer.com/esm/art%3A10.1038%2Fnbt.3154/MediaObjects/41587_2015_BFnbt3154_MOESM4_ESM.xlsx"
     adata = read(filename, sheet="dCt_values.txt", backup_url=backup_url)
     # filter out 4 genes as in Haghverdi et al. (2016)
-    gene_subset = ~np.in1d(adata.var_names, ["Eif2b1", "Mrpl19", "Polr2a", "Ubc"])
+    gene_subset = ~np.isin(adata.var_names, ["Eif2b1", "Mrpl19", "Polr2a", "Ubc"])
     adata = adata[:, gene_subset].copy()  # retain non-removed genes
     # choose root cell for DPT analysis as in Haghverdi et al. (2016)
     adata.uns["iroot"] = 532  # note that in Matlab/R, counting starts at 1

--- a/tests/test_ingest.py
+++ b/tests/test_ingest.py
@@ -84,7 +84,7 @@ def test_neighbors(adatas):
 
     num_correct = 0.0
     for i in range(adata_new.n_obs):
-        num_correct += np.sum(np.in1d(true_indices[i], indices[i]))
+        num_correct += np.sum(np.isin(true_indices[i], indices[i]))
     percent_correct = num_correct / (adata_new.n_obs * 10)
 
     assert percent_correct > 0.99


### PR DESCRIPTION
# PR Summary
This small PR resolves the NumPy deprecation warnings of `np.in1d` which you can find in the [CI logs](https://github.com/scverse/scanpy/actions/runs/15634719414/job/44046933495#step:6:4520):
```python
/home/runner/work/scanpy/scanpy/tests/test_ingest.py:87: DeprecationWarning: `in1d` is deprecated. Use `np.isin` instead.
```