### PR TITLE
performance: Refactor BasePlot & subclasses to copy less

### DIFF
--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -14,8 +14,13 @@ from .. import logging as logg
 from .._compat import old_positionals
 from .._utils import _empty
 from ..get._aggregated import aggregate
-from ._anndata import (VarGroups, _plot_dendrogram, _plot_var_groups_brackets,
-                       _prepare_dataframe, _reorder_categories_after_dendrogram)
+from ._anndata import (
+    VarGroups,
+    _plot_dendrogram,
+    _plot_var_groups_brackets,
+    _prepare_dataframe,
+    _reorder_categories_after_dendrogram,
+)
 from ._utils import check_colornorm, make_grid_spec
 
 if TYPE_CHECKING:
@@ -140,7 +145,7 @@ class BasePlot:
         del var_group_labels, var_group_positions
         self.var_group_rotation = var_group_rotation
         self.width, self.height = figsize if figsize is not None else (None, None)
-        
+
         # still need this as pandas handles this procedure more optimally
         self.categories, obs_tidy = _prepare_dataframe(
             adata,
@@ -162,7 +167,6 @@ class BasePlot:
             var=pd.DataFrame(index=var_names),
         )
 
-        
         if len(self.categories) > self.MAX_NUM_CATEGORIES:
             warn(
                 f"Over {self.MAX_NUM_CATEGORIES} categories found. "
@@ -405,11 +409,13 @@ class BasePlot:
 
         _sort = sort is not None
         _ascending = sort == "ascending"
-        counts_df = self._view.obs[self._group_key].value_counts(sort=_sort, ascending=_ascending)
+        counts_df = self._view.obs[self._group_key].value_counts(
+            sort=_sort, ascending=_ascending
+        )
 
         if _sort:
             self.categories_order = list(counts_df.index)
-        
+
         self.plot_group_extra = {
             "kind": "group_totals",
             "width": size,
@@ -419,7 +425,6 @@ class BasePlot:
         }
         return self
 
-    
     def _agg_df(self, func, mask: np.ndarray | None = None) -> pd.DataFrame:
         """
         Aggregate self._view by self._group_key, running `func`
@@ -449,11 +454,11 @@ class BasePlot:
             arr = ag.layers[f]
             out[f] = pd.DataFrame(arr, index=self.categories, columns=self.var_names)
         return out
-    
+
     def _scale_df(
         self,
         standard_scale: Literal["var", "group"] | None = None,
-        df : pd.DataFrame | None = None
+        df: pd.DataFrame | None = None,
     ):
         """
         Performs scaling of `df` based on `standard_scale` parameter
@@ -473,7 +478,7 @@ class BasePlot:
         else:
             logg.warning("Unknown type for standard_scale, ignored")
         return df
-    
+
     @old_positionals("cmap")
     def style(self, *, cmap: Colormap | str | None | Empty = _empty) -> Self:
         r"""Set visual style parameters.

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -165,7 +165,7 @@ class BasePlot:
         self._group_key = obs_tidy.index.name
         self._view = AnnData(
             X=obs_tidy.values,
-            obs=obs_tidy.index.to_frame(index=False),
+            obs={self._group_key: obs_tidy.index},
             var=pd.DataFrame(index=var_names),
         )
 

--- a/src/scanpy/plotting/_dotplot.py
+++ b/src/scanpy/plotting/_dotplot.py
@@ -205,7 +205,7 @@ class DotPlot(BasePlot):
             else:
                 dot_color_df = self._agg_df("mean")
 
-            dot_color_df = self._scale_df(standard_scale, dot_color_df)
+            dot_color_df = self._scale_df(dot_color_df, standard_scale)
         else:
             # check that both matrices have the same shape
             if dot_color_df.shape != dot_size_df.shape:

--- a/src/scanpy/plotting/_dotplot.py
+++ b/src/scanpy/plotting/_dotplot.py
@@ -9,15 +9,10 @@ from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params, _empty
+from ..get._aggregated import aggregate
 from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
-from ._utils import (
-    _dk,
-    check_colornorm,
-    fix_kwds,
-    make_grid_spec,
-    savefig_or_show,
-)
+from ._utils import _dk, check_colornorm, fix_kwds, make_grid_spec, savefig_or_show
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -187,46 +182,26 @@ class DotPlot(BasePlot):
             norm=norm,
             **kwds,
         )
-
-        # for if category defined by groupby (if any) compute for each var_name
-        # 1. the fraction of cells in the category having a value >expression_cutoff
-        # 2. the mean value over the category
-
-        # 1. compute fraction of cells having value > expression_cutoff
-        # transform obs_tidy into boolean matrix using the expression_cutoff
-        obs_bool = self.obs_tidy > expression_cutoff
-
-        # compute the sum per group which in the boolean matrix this is the number
-        # of values >expression_cutoff, and divide the result by the total number of
-        # values in the group (given by `count()`)
         if dot_size_df is None:
-            dot_size_df = (
-                obs_bool.groupby(level=0, observed=True).sum()
-                / obs_bool.groupby(level=0, observed=True).count()
-            )
+            if expression_cutoff > 0:
+                mask = (self._view.X > expression_cutoff).astype(self._view.X.dtype)
+                dot_size_df = self._agg_df("mean", mask=mask)
+            else:
+                df_all = self._agg_df("count_nonzero")
+                # count_nonzero → raw counts, divide by group sizes
+                group_sizes = self._view.obs[self._group_key].value_counts().loc[self.categories].values
+                dot_size_df = df_all.div(group_sizes, axis=0)
 
         if dot_color_df is None:
-            # 2. compute mean expression value value
-            if mean_only_expressed:
-                dot_color_df = (
-                    self.obs_tidy.mask(~obs_bool)
-                    .groupby(level=0, observed=True)
-                    .mean()
-                    .fillna(0)
-                )
+            if mean_only_expressed and expression_cutoff > 0:
+                mask = (self._view.X > expression_cutoff)
+                df_sum = self._agg_df("sum", mask=mask)
+                expr_counts = dot_size_df.values * group_sizes[:, None]
+                dot_color_df = df_sum.div(expr_counts).fillna(0)
             else:
-                dot_color_df = self.obs_tidy.groupby(level=0, observed=True).mean()
-
-            if standard_scale == "group":
-                dot_color_df = dot_color_df.sub(dot_color_df.min(1), axis=0)
-                dot_color_df = dot_color_df.div(dot_color_df.max(1), axis=0).fillna(0)
-            elif standard_scale == "var":
-                dot_color_df -= dot_color_df.min(0)
-                dot_color_df = (dot_color_df / dot_color_df.max(0)).fillna(0)
-            elif standard_scale is None:
-                pass
-            else:
-                logg.warning("Unknown type for standard_scale, ignored")
+                dot_color_df = self._agg_df("mean")
+            
+            dot_color_df = self._scale_df(standard_scale, dot_color_df)
         else:
             # check that both matrices have the same shape
             if dot_color_df.shape != dot_size_df.shape:
@@ -255,12 +230,12 @@ class DotPlot(BasePlot):
             # using the order from the doc_size_df
             dot_color_df = dot_color_df.loc[dot_size_df.index][dot_size_df.columns]
 
-        self.dot_color_df, self.dot_size_df = (
-            df.loc[
-                categories_order if categories_order is not None else self.categories
-            ]
-            for df in (dot_color_df, dot_size_df)
-        )
+
+
+        # reorder rows
+        self.dot_size_df  = dot_size_df.loc[categories_order if categories_order is not None else self.categories]
+        self.dot_color_df = dot_color_df.loc[categories_order if categories_order is not None else self.categories]
+
         self.standard_scale = standard_scale
 
         # Set default style parameters

--- a/src/scanpy/plotting/_matrixplot.py
+++ b/src/scanpy/plotting/_matrixplot.py
@@ -164,7 +164,7 @@ class MatrixPlot(BasePlot):
         if values_df is None:
             values_df = self._agg_df("mean")
 
-        values_df = self._scale_df(standard_scale, values_df)
+        values_df = self._scale_df(values_df, standard_scale)
 
         self.values_df = values_df.loc[
             categories_order if categories_order is not None else self.categories

--- a/src/scanpy/plotting/_matrixplot.py
+++ b/src/scanpy/plotting/_matrixplot.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 import numpy as np
 from matplotlib import colormaps, rcParams
 
-from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params, _empty
@@ -164,13 +163,11 @@ class MatrixPlot(BasePlot):
 
         if values_df is None:
             values_df = self._agg_df("mean")
-        
+
         values_df = self._scale_df(standard_scale, values_df)
 
         self.values_df = values_df.loc[
-            categories_order 
-            if categories_order is not None 
-            else self.categories
+            categories_order if categories_order is not None else self.categories
         ]
 
         self.cmap = self.DEFAULT_COLORMAP

--- a/src/scanpy/plotting/_matrixplot.py
+++ b/src/scanpy/plotting/_matrixplot.py
@@ -10,11 +10,7 @@ from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params, _empty
 from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
-from ._docs import (
-    doc_common_plot_args,
-    doc_show_save_ax,
-    doc_vboundnorm,
-)
+from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
 from ._utils import _dk, check_colornorm, fix_kwds, savefig_or_show
 
 if TYPE_CHECKING:
@@ -167,29 +163,15 @@ class MatrixPlot(BasePlot):
         )
 
         if values_df is None:
-            # compute mean value
-            values_df = (
-                self.obs_tidy.groupby(level=0, observed=True)
-                .mean()
-                .loc[
-                    self.categories_order
-                    if self.categories_order is not None
-                    else self.categories
-                ]
-            )
+            values_df = self._agg_df("mean")
+        
+        values_df = self._scale_df(standard_scale, values_df)
 
-            if standard_scale == "group":
-                values_df = values_df.sub(values_df.min(1), axis=0)
-                values_df = values_df.div(values_df.max(1), axis=0).fillna(0)
-            elif standard_scale == "var":
-                values_df -= values_df.min(0)
-                values_df = (values_df / values_df.max(0)).fillna(0)
-            elif standard_scale is None:
-                pass
-            else:
-                logg.warning("Unknown type for standard_scale, ignored")
-
-        self.values_df = values_df
+        self.values_df = values_df.loc[
+            categories_order 
+            if categories_order is not None 
+            else self.categories
+        ]
 
         self.cmap = self.DEFAULT_COLORMAP
         self.edge_color = self.DEFAULT_EDGE_COLOR

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -226,7 +226,7 @@ class StackedViolin(BasePlot):
         )
         # scale before aggregation
         X = self._view.X.astype(float)
-        X = self._scale_df(standard_scale, X)
+        X = self._scale_df(X, standard_scale)
         # replace view.X with the scaled values (NaNs => 0)
         self._view.X = np.nan_to_num(X)
         # Set default style parameters

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -9,14 +9,18 @@ from matplotlib import colormaps
 from matplotlib.colors import is_color_like
 from packaging.version import Version
 
-from .. import logging as logg
 from .._compat import old_positionals
 from .._settings import settings
 from .._utils import _doc_params, _empty
 from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
 from ._docs import doc_common_plot_args, doc_show_save_ax, doc_vboundnorm
-from ._utils import (_deprecated_scale, _dk, check_colornorm, make_grid_spec,
-                     savefig_or_show)
+from ._utils import (
+    _deprecated_scale,
+    _dk,
+    check_colornorm,
+    make_grid_spec,
+    savefig_or_show,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -371,22 +375,20 @@ class StackedViolin(BasePlot):
         # on the original data frames after repetitive calls to the
         # StackedViolin object, for example once with swap_axes and other without
         _matrix = pd.DataFrame(
-            self._view.X,
-            index=self._view.obs[self._group_key],
-            columns=self.var_names
+            self._view.X, index=self._view.obs[self._group_key], columns=self.var_names
         )
-        
+
         if self.var_names_idx_order is not None:
             _matrix = _matrix.iloc[:, self.var_names_idx_order]
 
         # get mean values for color and transform to color values
         # using colormap
         _color_df = self._agg_df("median").loc[
-            self.categories_order 
-            if self.categories_order is not None 
+            self.categories_order
+            if self.categories_order is not None
             else self.categories
-         ]
-        
+        ]
+
         if self.are_axes_swapped:
             _color_df = _color_df.T
 


### PR DESCRIPTION
- [x] Closes [#3718](https://github.com/scverse/scanpy/issues/3718)
- [x] [Tests][plotting] this is a pure refactor of plotting internals, no new behavior, and all existing plotting tests pass locally (the one failing heatmap test also fails on main in my environment).
<!-- Only check the following box if you did not include release notes -->
- [X] [Release notes][] not necessary because: there are no user-facing API changes, only internal performance and memory optimizations.

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
