### PR TITLE
fix: recalculate colors when color keys length does not match number of categories

### DIFF
--- a/docs/release-notes/3725.bugfix.md
+++ b/docs/release-notes/3725.bugfix.md
@@ -1,0 +1,1 @@
+Recalculate colors when color keys length does not match number of categories e.g., in {func}`scanpy.pl.umap` {smaller}`Ilan G`

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -1225,14 +1225,20 @@ def _get_palette(adata, values_key: str, palette=None):
         values = pd.Categorical(adata.obs[values_key])
     if palette:
         _utils._set_colors_for_categorical_obs(adata, values_key, palette)
-    elif color_key not in adata.uns or len(adata.uns[color_key]) != len(
+    elif color_key not in adata.uns or len(adata.uns[color_key]) < len(
         values.categories
     ):
-        #  set a default palette in case that no colors or too few/too many colors are found
+        #  set a default palette in case that no colors or too few colors are found
         _utils._set_default_colors_for_categorical_obs(adata, values_key)
     else:
         _utils._validate_palette(adata, values_key)
-    return dict(zip(values.categories, adata.uns[color_key], strict=True))
+    return dict(
+        zip(
+            values.categories,
+            adata.uns[color_key][: len(values.categories)],
+            strict=True,
+        )
+    )
 
 
 def _color_vector(

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -1214,10 +1214,10 @@ def _get_palette(adata, values_key: str, palette=None):
         values = pd.Categorical(adata.obs[values_key])
     if palette:
         _utils._set_colors_for_categorical_obs(adata, values_key, palette)
-    elif color_key not in adata.uns or len(adata.uns[color_key]) < len(
+    elif color_key not in adata.uns or len(adata.uns[color_key]) != len(
         values.categories
     ):
-        #  set a default palette in case that no colors or few colors are found
+        #  set a default palette in case that no colors or too few/too many colors are found
         _utils._set_default_colors_for_categorical_obs(adata, values_key)
     else:
         _utils._validate_palette(adata, values_key)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1787,7 +1787,7 @@ def test_umap_mask_mult_plots():
 
 
 def test_umap_categories_dont_change_when_rerun_with_fewer_categories():
-    """Check that altering the categories of interest does not cause a recalculation of colors."""
+    """Check that lowering the categories of interest does not cause a recalculation of colors."""
     pbmc = pbmc3k_processed()
     _ = sc.pl.umap(pbmc, color="louvain", show=False)
     assert len(pbmc.uns["louvain_colors"]) == len(pbmc.obs["louvain"].cat.categories)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1786,16 +1786,30 @@ def test_umap_mask_mult_plots():
     assert len(axes) == len(color)
 
 
-def test_umap_categories_change():
-    """Check that altering the categories of interest causes a recalculation of colors."""
+def test_umap_categories_dont_change_when_rerun_with_fewer_categories():
+    """Check that altering the categories of interest does not cause a recalculation of colors."""
     pbmc = pbmc3k_processed()
     _ = sc.pl.umap(pbmc, color="louvain", show=False)
     assert len(pbmc.uns["louvain_colors"]) == len(pbmc.obs["louvain"].cat.categories)
+    old_colors = pbmc.uns["louvain_colors"].copy()
     pbmc.obs.loc[pbmc.obs["louvain"] == "NK cells", "louvain"] = "B cells"
     pbmc.obs["louvain"] = pbmc.obs["louvain"].cat.remove_unused_categories()
     # see https://github.com/scverse/scanpy/issues/3716 for why this used to fail
+    # Recalculation of the UMAP should not cause a re-calculation of colors
+    # when there are fewer categories.
+    _ = sc.pl.umap(pbmc, color="louvain", show=False)
+    assert (old_colors == pbmc.uns["louvain_colors"]).all()
+
+
+def test_umap_categories_change_when_rerun_with_more_categories():
+    """Check that growing the categories of interest causes a recalculation of colors."""
+    pbmc = pbmc3k_processed()
     _ = sc.pl.umap(pbmc, color="louvain", show=False)
     assert len(pbmc.uns["louvain_colors"]) == len(pbmc.obs["louvain"].cat.categories)
+    pbmc.obs["louvain"] = pbmc.obs["louvain"].cat.add_categories("New Category")
+    pbmc.obs.loc[pbmc.obs_names[:5], "louvain"] = "New Category"
+    _ = sc.pl.umap(pbmc, color="louvain", show=False)
+    assert len(pbmc.obs["louvain"].cat.categories) == len(pbmc.uns["louvain_colors"])
 
 
 def test_umap_mask_no_modification():

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1754,6 +1754,18 @@ def test_umap_mask_mult_plots():
     assert len(axes) == len(color)
 
 
+def test_umap_categories_change():
+    """Check that altering the categories of interest causes a recalculation of colors."""
+    pbmc = pbmc3k_processed()
+    _ = sc.pl.umap(pbmc, color="louvain", show=False)
+    assert len(pbmc.uns["louvain_colors"]) == len(pbmc.obs["louvain"].cat.categories)
+    pbmc.obs.loc[pbmc.obs["louvain"] == "NK cells", "louvain"] = "B cells"
+    pbmc.obs["louvain"] = pbmc.obs["louvain"].cat.remove_unused_categories()
+    # see https://github.com/scverse/scanpy/issues/3716 for why this used to fail
+    _ = sc.pl.umap(pbmc, color="louvain", show=False)
+    assert len(pbmc.uns["louvain_colors"]) == len(pbmc.obs["louvain"].cat.categories)
+
+
 def test_umap_mask_no_modification():
     """Check that mask_obs argument doesn't affect the data being plotted."""
     pbmc = pbmc3k_processed()


### PR DESCRIPTION

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3716
- [x] Tests included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because:
