### PR TITLE
Backport PR #3737 on branch 1.11.x (chore: use `dask` bound from `anndata`)

### DIFF
--- a/docs/release-notes/3737.bugfix.md
+++ b/docs/release-notes/3737.bugfix.md
@@ -1,0 +1,1 @@
+Use `dask` version from `anndata` for the `[dask]` extra in `scanpy` {smaller}`I Gold`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,7 @@ scanorama = [ "scanorama" ]                       # Scanorama dataset integratio
 scrublet = [ "scikit-image" ]                     # Doublet detection with automatic thresholds
 # Acceleration
 rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ] # GPU accelerated calculation of neighbors
-dask = [ "dask[array]>=2022.09.2" ]                   # Use the Dask parallelization engine
+dask = [ "dask[array]>=2022.09.2", "anndata[dask]" ]  # Use the Dask parallelization engine
 dask-ml = [ "dask-ml", "scanpy[dask]" ]               # Dask-ML for sklearn-like API
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
Backports #3737