### PR TITLE
doc: Add missing pl.correlation_matrix API docs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -38,7 +38,7 @@ jobs:
         id: checked-relnotes
         with:
           text: ${{ github.event.pull_request.body }}
-          regex: '^\s*- \[x\] Release notes not necessary because:(.*)$'
+          regex: '^\s*- \[x\].*Release notes.*not necessary because:(.*)$'
           flags: m
     outputs:
       no-relnotes-reason: ${{ steps.checked-relnotes.outputs.group1 }}

--- a/docs/api/deprecated.md
+++ b/docs/api/deprecated.md
@@ -12,6 +12,7 @@
    pp.filter_genes_dispersion
    pp.normalize_per_cell
    pp.subsample
+   pl.filter_genes_dispersion
    tl.louvain
    logging.print_versions
 ```

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -48,9 +48,9 @@ These classes allow fine tuning of visual parameters.
    :nosignatures:
    :toctree: generated/classes
 
-    pl.DotPlot
-    pl.MatrixPlot
-    pl.StackedViolin
+   pl.DotPlot
+   pl.MatrixPlot
+   pl.StackedViolin
 
 ```
 
@@ -130,6 +130,16 @@ Visualize clusters using one of the embedding methods passing e.g. `color='leide
    pl.paga
    pl.paga_path
    pl.paga_compare
+```
+
+Visualize hierarchical clustering results as a heatmap.
+
+```{eval-rst}
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   pl.correlation_matrix
 ```
 
 #### Marker genes

--- a/docs/api/plotting.md
+++ b/docs/api/plotting.md
@@ -64,7 +64,6 @@ Methods for visualizing quality control and results of preprocessing functions.
    :toctree: generated/
 
    pl.highest_expr_genes
-   pl.filter_genes_dispersion
    pl.highly_variable_genes
    pl.scrublet_score_distribution
 

--- a/src/scanpy/plotting/__init__.py
+++ b/src/scanpy/plotting/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .._compat import deprecated
 from . import palettes
 from ._anndata import (
     clustermap,
@@ -98,11 +99,12 @@ __all__ = [
     "sim",
     "spatial",
     "stacked_violin",
-    "timeseries",
-    "timeseries_as_heatmap",
-    "timeseries_subplot",
     "tracksplot",
     "tsne",
     "umap",
     "violin",
 ]
+
+timeseries = deprecated("Use `dpt_timeseries`.")(timeseries)
+timeseries_as_heatmap = deprecated("Use `dpt_timeseries`.")(timeseries_as_heatmap)
+timeseries_subplot = deprecated("Use `dpt_timeseries`.")(timeseries_subplot)

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -1868,7 +1868,7 @@ def correlation_matrix(  # noqa: PLR0912, PLR0913, PLR0915
     norm: Normalize | None = None,
     **kwds,
 ) -> list[Axes] | None:
-    """Plot the correlation matrix computed as part of `sc.tl.dendrogram`.
+    """Plot the correlation matrix computed as part of :func:`scanpy.tl.dendrogram`.
 
     Parameters
     ----------

--- a/src/scanpy/plotting/_docs.py
+++ b/src/scanpy/plotting/_docs.py
@@ -141,7 +141,7 @@ vmax
 vcenter
     The value representing the center of the color scale. Useful for diverging colormaps.
 norm
-    Custom color normalization object from matplotlib. See ref:`colormapnorms` for details.\
+    Custom color normalization object from matplotlib. See :ref:`colormapnorms` for details.\
 """
 
 doc_outline = """\

--- a/src/scanpy/plotting/_docs.py
+++ b/src/scanpy/plotting/_docs.py
@@ -141,8 +141,7 @@ vmax
 vcenter
     The value representing the center of the color scale. Useful for diverging colormaps.
 norm
-    Custom color normalization object from matplotlib. See
-    `https://matplotlib.org/stable/tutorials/colors/colormapnorms.html` for details.\
+    Custom color normalization object from matplotlib. See ref:`colormapnorms` for details.\
 """
 
 doc_outline = """\


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] Tests included: New tests were added for the core functionality, swap_axes compatibility, and error conditions.
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: Just a small visibility change


Discovered in https://github.com/holoviz-topics/hv-anndata/pull/66

This [prominently displays `correlation_matrix`](https://icb-scanpy--3762.com.readthedocs.build/en/3762/api/plotting.html#branching-trajectories-and-pseudotime-clustering), which is already exported and used in a tutorial.

It also deprecates a few functions that were accidentally in `__all__`.