### PR TITLE
ci: fix tests in 1.11 branch

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -31,7 +31,7 @@ overrides.matrix.deps.python = [
     { if = [ "stable", "pre" ], value = "3.12" },
 ]
 overrides.matrix.deps.extra-dependencies = [
-    { if = [ "pre" ], value = "anndata[dev,test] @ git+https://github.com/scverse/anndata.git" },
+    { if = [ "pre" ], value = "anndata[test-min] @ git+https://github.com/scverse/anndata.git" },
 ]
 overrides.matrix.deps.features = [
     { if = [ "stable", "pre", "low-vers" ], value = "test" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,9 @@ harmony = [ "harmonypy" ] # Harmony dataset integration
 scanorama = [ "scanorama" ] # Scanorama dataset integration
 scrublet = [ "scikit-image" ] # Doublet detection with automatic thresholds
 # Acceleration
-rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ]         # GPU accelerated calculation of neighbors
-dask = [ "dask[array]>=2022.09.2, <2025.3", "anndata[dask]" ] # Use the Dask parallelization engine
-dask-ml = [ "dask-ml", "scanpy[dask]" ]                       # Dask-ML for sklearn-like API
+rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ] # GPU accelerated calculation of neighbors
+dask = [ "dask[array]>=2022.09.2", "anndata[dask]" ]  # Use the Dask parallelization engine
+dask-ml = [ "dask-ml", "scanpy[dask]" ]               # Dask-ML for sklearn-like API
 
 [tool.hatch.build.targets.wheel]
 packages = [ "src/testing", "src/scanpy" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,9 +142,9 @@ harmony = [ "harmonypy" ] # Harmony dataset integration
 scanorama = [ "scanorama" ] # Scanorama dataset integration
 scrublet = [ "scikit-image" ] # Doublet detection with automatic thresholds
 # Acceleration
-rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ] # GPU accelerated calculation of neighbors
-dask = [ "dask[array]>=2022.09.2", "anndata[dask]" ]  # Use the Dask parallelization engine
-dask-ml = [ "dask-ml", "scanpy[dask]" ]               # Dask-ML for sklearn-like API
+rapids = [ "cudf>=0.9", "cuml>=0.9", "cugraph>=0.9" ]         # GPU accelerated calculation of neighbors
+dask = [ "dask[array]>=2022.09.2, <2025.3", "anndata[dask]" ] # Use the Dask parallelization engine
+dask-ml = [ "dask-ml", "scanpy[dask]" ]                       # Dask-ML for sklearn-like API
 
 [tool.hatch.build.targets.wheel]
 packages = [ "src/testing", "src/scanpy" ]

--- a/src/testing/scanpy/_helpers/__init__.py
+++ b/src/testing/scanpy/_helpers/__init__.py
@@ -141,10 +141,13 @@ def as_dense_dask_array(*args, **kwargs) -> DaskArray:
     return as_dense_dask_array(*args, **kwargs)
 
 
-def as_sparse_dask_array(*args, **kwargs) -> DaskArray:
-    from anndata.tests.helpers import as_sparse_dask_array
+def as_sparse_dask_matrix(*args, **kwargs) -> DaskArray:
+    try:
+        from anndata.tests.helpers import as_sparse_dask_matrix
+    except ImportError:
+        from anndata.tests.helpers import as_sparse_dask_array as as_sparse_dask_matrix
 
-    return as_sparse_dask_array(*args, **kwargs)
+    return as_sparse_dask_matrix(*args, **kwargs)
 
 
 @dataclass(init=False)

--- a/src/testing/scanpy/_pytest/params.py
+++ b/src/testing/scanpy/_pytest/params.py
@@ -10,7 +10,7 @@ from scipy import sparse
 
 from .._helpers import (
     as_dense_dask_array,
-    as_sparse_dask_array,
+    as_sparse_dask_matrix,
 )
 from .._pytest.marks import needs
 
@@ -51,7 +51,7 @@ MAP_ARRAY_TYPES: dict[
     ),
     ("dask", "sparse"): (
         pytest.param(
-            as_sparse_dask_array,
+            as_sparse_dask_matrix,
             marks=[needs.dask, pytest.mark.anndata_dask_support],
             id="dask_array_sparse",
         ),

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -87,7 +87,7 @@ def _chunked_1d(
 
 DASK_CONVERTERS = {
     f: _chunked_1d(f)
-    for f in (_helpers.as_dense_dask_array, _helpers.as_sparse_dask_array)
+    for f in (_helpers.as_dense_dask_array, _helpers.as_sparse_dask_matrix)
 }
 
 
@@ -131,7 +131,10 @@ def gen_pca_params(
     svd_solver_type: Literal["valid", "invalid"] | None,
     zero_center: bool,
 ) -> Generator[tuple[SVDSolver | None, str | None, str | None], None, None]:
-    if array_type is DASK_CONVERTERS[_helpers.as_sparse_dask_array] and not zero_center:
+    if (
+        array_type is DASK_CONVERTERS[_helpers.as_sparse_dask_matrix]
+        and not zero_center
+    ):
         xfail_reason = "Sparse-in-dask with zero_center=False not implemented yet"
         yield None, None, xfail_reason
         return
@@ -171,7 +174,7 @@ def possible_solvers(
             svd_solvers = {"auto", "full", "tsqr", "randomized", "covariance_eigh"}
         case (dc, False) if dc is DASK_CONVERTERS[_helpers.as_dense_dask_array]:
             svd_solvers = {"tsqr", "randomized"}
-        case (dc, True) if dc is DASK_CONVERTERS[_helpers.as_sparse_dask_array]:
+        case (dc, True) if dc is DASK_CONVERTERS[_helpers.as_sparse_dask_matrix]:
             svd_solvers = {"covariance_eigh"}
         case (type() as dc, True) if issubclass(dc, CSBase):
             svd_solvers = {"arpack"} | SKLEARN_ADDITIONAL
@@ -570,7 +573,7 @@ needs_anndata_dask = pytest.mark.skipif(
     "other_array_type",
     [
         lambda x: x.toarray(),
-        DASK_CONVERTERS[_helpers.as_sparse_dask_array],
+        DASK_CONVERTERS[_helpers.as_sparse_dask_matrix],
         DASK_CONVERTERS[_helpers.as_dense_dask_array],
     ],
     ids=["dense-mem", "sparse-dask", "dense-dask"],
@@ -616,7 +619,7 @@ def test_covariance_eigh_impls(other_array_type):
 )
 def test_sparse_dask_input_errors(msg_re: str, op: Callable[[DaskArray], DaskArray]):
     adata_sparse = pbmc3k_normalized()
-    adata_sparse.X = op(DASK_CONVERTERS[_helpers.as_sparse_dask_array](adata_sparse.X))
+    adata_sparse.X = op(DASK_CONVERTERS[_helpers.as_sparse_dask_matrix](adata_sparse.X))
 
     with pytest.raises(ValueError, match=msg_re):
         sc.pp.pca(adata_sparse, svd_solver="covariance_eigh")
@@ -635,7 +638,7 @@ def test_sparse_dask_input_errors(msg_re: str, op: Callable[[DaskArray], DaskArr
 )
 def test_cov_sparse_dask(dtype, dtype_arg, rtol):
     x_arr = A_list.astype(dtype)
-    x = DASK_CONVERTERS[_helpers.as_sparse_dask_array](x_arr)
+    x = DASK_CONVERTERS[_helpers.as_sparse_dask_matrix](x_arr)
     cov, gram, mean = _cov_sparse_dask(x, return_gram=True, dtype=dtype_arg)
     np.testing.assert_allclose(mean, np.mean(x_arr, axis=0))
     np.testing.assert_allclose(gram, (x_arr.T @ x_arr) / x.shape[0])

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -19,7 +19,7 @@ from scanpy.preprocessing._qc import (
     top_proportions,
     top_segment_proportions,
 )
-from testing.scanpy._helpers import as_sparse_dask_array, maybe_dask_process_context
+from testing.scanpy._helpers import as_sparse_dask_matrix, maybe_dask_process_context
 from testing.scanpy._pytest.marks import needs
 from testing.scanpy._pytest.params import ARRAY_TYPES, ARRAY_TYPES_MEM
 
@@ -180,7 +180,7 @@ def test_qc_metrics_no_log1p(adata_prepared: AnnData):
 @pytest.mark.parametrize("log1p", [True, False], ids=["log1p", "no_log1p"])
 def test_dask_against_in_memory(adata, log1p):
     adata_as_dask = adata.copy()
-    adata_as_dask.X = as_sparse_dask_array(adata.X)
+    adata_as_dask.X = as_sparse_dask_matrix(adata.X)
     adata = prepare_adata(adata)
     adata_as_dask = prepare_adata(adata_as_dask)
     with maybe_dask_process_context():


### PR DESCRIPTION
`as_sparse_dask_array` now returns `csr_array`s, which scanpy 1.11 doesn’t support.

This fixes us accidentally trying to use it.

The `anndata[tests-min]` part should also go into `main`