### PR TITLE
feat: add `obsm` parameter to `normalize_total` and `pca`

### DIFF
--- a/docs/release-notes/3863.fix.md
+++ b/docs/release-notes/3863.fix.md
@@ -1,0 +1,1 @@
+Allow operating on :attr:`~anndata.AnnData.obsm` arrays in {func}`scanpy.pp.normalize_total` and {func}`scanpy.pp.pca` {smaller}`P Angerer`

--- a/src/scanpy/experimental/pp/_normalization.py
+++ b/src/scanpy/experimental/pp/_normalization.py
@@ -96,6 +96,7 @@ def normalize_pearson_residuals(
     clip: float | None = None,
     check_values: bool = True,
     layer: str | None = None,
+    obsm: str | None = None,
     inplace: bool = True,
     copy: bool = False,
 ) -> AnnData | dict[str, np.ndarray] | None:
@@ -138,8 +139,8 @@ def normalize_pearson_residuals(
         adata = adata.copy()
 
     view_to_actual(adata)
-    x = _get_obs_rep(adata, layer=layer)
-    computed_on = layer if layer else "adata.X"
+    x = _get_obs_rep(adata, layer=layer, obsm=obsm)
+    computed_on = layer or obsm or "adata.X"
 
     msg = f"computing analytic Pearson residuals on {computed_on}"
     start = logg.info(msg)
@@ -148,7 +149,7 @@ def normalize_pearson_residuals(
     settings_dict = dict(theta=theta, clip=clip, computed_on=computed_on)
 
     if inplace:
-        _set_obs_rep(adata, residuals, layer=layer)
+        _set_obs_rep(adata, residuals, layer=layer, obsm=obsm)
         adata.uns["pearson_residuals_normalization"] = settings_dict
     else:
         results_dict = dict(X=residuals, **settings_dict)

--- a/src/scanpy/get/__init__.py
+++ b/src/scanpy/get/__init__.py
@@ -6,6 +6,7 @@ from ._aggregated import aggregate
 from .get import (
     _check_mask,
     _get_obs_rep,
+    _ObsRep,
     _set_obs_rep,
     obs_df,
     rank_genes_groups_df,
@@ -13,6 +14,7 @@ from .get import (
 )
 
 __all__ = [
+    "_ObsRep",
     "_check_mask",
     "_get_obs_rep",
     "_set_obs_rep",

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -20,9 +20,9 @@ from .. import logging as logg
 from .._compat import CSBase, old_positionals
 from .._settings import settings
 from .._utils import (
-    _check_use_raw,
     _doc_params,
     _empty,
+    check_use_raw,
     get_literal_vals,
     sanitize_anndata,
 )
@@ -227,7 +227,7 @@ def _check_if_annotations(
     """
     annotations: pd.Index[str] = getattr(adata, axis_name).columns
     other_ax_obj = (
-        adata.raw if _check_use_raw(adata, use_raw) and axis_name == "obs" else adata
+        adata.raw if check_use_raw(adata, use_raw) and axis_name == "obs" else adata
     )
     names: pd.Index[str] = getattr(
         other_ax_obj, "var" if axis_name == "obs" else "obs"
@@ -282,7 +282,7 @@ def _scatter_obs(  # noqa: PLR0912, PLR0913, PLR0915
     """See docstring of scatter."""
     sanitize_anndata(adata)
 
-    use_raw = _check_use_raw(adata, use_raw)
+    use_raw = check_use_raw(adata, use_raw)
 
     # Process layers
     if layers in ["X", None] or (isinstance(layers, str) and layers in adata.layers):
@@ -861,7 +861,7 @@ def violin(  # noqa: PLR0912, PLR0913, PLR0915
     import seaborn as sns  # Slow import, only import if called
 
     sanitize_anndata(adata)
-    use_raw = _check_use_raw(adata, use_raw)
+    use_raw = check_use_raw(adata, use_raw)
     if isinstance(keys, str):
         keys = [keys]
     keys = list(OrderedDict.fromkeys(keys))  # remove duplicates, preserving the order
@@ -1054,7 +1054,7 @@ def clustermap(
         msg = "Currently, only a single key is supported."
         raise ValueError(msg)
     sanitize_anndata(adata)
-    use_raw = _check_use_raw(adata, use_raw)
+    use_raw = check_use_raw(adata, use_raw)
     x = adata.raw.X if use_raw else adata.X
     if isinstance(x, CSBase):
         x = x.toarray()
@@ -2047,7 +2047,7 @@ def _prepare_dataframe(  # noqa: PLR0912
 
     """
     sanitize_anndata(adata)
-    use_raw = _check_use_raw(adata, use_raw, layer=layer)
+    use_raw = check_use_raw(adata, use_raw, layer=layer)
     if isinstance(var_names, str):
         var_names = [var_names]
 

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -302,7 +302,7 @@ def normalize_total(  # noqa: PLR0912
     if inplace:
         if key_added is not None:
             adata.obs[key_added] = dat["norm_factor"]
-        _set_obs_rep(adata, dat["X"], layer=layer)
+        _set_obs_rep(adata, dat["X"], layer=layer, obsm=obsm)
 
     logg.info(
         "    finished ({time_passed})",

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -148,6 +148,7 @@ def normalize_total(  # noqa: PLR0912
     max_fraction: float = 0.05,
     key_added: str | None = None,
     layer: str | None = None,
+    obsm: str | None = None,
     inplace: bool = True,
     copy: bool = False,
 ) -> AnnData | dict[str, np.ndarray] | None:
@@ -194,7 +195,9 @@ def normalize_total(  # noqa: PLR0912
         Name of the field in `adata.obs` where the normalization factor is
         stored.
     layer
-        Layer to normalize instead of `X`. If `None`, `X` is normalized.
+        Layer to normalize instead of `X`.
+    obsm
+        Array to normalize instead of `X`.
     inplace
         Whether to update `adata` or return dictionary with normalized copies of
         `adata.X` and `adata.layers`.
@@ -265,10 +268,7 @@ def normalize_total(  # noqa: PLR0912
 
     view_to_actual(adata)
 
-    x = _get_obs_rep(adata, layer=layer)
-    if x is None:
-        msg = f"Layer {layer!r} not found in adata."
-        raise ValueError(msg)
+    x = _get_obs_rep(adata, layer=layer, obsm=obsm)
     if isinstance(x, CSCBase):
         x = x.tocsr()
     if not inplace:

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -203,9 +203,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
 
     """
     logg_start = logg.info("computing PCA")
-    if layer is not None and chunked:
+    if (layer is not None or obsm is not None) and chunked:
         # Current chunking implementation relies on pca being called on X
-        msg = "Cannot use `layer` and `chunked` at the same time."
+        msg = "Cannot use `layer`/`obsm` and `chunked` at the same time."
         raise NotImplementedError(msg)
 
     # chunked calculation is not randomized, anyways
@@ -216,12 +216,11 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
             "reproducibility, choose `svd_solver='arpack'`."
         )
     if return_anndata := isinstance(data, AnnData):
-        if layer is None and not chunked and is_backed_type(data.X):
+        if not chunked and is_backed_type(data.X):
+            assert layer is None and obsm is None  # noqa: PT018
             msg = f"PCA is not implemented for matrices of type {type(data.X)} with chunked as False"
             raise NotImplementedError(msg)
         adata = data.copy() if copy else data
-    elif pkg_version("anndata") < Version("0.8.0rc1"):
-        adata = AnnData(data, dtype=data.dtype)
     else:
         adata = AnnData(data)
 

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -195,7 +195,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         PCA representation of data.
     `.varm['PCs' | key_added]` : :class:`~numpy.ndarray` (shape `(adata.n_vars, n_comps)`)
         The principal components containing the loadings *when `obsm=None`*.
-    `.uns['pca' | key_added]['components']` : :class:`~numpy.ndarray` (shape `(adata.obsm][obsm].shape[1], n_comps)`)
+    `.uns['pca' | key_added]['components']` : :class:`~numpy.ndarray` (shape `(adata.obsm[obsm].shape[1], n_comps)`)
         The principal components containing the loadings *when `obsm="..."`*.
     `.uns['pca' | key_added]['variance_ratio']` : :class:`~numpy.ndarray` (shape `(n_comps,)`)
         Ratio of explained variance.

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -63,6 +63,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     n_comps: int | None = None,
     *,
     layer: str | None = None,
+    obsm: str | None = None,
     zero_center: bool = True,
     svd_solver: SvdSolver | None = None,
     chunked: bool = False,
@@ -111,7 +112,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         Number of principal components to compute. Defaults to 50,
         or 1 - minimum dimension size of selected representation.
     layer
-        If provided, which element of layers to use for PCA.
+        If provided, which element of :attr:`~anndata.AnnData.layers` to use for PCA instead of `X`.
+    obsm
+        If provided, which element of :attr:`~anndata.AnnData.obsm` to use for PCA instead of `X`.
     zero_center
         If `True`, compute (or approximate) PCA from covariance matrix.
         If `False`, performa a truncated SVD instead of PCA.
@@ -235,9 +238,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
 
     logg.info(f"    with {n_comps=}")
 
-    x = _get_obs_rep(adata_comp, layer=layer)
-    if is_backed_type(x) and layer is not None:
-        msg = f"PCA is not implemented for matrices of type {type(x)} from layers"
+    x = _get_obs_rep(adata_comp, layer=layer, obsm=obsm)
+    if is_backed_type(x) and layer is not None and obsm is not None:
+        msg = f"PCA is not implemented for matrices of type {type(x)} from layers/obsm"
         raise NotImplementedError(msg)
 
     # check_random_state returns a numpy RandomState when passed an int but
@@ -383,6 +386,8 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         )
         if layer is not None:
             params["layer"] = layer
+        if obsm is not None:
+            params["obsm"] = obsm
         adata.uns[key_uns] = dict(
             params=params,
             variance=pca_.explained_variance_,

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -218,8 +218,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
             "reproducibility, choose `svd_solver='arpack'`."
         )
     if return_anndata := isinstance(data, AnnData):
-        if not chunked and is_backed_type(data.X):
-            assert layer is None and obsm is None  # noqa: PT018
+        if (layer is None and obsm is None) and not chunked and is_backed_type(data.X):
             msg = f"PCA is not implemented for matrices of type {type(data.X)} with chunked as False"
             raise NotImplementedError(msg)
         adata = data.copy() if copy else data

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -13,8 +13,8 @@ from fast_array_utils.stats import mean_var
 from .. import logging as logg
 from .._compat import CSBase, CSCBase, CSRBase, DaskArray, njit, old_positionals
 from .._utils import (
-    _check_array_function_arguments,
     axis_mul_or_truediv,
+    check_array_function_arguments,
     dematrix,
     raise_not_implemented_error_if_backed_type,
     renamed_arg,
@@ -131,7 +131,7 @@ def scale(
         Variances per gene before scaling.
 
     """
-    _check_array_function_arguments(layer=layer, obsm=obsm)
+    check_array_function_arguments(layer=layer, obsm=obsm)
     if layer is not None:
         msg = f"`layer` argument inappropriate for value of type {type(data)}"
         raise ValueError(msg)

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -22,8 +22,8 @@ from .. import logging as logg
 from .._compat import CSBase, CSRBase, DaskArray, deprecated, njit, old_positionals
 from .._settings import settings as sett
 from .._utils import (
-    _check_array_function_arguments,
     _resolve_axis,
+    check_array_function_arguments,
     is_backed_type,
     raise_not_implemented_error_if_backed_type,
     renamed_arg,
@@ -352,7 +352,7 @@ def log1p(
     Returns or updates `data`, depending on `copy`.
 
     """
-    _check_array_function_arguments(
+    check_array_function_arguments(
         chunked=chunked, chunk_size=chunk_size, layer=layer, obsm=obsm
     )
     return log1p_array(data, copy=copy, base=base)

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -5,11 +5,10 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas as pd
-from packaging.version import Version
 from sklearn.utils import check_random_state
 
 from .. import logging as logg
-from .._compat import CSBase, old_positionals, pkg_version
+from .._compat import CSBase, old_positionals
 from .._settings import settings
 from .._utils import NeighborsView, raise_not_implemented_error_if_backed_type
 from .._utils._doctests import doctest_skip
@@ -21,8 +20,6 @@ if TYPE_CHECKING:
     from anndata import AnnData
 
     from ..neighbors import RPForestDict
-
-ANNDATA_MIN_VERSION = Version("0.7rc1")
 
 
 @old_positionals(
@@ -119,16 +116,6 @@ def ingest(
     >>> sc.tl.ingest(adata, adata_ref, obs="cell_type")
 
     """
-    # anndata version check
-    anndata_version = pkg_version("anndata")
-    if anndata_version < ANNDATA_MIN_VERSION:
-        msg = (
-            f"ingest only works correctly with anndata>={ANNDATA_MIN_VERSION} "
-            f"(you have {anndata_version}) as prior to {ANNDATA_MIN_VERSION}, "
-            "`AnnData.concatenate` did not concatenate `.obsm`."
-        )
-        raise ValueError(msg)
-
     start = logg.info("running ingest")
     obs = [obs] if isinstance(obs, str) else obs
     embedding_method = (

--- a/src/scanpy/tools/_score_genes.py
+++ b/src/scanpy/tools/_score_genes.py
@@ -9,7 +9,7 @@ import pandas as pd
 
 from .. import logging as logg
 from .._compat import CSBase, old_positionals
-from .._utils import _check_use_raw, is_backed_type
+from .._utils import check_use_raw, is_backed_type
 from ..get import _get_obs_rep
 
 if TYPE_CHECKING:
@@ -123,7 +123,7 @@ def score_genes(  # noqa: PLR0913
     """
     start = logg.info(f"computing score {score_name!r}")
     adata = adata.copy() if copy else adata
-    use_raw = _check_use_raw(adata, use_raw, layer=layer)
+    use_raw = check_use_raw(adata, use_raw, layer=layer)
     if is_backed_type(adata.X) and not use_raw:
         msg = f"score_genes is not implemented for matrices of type {type(adata.X)}"
         raise NotImplementedError(msg)

--- a/src/testing/scanpy/_pytest/__init__.py
+++ b/src/testing/scanpy/_pytest/__init__.py
@@ -107,13 +107,13 @@ def pytest_collection_modifyitems(
 
 
 def _modify_doctests(request: pytest.FixtureRequest) -> None:
-    from scanpy._utils import _import_name
+    from scanpy._utils import import_name
 
     assert isinstance(request.node, pytest.DoctestItem)
 
     request.getfixturevalue("_doctest_env")
 
-    func = _import_name(request.node.name)
+    func = import_name(request.node.name)
     needs_mod: str | None
     skip_reason: str | None
     if (

--- a/tests/test_backed.py
+++ b/tests/test_backed.py
@@ -8,7 +8,6 @@ from anndata import read_h5ad
 import scanpy as sc
 
 
-@pytest.mark.flaky(reruns=5, reruns_delay=2)
 @pytest.mark.parametrize(
     ("name", "func", "msg"),
     [

--- a/tests/test_get.py
+++ b/tests/test_get.py
@@ -512,3 +512,30 @@ def test_rank_genes_groups_df():
     assert "b" in dedf3["group"].unique()
     adata.var_names.name = "pr1388"
     sc.get.rank_genes_groups_df(adata, group=None, key="different_key")
+
+
+######################
+# _get_obs_rep tests #
+######################
+
+
+@pytest.mark.parametrize(
+    ("kw", "cls", "msg"),
+    [
+        pytest.param(
+            dict(layer="a", obsm="b"),
+            ValueError,
+            r"Only one of `layer`, or `obsm` can be specified.",
+            id="layer_and_obsm",
+        ),
+        pytest.param(dict(layer="b"), KeyError, r"'b'", id="missing_layer"),
+    ],
+)
+def test_get_obs_rep_errors(kw: sc.get._ObsRep, cls: type[Exception], msg: str) -> None:
+    adata = AnnData(
+        np.zeros((10, 10)),
+        layers={"a": np.zeros((10, 10))},
+        obsm={"b": np.zeros((10, 5))},
+    )
+    with pytest.raises(cls, match=msg):
+        sc.get._get_obs_rep(adata, **kw)

--- a/tests/test_normalization.py
+++ b/tests/test_normalization.py
@@ -76,10 +76,10 @@ def test_normalize_total(array_type, dtype):
 @pytest.mark.parametrize("array_type", ARRAY_TYPES)
 @pytest.mark.parametrize("dtype", ["float32", "int64"])
 def test_normalize_total_rep(array_type, dtype):
-    # Test that layer kwarg works
+    """Test that layer/obsm kwargs work."""
     x = array_type(sparse.random(100, 50, format="csr", density=0.2, dtype=dtype))
-    check_rep_mutation(sc.pp.normalize_total, x, fields=["layer"])
-    check_rep_results(sc.pp.normalize_total, x, fields=["layer"])
+    check_rep_mutation(sc.pp.normalize_total, x)
+    check_rep_results(sc.pp.normalize_total, x)
 
 
 @pytest.mark.parametrize("array_type", ARRAY_TYPES)

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -50,6 +50,7 @@ api_functions = [
     for mod_name, mod in api_modules.items()
     for name in sorted(mod.__all__)
     if callable(func := getattr(mod, name)) and func.__module__.startswith("scanpy.")
+    if not (isinstance(func, type) and issubclass(func, dict))  # TypedDict
 ]
 
 

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -11,7 +11,7 @@ from anndata import AnnData
 
 # CLI is locally not imported by default but on travis it is?
 import scanpy.cli
-from scanpy._utils import _import_name, descend_classes_and_funcs
+from scanpy._utils import descend_classes_and_funcs, import_name
 
 if TYPE_CHECKING:
     from types import FunctionType
@@ -39,7 +39,7 @@ api_module_names = [
     "sc.metrics",
 ]
 api_modules = {
-    mod_name: _import_name(f"scanpy{mod_name.removeprefix('sc')}")
+    mod_name: import_name(f"scanpy{mod_name.removeprefix('sc')}")
     for mod_name in api_module_names
 }
 

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -479,28 +479,40 @@ def test_mask_defaults(array_type, float_dtype):
     assert np.array_equal(without_var.obsm["X_pca"], with_no_mask.obsm["X_pca"])
 
 
-def test_pca_layer():
+@pytest.mark.parametrize("rep", ["layer", "obsm"])
+def test_pca_rep(rep: Literal["layer", "obsm"]) -> None:
     """Tests that layers works the same way as `X`."""
-    adata = pbmc3k_normalized()
+    adata = pbmc3k_normalized()[:200].copy()
 
-    layer_adata = adata.copy()
-    layer_adata.layers["counts"] = adata.X.copy()
-    del layer_adata.X
+    rep_adata = adata.copy()
+    if rep == "layer":
+        rep_adata.layers["counts"] = adata.X.copy()
+    elif rep == "obsm":
+        # make sure `rep_adata.obsm` has a different shape from `rep_adata`,
+        # so code can’t accidentally use `.var{,m,p}`
+        rep_adata.obsm["counts"] = adata.X.copy()[:, :100]
+        adata = adata[:, :100].copy()
+    else:
+        pytest.fail(f"Unknown {rep=}")
+    del rep_adata.X
 
-    sc.pp.pca(adata)
-    sc.pp.pca(layer_adata, layer="counts")
+    sc.pp.pca(adata, mask_var=None)
+    sc.pp.pca(rep_adata, **{rep: "counts"}, mask_var=None)
 
-    assert layer_adata.uns["pca"]["params"]["layer"] == "counts"
-    assert "layer" not in adata.uns["pca"]["params"]
+    assert rep_adata.uns["pca"]["params"][rep] == "counts"
+    assert rep not in adata.uns["pca"]["params"]
 
     np.testing.assert_equal(
-        adata.uns["pca"]["variance"], layer_adata.uns["pca"]["variance"]
+        adata.uns["pca"]["variance"], rep_adata.uns["pca"]["variance"]
     )
     np.testing.assert_equal(
-        adata.uns["pca"]["variance_ratio"], layer_adata.uns["pca"]["variance_ratio"]
+        adata.uns["pca"]["variance_ratio"], rep_adata.uns["pca"]["variance_ratio"]
     )
-    np.testing.assert_equal(adata.obsm["X_pca"], layer_adata.obsm["X_pca"])
-    np.testing.assert_equal(adata.varm["PCs"], layer_adata.varm["PCs"])
+    np.testing.assert_equal(adata.obsm["X_pca"], rep_adata.obsm["X_pca"])
+    pcs = (
+        rep_adata.varm["PCs"] if rep == "layer" else rep_adata.uns["pca"]["components"]
+    )
+    np.testing.assert_equal(adata.varm["PCs"], pcs)
 
 
 # Skipping these tests during min-deps testing shouldn't be an issue because the sparse-in-dask feature is not available on anndata<0.10 anyway

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -410,6 +410,19 @@ def test_mask_length_error():
         sc.pp.pca(adata, mask_var=mask_var, copy=True)
 
 
+@pytest.mark.parametrize("mask_type", ["highly_variable", "array"])
+def test_obsm_mask_error(mask_type: Literal["highly_variable", "array"]) -> None:
+    """Check that trying to use mask_var with obsm raises an error."""
+    adata = AnnData(A_list)
+    mask_var = (
+        _helpers.random_mask(adata.shape[1]) if mask_type == "array" else mask_type
+    )
+    with pytest.raises(
+        ValueError, match=r"Argument `mask_var` is incompatible with `obsm`."
+    ):
+        sc.pp.pca(adata, mask_var=mask_var, obsm="X_pca", copy=True)
+
+
 def test_mask_var_argument_equivalence(float_dtype, array_type):
     """Test if pca result is equal when given mask as boolarray vs string."""
     adata_base = AnnData(array_type(np.random.random((100, 10))).astype(float_dtype))


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3846
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

The two functions in #3846 (plus the experimental version) seem to be the only valid candidates!

Everything else that (isn’t plotting and) has a `layer` parameter is gene expression specific (like `highly_variable_genes`)