### PR TITLE
chore: Backport PR #3840 on branch main ((chore): generate 1.11.5 release notes)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -23,4 +23,3 @@ python:
     extra_requirements:
     - doc
     - dev  # for towncrier
-    - leiden

--- a/docs/release-notes/1.11.5.md
+++ b/docs/release-notes/1.11.5.md
@@ -1,0 +1,14 @@
+(v1.11.5)=
+### 1.11.5 {small}`2025-10-20`
+
+#### Documentation
+
+- Add {doc}`/how-to/cell-cycle` {smaller}`P Angerer` ({pr}`3816`)
+
+#### Bug fixes
+
+- Deprecate `__version__` and use standard {func}`~importlib.metadata.version` API {smaller}`P Angerer` ({pr}`3811`)
+
+#### Performance
+
+- Optimise {func}`scanpy.pp.highly_variable_genes` with `batch_key` set for dask arrays {smaller}`M Mueller` ({pr}`3735`)

--- a/docs/release-notes/3735.perf.md
+++ b/docs/release-notes/3735.perf.md
@@ -1,1 +1,0 @@
-Optimise {func}`scanpy.pp.highly_variable_genes` with `batch_key` set for dask arrays {smaller}`M Mueller`

--- a/docs/release-notes/3811.fix.md
+++ b/docs/release-notes/3811.fix.md
@@ -1,1 +1,0 @@
-Deprecate `__version__` and use standard {func}`~importlib.metadata.version` API {smaller}`P Angerer`

--- a/docs/release-notes/3816.docs.md
+++ b/docs/release-notes/3816.docs.md
@@ -1,1 +1,0 @@
-Add {doc}`/how-to/cell-cycle` {smaller}`P Angerer`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -121,7 +121,7 @@ doc = [
     "ipython>=7.20",                    # for nbsphinx code highlighting
     "sphinxcontrib-bibtex",
     # TODO: remove necessity for being able to import doc-linked classes
-    "scanpy[paga,dask-ml]",
+    "scanpy[paga,dask-ml,leiden]",
     "sam-algorithm",
 ]
 dev = [


### PR DESCRIPTION
- [x] Release notes not necessary because: backport