### PR TITLE
chore: use `dask` bound from `anndata`

### DIFF
--- a/docs/release-notes/3737.bugfix.md
+++ b/docs/release-notes/3737.bugfix.md
@@ -1,0 +1,1 @@
+Use `dask` version from `anndata` for the `[dask]` extra in `scanpy` {smaller}`I Gold`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ scanorama = [ "scanorama" ]                            # Scanorama dataset integ
 scrublet = [ "scikit-image>=0.20.0" ]                  # Doublet detection with automatic thresholds
 # Acceleration
 rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ] # GPU accelerated calculation of neighbors
-dask = [ "dask[array]>=2023.5.1" ]                    # Use the Dask parallelization engine
+dask = [ "dask[array]>=2023.5.1", "anndata[dask]" ]   # Use the Dask parallelization engine
 dask-ml = [ "dask-ml", "scanpy[dask]" ]               # Dask-ML for sklearn-like API
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->
~~Whether or not this should be merged until the `anndata` PR is merged is up for debate~~

~~I think this PR can be merged as-is.  I think there is a fix in https://github.com/scverse/anndata/pull/2053 that will allow us to continue using latest dask versions safely (hopefully).~~

I think this PR should be merged as-is independent of a fix.  This operation is broken in `anndata` and therefore we shouldn't be promoting its use in the broader ecosystem, at least as much as possible

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] I noticed this inconcsistency after noticing https://github.com/scverse/anndata/pull/2053
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
