### PR TITLE
Include `scipy-stubs` in the optional dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,10 +127,10 @@ doc = [
     "sam-algorithm",
 ]
 dev = [
-    "hatch-vcs",  # runtime dev version generation
-    "pre-commit", # static checking
-    "towncrier",  # release note management
-    "scipy-stubs",  # static typing and IDE support
+    "hatch-vcs",   # runtime dev version generation
+    "pre-commit",  # static checking
+    "towncrier",   # release note management
+    "scipy-stubs", # static typing and IDE support
 ]
 # Algorithms
 paga = [ "igraph" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,6 +130,7 @@ dev = [
     "hatch-vcs",  # runtime dev version generation
     "pre-commit", # static checking
     "towncrier",  # release note management
+    "scipy-stubs",  # static typing and IDE support
 ]
 # Algorithms
 paga = [ "igraph" ]


### PR DESCRIPTION
This adds [`scipy-stubs`](https://github.com/scipy/scipy-stubs) as an optional development dependency. It can help quite a bit with IDE supports, such as autocompletion and introspection. It requires no configuration, mypy plugins, and there's no runtime impact.  So even if you don't care about typing annotations, you'll basically improve DX for free :)
