### PR TITLE
docs: fix sc.filter_cells return documentation typo

### DIFF
--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -100,7 +100,7 @@ def filter_cells(
         cell is kept. `False` means the cell is removed.
     number_per_cell
         Depending on what was thresholded (`counts` or `genes`),
-        the array stores `n_counts` or `n_cells` per gene.
+        the array stores `n_counts` or `n_genes` per cell.
 
     Examples
     --------


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3332
- [x] Tests included or not required because: docs
<!-- Only check the following box if you did not include release notes -->
- [x] Release notes not necessary because: just a typo
