### PR TITLE
Refactor BasePlot: avoid unnecessary DataFrame conversion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ Thumbs.db
 # asv benchmark files
 /benchmarks/.asv
 /benchmarks/data/
+venv/

--- a/src/scanpy/__init__.py
+++ b/src/scanpy/__init__.py
@@ -91,3 +91,4 @@ __all__ = [
     "tl",
     "write",
 ]
+# TODO: investigate BasePlot DataFrame conversion


### PR DESCRIPTION

This PR prepares a refactor of the BasePlot implementation.

- Currently, BasePlot converts AnnData objects to a Pandas DataFrame internally,
  which can be inefficient and memory-heavy for large single-cell datasets.
- This branch scaffolds a space for replacing `.to_df()` usage with direct access
  to AnnData.obs and NumPy arrays where possible.
- Follow-up commits will add the actual refactor and tests.

This is an initial step to discuss approach and confirm direction before proceeding.

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
