### PR TITLE
chore: use `uv run`able code sample for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,7 +33,11 @@ body:
   id: code
   attributes:
     label: Minimal code sample
-    description: Reproducible code sample. Must list dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example). When put in a file named `issue.py` calling `uv run issue.py` should show the issue.
+    description: |
+      Reproducible code sample. Must list dependencies in [inline script metadata][]. When put in a file named `issue.py` calling `[uv run][] issue.py` should show the issue.
+
+      [uv run]: https://docs.astral.sh/uv/guides/scripts/#running-a-script-with-dependencies
+      [inline script metadata]: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example
     render: python
     value: |
       ```python

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -33,8 +33,22 @@ body:
   id: code
   attributes:
     label: Minimal code sample
-    description: (that we can copy&paste without having any data)
+    description: Reproducible code sample. Must list dependencies in [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example). When put in a file named `issue.py` calling `uv run issue.py` should show the issue.
     render: python
+    value: |
+      ```python
+      # /// script
+      # requires-python = ">=3.12"
+      # dependencies = [
+      #   "scanpy@git+https://github.com/scverse/scanpy.git@main",
+      # ]
+      # ///
+      #
+      # This script automatically imports the development branch of scanpy to check for issues
+
+      import scanpy as sc
+      # your reproducer code
+        ```
   validations:
     required: true
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -34,7 +34,7 @@ body:
   attributes:
     label: Minimal code sample
     description: |
-      Reproducible code sample. Must list dependencies in [inline script metadata][]. When put in a file named `issue.py` calling `[uv run][] issue.py` should show the issue.
+      Reproducible code sample. Must list dependencies in [inline script metadata][]. When put in a file named `issue.py` using [uv run][] i.e., `uv run issue.py`, should show the issue.
 
       [uv run]: https://docs.astral.sh/uv/guides/scripts/#running-a-script-with-dependencies
       [inline script metadata]: https://packaging.python.org/en/latest/specifications/inline-script-metadata/#example


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

I saw this in https://github.com/zarr-developers/zarr-python/blob/main/.github/ISSUE_TEMPLATE/bug_report.yml and really liked it

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: repo change

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
