### PR TITLE
fix: scanpy benchmark uses `pip` for `igraph` + `setup_cache`

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -48,7 +48,7 @@ jobs:
           key: benchmark-state-${{ hashFiles('benchmarks/**') }}
 
       - name: Install dependencies
-        run: pip install 'asv>=0.6.4'
+        run: pip install 'asv>=0.6.4' py-rattler
 
       - name: Configure ASV
         working-directory: ${{ env.ASV_DIR }}

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -78,7 +78,7 @@
         "natsort": [""],
         "pandas": [""],
         "memory_profiler": [""],
-        "zarr": ["2.18.4"],
+        "zarr": [""],
         "pytest": [""],
         "pip+igraph": [""], // https://github.com/airspeed-velocity/asv/issues/1554
         // "psutil": [""]

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -84,7 +84,7 @@
         // "psutil": [""]
         "pooch": [""],
         "scikit-image": [""],
-        // "scikit-misc": [""],
+        "scikit-misc": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -43,7 +43,7 @@
     // If missing or the empty string, the tool will be automatically
     // determined by looking for tools on the PATH environment
     // variable.
-    "environment_type": "conda",
+    "environment_type": "rattler",
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
@@ -80,8 +80,7 @@
         "memory_profiler": [""],
         "zarr": ["2.18.4"],
         "pytest": [""],
-        "scanpy": [""],
-        "python-igraph": [""],
+        "pip+igraph": [""], // https://github.com/airspeed-velocity/asv/issues/1554
         // "psutil": [""]
         "pooch": [""],
         "scikit-image": [""],

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -83,8 +83,8 @@
         "pip+igraph": [""], // https://github.com/airspeed-velocity/asv/issues/1554
         // "psutil": [""]
         "pooch": [""],
-        "scikit-image": [""],
-        "scikit-misc": [""],
+        "scikit-image": [""], // https://github.com/conda-forge/scikit-misc-feedstock/pull/29
+        // "scikit-misc": [""],
     },
 
     // Combinations of libraries/python versions can be excluded/included

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -55,17 +55,12 @@ class PreprocessingCountsSuite:  # noqa: D101
     def peakmem_scrublet(self, *_):
         sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
+    def time_hvg_seurat_v3(self, *_):
+        # seurat v3 runs on counts
+        sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
 
-# Can’t do seurat v3 yet: https://github.com/conda-forge/scikit-misc-feedstock/issues/17
-"""
-def time_hvg_seurat_v3(self):
-    # seurat v3 runs on counts
-    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
-
-
-def peakmem_hvg_seurat_v3(self):
-    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
-"""
+    def peakmem_hvg_seurat_v3(self, *_):
+        sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
 
 
 class FastSuite:

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -7,69 +7,63 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import anndata as ad
+
 import scanpy as sc
 
 from ._utils import get_count_dataset
 
 if TYPE_CHECKING:
-    from anndata import AnnData
-
     from ._utils import Dataset, KeyCount
-
-# setup variables
-
-adata: AnnData
-batch_key: str | None
-
-
-def setup(dataset: Dataset, layer: KeyCount, *_):
-    """Set up global variables before each benchmark."""
-    global adata, batch_key
-    adata, batch_key = get_count_dataset(dataset, layer=layer)
-    assert "log1p" not in adata.uns
 
 
 # ASV suite
+class PreprocessingCountsSuite:  # noqa: D101
+    params: tuple[list[Dataset], list[KeyCount]] = (
+        ["pbmc68k_reduced", "pbmc3k"],
+        ["counts", "counts-off-axis"],
+    )
+    param_names = ("dataset", "layer")
 
-params: tuple[list[Dataset], list[KeyCount]] = (
-    ["pbmc68k_reduced", "pbmc3k"],
-    ["counts", "counts-off-axis"],
-)
-param_names = ["dataset", "layer"]
+    def setup_cache(self):
+        """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
+        for dataset in self.params[0]:
+            for layer in self.params[1]:
+                adata, batch_key = get_count_dataset(dataset, layer=layer)
+                assert "lop1p" not in adata.uns
+                adata.uns["batch_key"] = batch_key
+                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
 
+    def setup(self, dataset, layer):
+        self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
 
-def time_filter_cells(*_):
-    sc.pp.filter_cells(adata, min_genes=100)
+    def time_filter_cells(self, *_):
+        sc.pp.filter_cells(self.adata, min_genes=100)
 
+    def peakmem_filter_cells(self, *_):
+        sc.pp.filter_cells(self.adata, min_genes=100)
 
-def peakmem_filter_cells(*_):
-    sc.pp.filter_cells(adata, min_genes=100)
+    def time_filter_genes(self, *_):
+        sc.pp.filter_genes(self.adata, min_cells=3)
 
+    def peakmem_filter_genes(self, *_):
+        sc.pp.filter_genes(self.adata, min_cells=3)
 
-def time_filter_genes(*_):
-    sc.pp.filter_genes(adata, min_cells=3)
+    def time_scrublet(self, *_):
+        sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
-
-def peakmem_filter_genes(*_):
-    sc.pp.filter_genes(adata, min_cells=3)
-
-
-def time_scrublet(*_):
-    sc.pp.scrublet(adata, batch_key=batch_key)
-
-
-def peakmem_scrublet(*_):
-    sc.pp.scrublet(adata, batch_key=batch_key)
+    def peakmem_scrublet(self, *_):
+        sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
 
 # Can’t do seurat v3 yet: https://github.com/conda-forge/scikit-misc-feedstock/issues/17
 """
-def time_hvg_seurat_v3(*_):
+def time_hvg_seurat_v3(self):
     # seurat v3 runs on counts
     sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
 
 
-def peakmem_hvg_seurat_v3(*_):
+def peakmem_hvg_seurat_v3(self):
     sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
 """
 
@@ -83,28 +77,39 @@ class FastSuite:
     )
     param_names = ("dataset", "layer")
 
+    def setup_cache(self):
+        """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
+        for dataset in self.params[0]:
+            for layer in self.params[1]:
+                adata, _ = get_count_dataset(dataset, layer=layer)
+                assert "lop1p" not in adata.uns
+                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
+
+    def setup(self, dataset, layer):
+        self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
+
     def time_calculate_qc_metrics(self, *_):
         sc.pp.calculate_qc_metrics(
-            adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
+            self.adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
         )
 
     def peakmem_calculate_qc_metrics(self, *_):
         sc.pp.calculate_qc_metrics(
-            adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
+            self.adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
         )
 
     def time_normalize_total(self, *_):
-        sc.pp.normalize_total(adata, target_sum=1e4)
+        sc.pp.normalize_total(self.adata, target_sum=1e4)
 
     def peakmem_normalize_total(self, *_):
-        sc.pp.normalize_total(adata, target_sum=1e4)
+        sc.pp.normalize_total(self.adata, target_sum=1e4)
 
     def time_log1p(self, *_):
-        # TODO: This would fail: assert "log1p" not in adata.uns, "ASV bug?"
+        # TODO: This would fail: assert "log1p" not in self.adata.uns, "ASV bug?"
         # https://github.com/scverse/scanpy/issues/3052
-        adata.uns.pop("log1p", None)
-        sc.pp.log1p(adata)
+        self.adata.uns.pop("log1p", None)
+        sc.pp.log1p(self.adata)
 
     def peakmem_log1p(self, *_):
-        adata.uns.pop("log1p", None)
-        sc.pp.log1p(adata)
+        self.adata.uns.pop("log1p", None)
+        sc.pp.log1p(self.adata)

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -55,12 +55,14 @@ class PreprocessingCountsSuite:  # noqa: D101
     def peakmem_scrublet(self, *_) -> None:
         sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
-    def time_hvg_seurat_v3(self, *_):
-        # seurat v3 runs on counts
-        sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
+    # sciki-misc does not exit on osx-arm64
+    # https://github.com/conda-forge/scikit-misc-feedstock/pull/29
+    # def time_hvg_seurat_v3(self, *_):
+    #     # seurat v3 runs on counts
+    #     sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
 
-    def peakmem_hvg_seurat_v3(self, *_):
-        sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
+    # def peakmem_hvg_seurat_v3(self, *_):
+    #     sc.pp.highly_variable_genes(self.adata, flavor="seurat_v3_paper")
 
 
 class FastSuite:

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -5,6 +5,7 @@ API documentation: <https://scanpy.readthedocs.io/en/stable/api/preprocessing.ht
 
 from __future__ import annotations
 
+from itertools import product
 from typing import TYPE_CHECKING
 
 import anndata as ad
@@ -25,34 +26,33 @@ class PreprocessingCountsSuite:  # noqa: D101
     )
     param_names = ("dataset", "layer")
 
-    def setup_cache(self):
+    def setup_cache(self) -> None:
         """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
-        for dataset in self.params[0]:
-            for layer in self.params[1]:
-                adata, batch_key = get_count_dataset(dataset, layer=layer)
-                assert "lop1p" not in adata.uns
-                adata.uns["batch_key"] = batch_key
-                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
+        for dataset, layer in product(*self.params):
+            adata, batch_key = get_count_dataset(dataset, layer=layer)
+            assert "lop1p" not in adata.uns
+            adata.uns["batch_key"] = batch_key
+            adata.write_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def setup(self, dataset, layer):
+    def setup(self, dataset, layer) -> None:
         self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def time_filter_cells(self, *_):
+    def time_filter_cells(self, *_) -> None:
         sc.pp.filter_cells(self.adata, min_genes=100)
 
-    def peakmem_filter_cells(self, *_):
+    def peakmem_filter_cells(self, *_) -> None:
         sc.pp.filter_cells(self.adata, min_genes=100)
 
-    def time_filter_genes(self, *_):
+    def time_filter_genes(self, *_) -> None:
         sc.pp.filter_genes(self.adata, min_cells=3)
 
-    def peakmem_filter_genes(self, *_):
+    def peakmem_filter_genes(self, *_) -> None:
         sc.pp.filter_genes(self.adata, min_cells=3)
 
-    def time_scrublet(self, *_):
+    def time_scrublet(self, *_) -> None:
         sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
-    def peakmem_scrublet(self, *_):
+    def peakmem_scrublet(self, *_) -> None:
         sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
 
@@ -77,39 +77,38 @@ class FastSuite:
     )
     param_names = ("dataset", "layer")
 
-    def setup_cache(self):
+    def setup_cache(self) -> None:
         """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
-        for dataset in self.params[0]:
-            for layer in self.params[1]:
-                adata, _ = get_count_dataset(dataset, layer=layer)
-                assert "lop1p" not in adata.uns
-                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
+        for dataset, layer in product(*self.params):
+            adata, _ = get_count_dataset(dataset, layer=layer)
+            assert "lop1p" not in adata.uns
+            adata.write_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def setup(self, dataset, layer):
+    def setup(self, dataset, layer) -> None:
         self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def time_calculate_qc_metrics(self, *_):
+    def time_calculate_qc_metrics(self, *_) -> None:
         sc.pp.calculate_qc_metrics(
             self.adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
         )
 
-    def peakmem_calculate_qc_metrics(self, *_):
+    def peakmem_calculate_qc_metrics(self, *_) -> None:
         sc.pp.calculate_qc_metrics(
             self.adata, qc_vars=["mt"], percent_top=None, log1p=False, inplace=True
         )
 
-    def time_normalize_total(self, *_):
+    def time_normalize_total(self, *_) -> None:
         sc.pp.normalize_total(self.adata, target_sum=1e4)
 
-    def peakmem_normalize_total(self, *_):
+    def peakmem_normalize_total(self, *_) -> None:
         sc.pp.normalize_total(self.adata, target_sum=1e4)
 
-    def time_log1p(self, *_):
+    def time_log1p(self, *_) -> None:
         # TODO: This would fail: assert "log1p" not in self.adata.uns, "ASV bug?"
         # https://github.com/scverse/scanpy/issues/3052
         self.adata.uns.pop("log1p", None)
         sc.pp.log1p(self.adata)
 
-    def peakmem_log1p(self, *_):
+    def peakmem_log1p(self, *_) -> None:
         self.adata.uns.pop("log1p", None)
         sc.pp.log1p(self.adata)

--- a/benchmarks/benchmarks/preprocessing_counts.py
+++ b/benchmarks/benchmarks/preprocessing_counts.py
@@ -55,17 +55,15 @@ class PreprocessingCountsSuite:  # noqa: D101
     def peakmem_scrublet(self, *_) -> None:
         sc.pp.scrublet(self.adata, batch_key=self.adata.uns["batch_key"])
 
+    # Can’t do seurat v3 yet: https://github.com/conda-forge/scikit-misc-feedstock/issues/17
+    """
+    def time_hvg_seurat_v3(self, *_):
+        # seurat v3 runs on counts
+        sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
 
-# Can’t do seurat v3 yet: https://github.com/conda-forge/scikit-misc-feedstock/issues/17
-"""
-def time_hvg_seurat_v3(self):
-    # seurat v3 runs on counts
-    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
-
-
-def peakmem_hvg_seurat_v3(self):
-    sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
-"""
+    def peakmem_hvg_seurat_v3(self, *_):
+        sc.pp.highly_variable_genes(adata, flavor="seurat_v3_paper")
+    """
 
 
 class FastSuite:

--- a/benchmarks/benchmarks/preprocessing_log.py
+++ b/benchmarks/benchmarks/preprocessing_log.py
@@ -5,6 +5,7 @@ API documentation: <https://scanpy.readthedocs.io/en/stable/api/preprocessing.ht
 
 from __future__ import annotations
 
+from itertools import product
 from typing import TYPE_CHECKING
 
 import anndata as ad
@@ -31,44 +32,43 @@ class PreprocessingSuite:  # noqa: D101
     params = params
     param_names = param_names
 
-    def setup_cache(self):
+    def setup_cache(self) -> None:
         """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
-        for dataset in self.params[0]:
-            for layer in self.params[1]:
-                adata, _ = get_dataset(dataset, layer=layer)
-                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
+        for dataset, layer in product(*self.params):
+            adata, _ = get_dataset(dataset, layer=layer)
+            adata.write_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def setup(self, dataset, layer):
+    def setup(self, dataset, layer) -> None:
         self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
 
-    def time_pca(self, *_):
+    def time_pca(self, *_) -> None:
         sc.pp.pca(self.adata, svd_solver="arpack")
 
-    def peakmem_pca(self, *_):
+    def peakmem_pca(self, *_) -> None:
         sc.pp.pca(self.adata, svd_solver="arpack")
 
-    def time_highly_variable_genes(self, *_):
+    def time_highly_variable_genes(self, *_) -> None:
         # the default flavor runs on log-transformed data
         sc.pp.highly_variable_genes(
             self.adata, min_mean=0.0125, max_mean=3, min_disp=0.5
         )
 
-    def peakmem_highly_variable_genes(self, *_):
+    def peakmem_highly_variable_genes(self, *_) -> None:
         sc.pp.highly_variable_genes(
             self.adata, min_mean=0.0125, max_mean=3, min_disp=0.5
         )
 
     # regress_out is very slow for this dataset
     @skip_when(dataset={"pbmc3k"})
-    def time_regress_out(self, *_):
+    def time_regress_out(self, *_) -> None:
         sc.pp.regress_out(self.adata, ["total_counts", "pct_counts_mt"])
 
     @skip_when(dataset={"pbmc3k"})
-    def peakmem_regress_out(self, *_):
+    def peakmem_regress_out(self, *_) -> None:
         sc.pp.regress_out(self.adata, ["total_counts", "pct_counts_mt"])
 
-    def time_scale(self, *_):
+    def time_scale(self, *_) -> None:
         sc.pp.scale(self.adata, max_value=10)
 
-    def peakmem_scale(self, *_):
+    def peakmem_scale(self, *_) -> None:
         sc.pp.scale(self.adata, max_value=10)

--- a/benchmarks/benchmarks/preprocessing_log.py
+++ b/benchmarks/benchmarks/preprocessing_log.py
@@ -7,26 +7,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+import anndata as ad
+
 import scanpy as sc
 
 from ._utils import get_dataset, param_skipper
 
 if TYPE_CHECKING:
-    from anndata import AnnData
-
     from ._utils import Dataset, KeyX
-
-# setup variables
-
-
-adata: AnnData
-batch_key: str | None
-
-
-def setup(dataset: Dataset, layer: KeyX, *_):
-    """Set up global variables before each benchmark."""
-    global adata, batch_key
-    adata, batch_key = get_dataset(dataset, layer=layer)
 
 
 # ASV suite
@@ -35,42 +23,52 @@ params: tuple[list[Dataset], list[KeyX]] = (
     ["pbmc68k_reduced", "pbmc3k"],
     [None, "off-axis"],
 )
-param_names = ["dataset", "layer"]
-
+param_names = ("dataset", "layer")
 skip_when = param_skipper(param_names, params)
 
 
-def time_pca(*_):
-    sc.pp.pca(adata, svd_solver="arpack")
+class PreprocessingSuite:  # noqa: D101
+    params = params
+    param_names = param_names
 
+    def setup_cache(self):
+        """Without this caching, asv was running several processes which meant the data was repeatedly downloaded."""
+        for dataset in self.params[0]:
+            for layer in self.params[1]:
+                adata, _ = get_dataset(dataset, layer=layer)
+                adata.write_h5ad(f"{dataset}_{layer}.h5ad")
 
-def peakmem_pca(*_):
-    sc.pp.pca(adata, svd_solver="arpack")
+    def setup(self, dataset, layer):
+        self.adata = ad.read_h5ad(f"{dataset}_{layer}.h5ad")
 
+    def time_pca(self, *_):
+        sc.pp.pca(self.adata, svd_solver="arpack")
 
-def time_highly_variable_genes(*_):
-    # the default flavor runs on log-transformed data
-    sc.pp.highly_variable_genes(adata, min_mean=0.0125, max_mean=3, min_disp=0.5)
+    def peakmem_pca(self, *_):
+        sc.pp.pca(self.adata, svd_solver="arpack")
 
+    def time_highly_variable_genes(self, *_):
+        # the default flavor runs on log-transformed data
+        sc.pp.highly_variable_genes(
+            self.adata, min_mean=0.0125, max_mean=3, min_disp=0.5
+        )
 
-def peakmem_highly_variable_genes(*_):
-    sc.pp.highly_variable_genes(adata, min_mean=0.0125, max_mean=3, min_disp=0.5)
+    def peakmem_highly_variable_genes(self, *_):
+        sc.pp.highly_variable_genes(
+            self.adata, min_mean=0.0125, max_mean=3, min_disp=0.5
+        )
 
+    # regress_out is very slow for this dataset
+    @skip_when(dataset={"pbmc3k"})
+    def time_regress_out(self, *_):
+        sc.pp.regress_out(self.adata, ["total_counts", "pct_counts_mt"])
 
-# regress_out is very slow for this dataset
-@skip_when(dataset={"pbmc3k"})
-def time_regress_out(*_):
-    sc.pp.regress_out(adata, ["total_counts", "pct_counts_mt"])
+    @skip_when(dataset={"pbmc3k"})
+    def peakmem_regress_out(self, *_):
+        sc.pp.regress_out(self.adata, ["total_counts", "pct_counts_mt"])
 
+    def time_scale(self, *_):
+        sc.pp.scale(self.adata, max_value=10)
 
-@skip_when(dataset={"pbmc3k"})
-def peakmem_regress_out(*_):
-    sc.pp.regress_out(adata, ["total_counts", "pct_counts_mt"])
-
-
-def time_scale(*_):
-    sc.pp.scale(adata, max_value=10)
-
-
-def peakmem_scale(*_):
-    sc.pp.scale(adata, max_value=10)
+    def peakmem_scale(self, *_):
+        sc.pp.scale(self.adata, max_value=10)

--- a/benchmarks/benchmarks/tools.py
+++ b/benchmarks/benchmarks/tools.py
@@ -13,30 +13,30 @@ from ._utils import pbmc68k_reduced
 
 
 class ToolsSuite:  # noqa: D101
-    def setup_cache(self):
+    def setup_cache(self) -> None:
         adata = pbmc68k_reduced()
         assert "X_pca" in adata.obsm
         adata.write_h5ad("adata.h5ad")
 
-    def setup(self):
+    def setup(self) -> None:
         self.adata = ad.read_h5ad("adata.h5ad")
 
-    def time_umap(self):
+    def time_umap(self) -> None:
         sc.tl.umap(self.adata)
 
-    def peakmem_umap(self):
+    def peakmem_umap(self) -> None:
         sc.tl.umap(self.adata)
 
-    def time_diffmap(self):
+    def time_diffmap(self) -> None:
         sc.tl.diffmap(self.adata)
 
-    def peakmem_diffmap(self):
+    def peakmem_diffmap(self) -> None:
         sc.tl.diffmap(self.adata)
 
-    def time_leiden(self):
+    def time_leiden(self) -> None:
         sc.tl.leiden(self.adata, flavor="igraph")
 
-    def peakmem_leiden(self):
+    def peakmem_leiden(self) -> None:
         sc.tl.leiden(self.adata, flavor="igraph")
 
     def time_rank_genes_groups(self) -> None:

--- a/benchmarks/benchmarks/tools.py
+++ b/benchmarks/benchmarks/tools.py
@@ -5,53 +5,42 @@ API documentation: <https://scanpy.readthedocs.io/en/stable/api/tools.html>.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import anndata as ad
 
 import scanpy as sc
 
 from ._utils import pbmc68k_reduced
 
-if TYPE_CHECKING:
-    from anndata import AnnData
 
-# setup variables
+class ToolsSuite:  # noqa: D101
+    def setup_cache(self):
+        adata = pbmc68k_reduced()
+        assert "X_pca" in adata.obsm
+        adata.write_h5ad("adata.h5ad")
 
-adata: AnnData
+    def setup(self):
+        self.adata = ad.read_h5ad("adata.h5ad")
 
+    def time_umap(self):
+        sc.tl.umap(self.adata)
 
-def setup():
-    global adata  # noqa: PLW0603
-    adata = pbmc68k_reduced()
-    assert "X_pca" in adata.obsm
+    def peakmem_umap(self):
+        sc.tl.umap(self.adata)
 
+    def time_diffmap(self):
+        sc.tl.diffmap(self.adata)
 
-def time_umap():
-    sc.tl.umap(adata)
+    def peakmem_diffmap(self):
+        sc.tl.diffmap(self.adata)
 
+    def time_leiden(self):
+        sc.tl.leiden(self.adata, flavor="igraph")
 
-def peakmem_umap():
-    sc.tl.umap(adata)
+    def peakmem_leiden(self):
+        sc.tl.leiden(self.adata, flavor="igraph")
 
+    def time_rank_genes_groups(self) -> None:
+        sc.tl.rank_genes_groups(self.adata, "bulk_labels", method="wilcoxon")
 
-def time_diffmap():
-    sc.tl.diffmap(adata)
-
-
-def peakmem_diffmap():
-    sc.tl.diffmap(adata)
-
-
-def time_leiden():
-    sc.tl.leiden(adata, flavor="igraph")
-
-
-def peakmem_leiden():
-    sc.tl.leiden(adata, flavor="igraph")
-
-
-def time_rank_genes_groups() -> None:
-    sc.tl.rank_genes_groups(adata, "bulk_labels", method="wilcoxon")
-
-
-def peakmem_rank_genes_groups() -> None:
-    sc.tl.rank_genes_groups(adata, "bulk_labels", method="wilcoxon")
+    def peakmem_rank_genes_groups(self) -> None:
+        sc.tl.rank_genes_groups(self.adata, "bulk_labels", method="wilcoxon")


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

This PR fixes in one fell swoop our benchmarking issues on CI

1. We started getting 403s in https://github.com/scverse/scanpy/actions/runs/18912251783/job/53985928561 which I would guess were from repeated requests (in any case, there are clearly multiple downloads happening if that's what the progress bars are for, and I think they are).  So we move to `setup_cache` like in `anndata`.  There are a lot fewer downloading bars: https://github.com/scverse/scanpy/actions/runs/18915072587/job/53996072887?pr=3853
2. We move to `pip` for `igraph`: https://github.com/airspeed-velocity/asv/issues/1554

Separately, it looks like the benchmarking machine is out of disk space.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes # Current benchmark CI is broken
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: only benchmarking

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
