### PR TITLE
feat: use `skip_file_prefixes` in warnings

### DIFF
--- a/docs/release-notes/3876.feat.md
+++ b/docs/release-notes/3876.feat.md
@@ -1,0 +1,1 @@
+Raised warnings now always point at user code, not internal scanpy code {smaller}`P Angerer`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "pynndescent>=0.5.13",
     "packaging>=21.3",
     "session-info2",
-    "legacy-api-wrap>=1.4.1",                     # for positional API deprecations
+    "legacy-api-wrap>=1.5",                       # for positional API deprecations
     "typing-extensions; python_version < '3.13'",
 ]
 dynamic = [ "version" ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -285,6 +285,7 @@ required-imports = [ "from __future__ import annotations" ]
 "numpy.bool".msg = "Use `np.bool_` instead for numpy>=1.24<2 compatibility"
 "numba.jit".msg = "Use `scanpy._compat.njit` instead"
 "numba.njit".msg = "Use `scanpy._compat.njit` instead"
+"warnings.warn".msg = "Use `scanpy._compat.warn` instead"
 [tool.ruff.lint.flake8-type-checking]
 exempt-modules = [  ]
 strict = true

--- a/src/scanpy/__init__.py
+++ b/src/scanpy/__init__.py
@@ -90,11 +90,12 @@ sys.modules.update({f"{__name__}.{m}": globals()[m] for m in ["tl", "pp", "pl"]}
 
 def __getattr__(name: str) -> Any:
     if name == "__version__":
-        import warnings
         from importlib.metadata import version
 
+        from ._compat import warn
+
         msg = "`__version__` is deprecated, use `importlib.metadata.version('scanpy')` instead"
-        warnings.warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         return version("scanpy")
 
     raise AttributeError

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -86,7 +86,18 @@ def pkg_version(package: str) -> Version:
     return Version(version(package))
 
 
-old_positionals = partial(legacy_api_wrap.legacy_api, category=FutureWarning)  # noqa: TID251
+# File prefixes for us and decorators we use
+_FILE_PREFIXES: tuple[str, ...] = (
+    str(Path(__file__).parent),
+    str(Path(legacy_api_wrap.__file__).parent),
+)
+
+
+old_positionals = partial(
+    legacy_api_wrap.legacy_api,  # noqa: TID251
+    category=FutureWarning,
+    skip_file_prefixes=_FILE_PREFIXES,
+)
 
 
 if sys.version_info >= (3, 13):
@@ -96,13 +107,6 @@ else:
 
 
 deprecated = partial(_deprecated, category=FutureWarning)
-
-
-# File prefixes for us and decorators we use
-_FILE_PREFIXES: tuple[str, ...] = (
-    str(Path(__file__).parent),
-    str(Path(legacy_api_wrap.__file__).parent),
-)
 
 
 def warn(

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -100,13 +100,16 @@ old_positionals = partial(
 )
 
 
-if sys.version_info >= (3, 13):
-    from warnings import deprecated as _deprecated
+# we’re not using _FILE_PREFIXES here,
+# since a wholesale deprecated function shouldn’t be used internally anyway
+if TYPE_CHECKING:
+    from warnings import deprecated
 else:
-    from typing_extensions import deprecated as _deprecated
-
-
-deprecated = partial(_deprecated, category=FutureWarning)
+    if sys.version_info >= (3, 13):
+        from warnings import deprecated as _deprecated
+    else:
+        from typing_extensions import deprecated as _deprecated
+    deprecated = partial(_deprecated, category=FutureWarning)
 
 
 def warn(

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -4,6 +4,7 @@ import sys
 import warnings
 from functools import cache, partial, wraps
 from importlib.util import find_spec
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal, ParamSpec, TypeVar, cast, overload
 
 from packaging.version import Version
@@ -105,6 +106,32 @@ else:
 
 
 deprecated = partial(_deprecated, category=FutureWarning)
+
+
+# File prefixes for us and decorators we use
+_FILE_PREFIXES: tuple[str, ...] = (
+    str(Path(__file__).parent),
+    str(Path(legacy_api.__file__).parent),
+)
+
+
+def warn(
+    message: str,
+    category: type[Warning] = UserWarning,
+    *,
+    source: str | None = None,
+    skip_file_prefixes: tuple[str, ...] = (),
+    more_file_prefixes: tuple[str, ...] = (),
+) -> None:
+    """Issue a warning, skipping frames from certain file prefixes."""
+    if not skip_file_prefixes:
+        skip_file_prefixes = (*_FILE_PREFIXES, *more_file_prefixes)
+    elif more_file_prefixes:
+        msg = "Cannot use both `skip_file_prefixes` and `more_file_prefixes`."
+        raise TypeError(msg)
+    warnings.warn(  # noqa: TID251
+        message, category, source=source, skip_file_prefixes=skip_file_prefixes
+    )
 
 
 @overload

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -7,6 +7,7 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal, cast, overload
 
+import legacy_api_wrap
 from packaging.version import Version
 from scipy import sparse
 
@@ -85,15 +86,7 @@ def pkg_version(package: str) -> Version:
     return Version(version(package))
 
 
-if find_spec("legacy_api_wrap") or TYPE_CHECKING:
-    from legacy_api_wrap import legacy_api  # noqa: TID251
-
-    old_positionals = partial(legacy_api, category=FutureWarning)
-else:
-    # legacy_api_wrap is currently a hard dependency,
-    # but this code makes it possible to run scanpy without it.
-    def old_positionals(*old_positionals: str):
-        return lambda func: func
+old_positionals = partial(legacy_api_wrap.legacy_api, category=FutureWarning)  # noqa: TID251
 
 
 if sys.version_info >= (3, 13):
@@ -108,7 +101,7 @@ deprecated = partial(_deprecated, category=FutureWarning)
 # File prefixes for us and decorators we use
 _FILE_PREFIXES: tuple[str, ...] = (
     str(Path(__file__).parent),
-    str(Path(legacy_api.__file__).parent),
+    str(Path(legacy_api_wrap.__file__).parent),
 )
 
 

--- a/src/scanpy/_compat.py
+++ b/src/scanpy/_compat.py
@@ -29,6 +29,7 @@ __all__ = [
     "old_positionals",
     "pkg_metadata",
     "pkg_version",
+    "warn",
 ]
 
 
@@ -113,7 +114,7 @@ _FILE_PREFIXES: tuple[str, ...] = (
 
 def warn(
     message: str,
-    category: type[Warning] = UserWarning,
+    category: type[Warning],
     *,
     source: str | None = None,
     skip_file_prefixes: tuple[str, ...] = (),
@@ -162,7 +163,7 @@ def njit[**P, R](
                     f"Trying to run {f.__name__} in serial mode. "
                     "In case of problems, install `tbb`."
                 )
-                warnings.warn(msg, stacklevel=2)
+                warn(msg, UserWarning)
             return fns[parallel](*args, **kwargs)
 
         return wrapper

--- a/src/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/src/scanpy/experimental/pp/_highly_variable_genes.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from functools import partial
 from math import sqrt
 from typing import TYPE_CHECKING
@@ -12,7 +11,7 @@ from anndata import AnnData
 from fast_array_utils.stats import mean_var
 
 from ... import logging as logg
-from ..._compat import CSBase, njit
+from ..._compat import CSBase, njit, warn
 from ..._settings import Verbosity, settings
 from ..._utils import _doc_params, check_nonnegative_integers, view_to_actual
 from ...experimental._docs import (
@@ -145,11 +144,8 @@ def _highly_variable_pearson_residuals(  # noqa: PLR0912, PLR0915
 
     # Check for raw counts
     if check_values and not check_nonnegative_integers(x):
-        warnings.warn(
-            "`flavor='pearson_residuals'` expects raw count data, but non-integers were found.",
-            UserWarning,
-            stacklevel=3,
-        )
+        msg = "`flavor='pearson_residuals'` expects raw count data, but non-integers were found."
+        warn(msg, UserWarning)
     # check theta
     if theta <= 0:
         # TODO: would "underdispersion" with negative theta make sense?

--- a/src/scanpy/experimental/pp/_normalization.py
+++ b/src/scanpy/experimental/pp/_normalization.py
@@ -2,14 +2,12 @@ from __future__ import annotations
 
 from types import MappingProxyType
 from typing import TYPE_CHECKING
-from warnings import warn
 
 import numpy as np
 from anndata import AnnData
 
-from scanpy._compat import CSBase
-
 from ... import logging as logg
+from ..._compat import CSBase, warn
 from ..._utils import (
     _doc_params,
     _empty,
@@ -56,11 +54,8 @@ def _pearson_residuals(
         raise ValueError(msg)
 
     if check_values and not check_nonnegative_integers(x):
-        warn(
-            "`normalize_pearson_residuals()` expects raw count data, but non-integers were found.",
-            UserWarning,
-            stacklevel=3,
-        )
+        msg = "`normalize_pearson_residuals()` expects raw count data, but non-integers were found."
+        warn(msg, UserWarning)
 
     if isinstance(x, CSBase):
         sums_genes = np.sum(x, axis=0)

--- a/src/scanpy/metrics/_common.py
+++ b/src/scanpy/metrics/_common.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from abc import ABC, abstractmethod
 from dataclasses import InitVar, dataclass, field
 from functools import singledispatch
@@ -9,7 +8,7 @@ from typing import TYPE_CHECKING, ClassVar, overload
 import numpy as np
 import pandas as pd
 
-from .._compat import CSRBase, DaskArray, SpBase, fullname
+from .._compat import CSRBase, DaskArray, SpBase, fullname, warn
 
 if TYPE_CHECKING:
     from typing import NoReturn
@@ -135,9 +134,6 @@ def _vals_heterogeneous[V: NDArray | CSRBase](
     if idxer.all():
         idxer = slice(None)
     else:
-        warnings.warn(
-            f"{len(idxer) - idxer.sum()} variables were constant, will return nan for these.",
-            UserWarning,
-            stacklevel=3,
-        )
+        msg = f"{len(idxer) - idxer.sum()} variables were constant, will return nan for these."
+        warn(msg, UserWarning)
     return vals[idxer], idxer, full_result

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -6,7 +6,6 @@ import contextlib
 from textwrap import indent
 from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple, TypedDict
-from warnings import warn
 
 import numpy as np
 import scipy
@@ -15,7 +14,7 @@ from sklearn.utils import check_random_state
 
 from .. import _utils
 from .. import logging as logg
-from .._compat import CSBase, CSRBase, SpBase, old_positionals
+from .._compat import CSBase, CSRBase, SpBase, old_positionals, warn
 from .._settings import settings
 from .._utils import NeighborsView, _doc_params, get_literal_vals
 from . import _connectivity
@@ -703,7 +702,7 @@ class Neighbors:
                 "`transformer='rapids'` is deprecated. "
                 "Use `rapids_singlecell.tl.neighbors` instead."
             )
-            warn(msg, FutureWarning, stacklevel=3)
+            warn(msg, FutureWarning)
             from scanpy.neighbors._backends.rapids import RapidsKNNTransformer
 
             transformer = RapidsKNNTransformer(**kwds)

--- a/src/scanpy/neighbors/_common.py
+++ b/src/scanpy/neighbors/_common.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from warnings import warn
 
 import numpy as np
 from fast_array_utils.stats import is_constant
 from scipy import sparse
+
+from .._compat import warn
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -133,8 +134,7 @@ def _ind_dist_shortcut(
             "Sparse matrix has no constant number of neighbors per row. "
             "Cannot efficiently get indices and distances."
         )
-        # 4: caller -> 3: `Neighbors.compute_neighbors` -> 2: `_get_indices_distances_from_sparse_matrix` -> 1: here
-        warn(msg, category=RuntimeWarning, stacklevel=4)
+        warn(msg, RuntimeWarning)
         return None
     n_obs, n_neighbors = d.shape[0], int(nnzs[0])
     return (

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -4,14 +4,13 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, NamedTuple
-from warnings import warn
 
 import numpy as np
 from matplotlib import colormaps, gridspec
 from matplotlib import pyplot as plt
 
 from .. import logging as logg
-from .._compat import old_positionals
+from .._compat import old_positionals, warn
 from .._utils import _empty
 from ._anndata import (
     VarGroups,
@@ -156,12 +155,11 @@ class BasePlot:
             gene_symbols=gene_symbols,
         )
         if len(self.categories) > self.MAX_NUM_CATEGORIES:
-            warn(
+            msg = (
                 f"Over {self.MAX_NUM_CATEGORIES} categories found. "
-                "Plot would be very large.",
-                UserWarning,
-                stacklevel=2,
+                "Plot would be very large."
             )
+            warn(msg, UserWarning)
 
         if categories_order is not None and (
             set(self.obs_tidy.index.categories) != set(categories_order)

--- a/src/scanpy/plotting/_stacked_violin.py
+++ b/src/scanpy/plotting/_stacked_violin.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -9,7 +8,7 @@ from matplotlib import colormaps
 from matplotlib.colors import is_color_like
 
 from .. import logging as logg
-from .._compat import old_positionals
+from .._compat import old_positionals, warn
 from .._settings import settings
 from .._utils import _doc_params, _empty
 from ._baseplot_class import BasePlot, doc_common_groupby_plot_args
@@ -153,7 +152,7 @@ class StackedViolin(BasePlot):
         # This is done because class properties are hard to do.
         if name == "DEFAULT_DENSITY_NORM" and hasattr(self, "DEFAULT_SCALE"):
             msg = "Don’t set DEFAULT_SCALE, use DEFAULT_DENSITY_NORM instead"
-            warnings.warn(msg, FutureWarning, stacklevel=2)
+            warn(msg, FutureWarning)
             return object.__getattribute__(self, "DEFAULT_SCALE")
         return object.__getattribute__(self, name)
 
@@ -228,7 +227,7 @@ class StackedViolin(BasePlot):
         if standard_scale == "obs":
             standard_scale = "group"
             msg = "`standard_scale='obs'` is deprecated, use `standard_scale='group'` instead"
-            warnings.warn(msg, FutureWarning, stacklevel=2)
+            warn(msg, FutureWarning)
         if standard_scale == "group":
             self.obs_tidy = self.obs_tidy.sub(self.obs_tidy.min(1), axis=0)
             self.obs_tidy = self.obs_tidy.div(self.obs_tidy.max(1), axis=0).fillna(0)
@@ -800,7 +799,7 @@ def stacked_violin(  # noqa: PLR0913
             "`order` is deprecated (and never worked for `stacked_violin`), "
             "use categories_order instead"
         )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         # no reason to set `categories_order` here, as `order` never worked.
 
     vp = StackedViolin(

--- a/src/scanpy/plotting/_utils.py
+++ b/src/scanpy/plotting/_utils.py
@@ -16,7 +16,7 @@ from matplotlib.figure import SubplotParams
 from matplotlib.patches import Circle
 
 from .. import logging as logg
-from .._compat import old_positionals
+from .._compat import old_positionals, warn
 from .._settings import settings
 from .._utils import NeighborsView, _empty
 from . import palettes
@@ -382,7 +382,7 @@ def savefig_or_show(
                 "Argument `save` is deprecated and will be removed in a future version. "
                 "Use `sc.pl.plot(show=False).figure.savefig()` instead."
             )
-            warnings.warn(msg, category=FutureWarning, stacklevel=2)
+            warn(msg, FutureWarning)
         _savefig(writekey, dpi=dpi, ext=ext)
     if settings.autoshow if show is None else show:
         plt.show()
@@ -1098,7 +1098,7 @@ def _deprecated_scale(
         msg = "can’t specify both `scale` and `density_norm`"
         raise ValueError(msg)
     msg = "`scale` is deprecated, use `density_norm` instead"
-    warnings.warn(msg, FutureWarning, stacklevel=3)
+    warn(msg, FutureWarning)
     return scale
 
 

--- a/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_deprecated/highly_variable_genes.py
@@ -9,7 +9,7 @@ from anndata import AnnData
 from fast_array_utils.stats import mean_var
 
 from ... import logging as logg
-from ..._compat import CSBase, deprecated, old_positionals
+from ..._compat import CSBase, deprecated, old_positionals, warn
 from .._distributed import materialize_as_ndarray
 
 if TYPE_CHECKING:
@@ -125,7 +125,7 @@ def filter_genes_dispersion(  # noqa: PLR0912, PLR0913, PLR0915
         x is None for x in [min_disp, max_disp, min_mean, max_mean]
     ):
         msg = "If you pass `n_top_genes`, all cutoffs are ignored."
-        warnings.warn(msg, UserWarning, stacklevel=2)
+        warn(msg, UserWarning)
     if min_disp is None:
         min_disp = 0.5
     if min_mean is None:

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from operator import truediv
 from typing import TYPE_CHECKING
-from warnings import warn
 
 import numba
 import numpy as np
 from fast_array_utils import stats
 
 from .. import logging as logg
-from .._compat import CSBase, CSCBase, CSRBase, DaskArray, njit, old_positionals
+from .._compat import CSBase, CSCBase, CSRBase, DaskArray, njit, old_positionals, warn
 from .._utils import axis_mul_or_truediv, dematrix, view_to_actual
 from ..get import _get_obs_rep, _set_obs_rep
 
@@ -286,7 +285,7 @@ def normalize_total(  # noqa: PLR0912
 
     cell_subset = counts_per_cell > 0
     if not isinstance(cell_subset, DaskArray) and not np.all(cell_subset):
-        warn("Some cells have zero counts", UserWarning, stacklevel=2)
+        warn("Some cells have zero counts", UserWarning)
 
     dat = dict(
         X=x,

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING, Literal, overload
-from warnings import warn
 
 import numpy as np
 from anndata import AnnData
@@ -10,7 +8,7 @@ from packaging.version import Version
 from sklearn.utils import check_random_state
 
 from ... import logging as logg
-from ..._compat import CSBase, DaskArray, pkg_version
+from ..._compat import CSBase, DaskArray, pkg_version, warn
 from ..._settings import settings
 from ..._utils import _doc_params, _empty, get_literal_vals, is_backed_type
 from ...get import _check_mask, _get_obs_rep
@@ -286,7 +284,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
                 f"{svd_solver=} for sparse relies on legacy code and will not be supported in the future. "
                 "Also the lobpcg solver has been observed to be inaccurate. Please use 'arpack' instead."
             )
-            warnings.warn(msg, FutureWarning, stacklevel=2)
+            warn(msg, FutureWarning)
             x_pca, pca_ = _pca_compat_sparse(
                 x, n_comps, solver=svd_solver, random_state=random_state
             )
@@ -307,10 +305,10 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
 
                 if random_state != 0:
                     msg = f"Ignoring {random_state=} when using a sparse dask array"
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warn(msg, UserWarning)
                 if svd_solver not in {None, "covariance_eigh"}:
                     msg = f"Ignoring {svd_solver=} when using a sparse dask array"
-                    warnings.warn(msg, UserWarning, stacklevel=2)
+                    warn(msg, UserWarning)
                 pca_ = PCAEighDask(n_components=n_comps)
             else:
                 from dask_ml.decomposition import PCA
@@ -425,7 +423,7 @@ def _handle_mask_var(
             "Use_highly_variable=False can be called through mask_var=None"
         )
         msg = f"Argument `use_highly_variable` is deprecated, consider using the mask argument. {hint}"
-        warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         if mask_var is not _empty:
             msg = f"These arguments are incompatible. {hint}"
             raise ValueError(msg)
@@ -523,6 +521,5 @@ def _handle_x_args[T: LiteralString](
             f"Ignoring {svd_solver=} and using {default}, "
             f"{method.__module__}.{method.__qualname__}{suffix} only supports {args}."
         )
-        # (4: caller of `pca` -> 3: `pca` -> 2: `_handle_{sklearn,dask_ml}_args` -> 1: here)
-        warnings.warn(msg, UserWarning, stacklevel=4)
+        warn(msg, UserWarning)
     return default

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from functools import singledispatch, wraps
 from typing import TYPE_CHECKING
-from warnings import warn
 
 import numba
 import numpy as np
@@ -13,7 +12,7 @@ from scipy import sparse
 from scanpy.get import _get_obs_rep
 from scanpy.preprocessing._distributed import materialize_as_ndarray
 
-from .._compat import CSBase, CSRBase, DaskArray, njit
+from .._compat import CSBase, CSRBase, DaskArray, njit, warn
 from .._utils import _doc_params, axis_nnz
 from ._docs import (
     doc_adata_basic,
@@ -82,11 +81,8 @@ def describe_obs(  # noqa: PLR0913
 
     """
     if parallel is not None:
-        warn(
-            "Argument `parallel` is deprecated, and currently has no effect.",
-            FutureWarning,
-            stacklevel=2,
-        )
+        msg = "Argument `parallel` is deprecated, and currently has no effect."
+        warn(msg, FutureWarning)
     # Handle whether X is passed
     if x is None:
         x = _get_obs_rep(adata, use_raw=use_raw, layer=layer)
@@ -276,11 +272,8 @@ def calculate_qc_metrics(
 
     """
     if parallel is not None:
-        warn(
-            "Argument `parallel` is deprecated, and currently has no effect.",
-            FutureWarning,
-            stacklevel=2,
-        )
+        msg = "Argument `parallel` is deprecated, and currently has no effect."
+        warn(msg, FutureWarning)
     # Pass X so I only have to do it once
     x = _get_obs_rep(adata, use_raw=use_raw, layer=layer)
     if isinstance(x, CSBase):

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from functools import singledispatch
 from operator import truediv
 from typing import TYPE_CHECKING
@@ -11,7 +10,7 @@ from anndata import AnnData
 from fast_array_utils.stats import mean_var
 
 from .. import logging as logg
-from .._compat import CSBase, CSCBase, CSRBase, DaskArray, njit, old_positionals
+from .._compat import CSBase, CSCBase, CSRBase, DaskArray, njit, old_positionals, warn
 from .._utils import (
     axis_mul_or_truediv,
     check_array_function_arguments,
@@ -195,7 +194,7 @@ def scale_array[A: _Array](
             isinstance(x, DaskArray) and isinstance(x._meta, CSBase)
         ):
             msg = "zero-centering a sparse array/matrix densifies it."
-            warnings.warn(msg, UserWarning, stacklevel=2)
+            warn(msg, UserWarning)
         x -= mean
         x = dematrix(x)
 

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -7,7 +7,6 @@ import warnings
 from functools import partial
 from pathlib import Path, PurePath
 from typing import TYPE_CHECKING, cast, get_args, overload
-from warnings import warn
 
 import anndata.utils
 import h5py
@@ -18,7 +17,7 @@ from matplotlib.image import imread
 from packaging.version import Version
 
 from . import logging as logg
-from ._compat import deprecated, old_positionals, pkg_version
+from ._compat import deprecated, old_positionals, pkg_version, warn
 from ._settings import AnnDataFileFormat, settings
 from ._utils import _empty
 
@@ -704,7 +703,7 @@ def write(
             "'csv' is not a good choice for anything, especially storing AnnData, "
             "and will be removed from this function. Use 'h5ad' or 'zarr' instead."
         )
-        warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         adata.write_csvs(filename)
         return
     elif ext not in {"h5ad", "h5", "zarr"}:

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -8,6 +8,7 @@ from natsort import natsorted
 
 from .. import _utils
 from .. import logging as logg
+from .._compat import warn
 from .._utils.random import set_igraph_random_state
 from ._utils_clustering import rename_groups, restrict_adjacency
 
@@ -125,7 +126,7 @@ def leiden(  # noqa: PLR0912, PLR0913, PLR0915
             "To achieve the future defaults please pass: `flavor='igraph'` and `n_iterations=2`. "
             "`directed` must also be `False` to work with igraph’s implementation."
         )
-        _utils.warn_once(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
     if flavor not in {"igraph", "leidenalg"}:
         msg = (
             f"flavor must be either 'igraph' or 'leidenalg', but {flavor!r} was passed"

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from types import MappingProxyType
 from typing import TYPE_CHECKING
 
@@ -11,7 +10,7 @@ from packaging.version import Version
 
 from .. import _utils
 from .. import logging as logg
-from .._compat import deprecated, old_positionals, pkg_version
+from .._compat import deprecated, old_positionals, pkg_version, warn
 from .._utils import _choose_graph, dematrix
 from ._utils_clustering import rename_groups, restrict_adjacency
 
@@ -195,7 +194,7 @@ def louvain(  # noqa: PLR0912, PLR0913, PLR0915
             "`flavor='rapids'` is deprecated. "
             "Use `rapids_singlecell.tl.louvain` instead."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         # nvLouvain only works with undirected graphs,
         # and `adjacency` must have a directed edge in both directions
         import cudf

--- a/src/scanpy/tools/_tsne.py
+++ b/src/scanpy/tools/_tsne.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 from .. import logging as logg
-from .._compat import old_positionals
+from .._compat import old_positionals, warn
 from .._settings import settings
 from .._utils import _doc_params, raise_not_implemented_error_if_backed_type
 from ..neighbors._doc import doc_n_pcs, doc_use_rep
@@ -128,21 +127,19 @@ def tsne(  # noqa: PLR0913
 
     # Backwards compat handling: Remove in scanpy 1.9.0
     if n_jobs != 1 and not use_fast_tsne:
-        warnings.warn(
+        msg = (
             "In previous versions of scanpy, calling tsne with `n_jobs` > 1 would use MulticoreTSNE. "
             "Now this uses the scikit-learn version of TSNE by default. "
             "If you’d like the old behaviour (which is deprecated), pass `use_fast_tsne=True`. "
-            "Note, MulticoreTSNE is not actually faster anymore.",
-            UserWarning,
-            stacklevel=2,
+            "Note, MulticoreTSNE is not actually faster anymore."
         )
+        warn(msg, UserWarning)
     if use_fast_tsne:
-        warnings.warn(
+        msg = (
             "Argument `use_fast_tsne` is deprecated, and support for MulticoreTSNE "
-            "will be dropped in a future version of scanpy.",
-            FutureWarning,
-            stacklevel=2,
+            "will be dropped in a future version of scanpy."
         )
+        warn(msg, FutureWarning)
 
     # deal with different tSNE implementations
     if use_fast_tsne:
@@ -150,11 +147,8 @@ def tsne(  # noqa: PLR0913
             from MulticoreTSNE import MulticoreTSNE as TSNE  # noqa: N814
         except ImportError:
             use_fast_tsne = False
-            warnings.warn(
-                "Could not import 'MulticoreTSNE'. Falling back to scikit-learn.",
-                ImportWarning,
-                stacklevel=2,
-            )
+            msg = "Could not import 'MulticoreTSNE'. Falling back to scikit-learn."
+            warn(msg, ImportWarning)
         else:
             tsne = TSNE(**params_sklearn)
             logg.info("    using the 'MulticoreTSNE' package by Ulyanov (2017)")

--- a/src/scanpy/tools/_umap.py
+++ b/src/scanpy/tools/_umap.py
@@ -7,7 +7,7 @@ import numpy as np
 from sklearn.utils import check_array, check_random_state
 
 from .. import logging as logg
-from .._compat import old_positionals
+from .._compat import old_positionals, warn
 from .._settings import settings
 from .._utils import NeighborsView
 from ._utils import _choose_representation, get_init_pos_from_paga
@@ -236,7 +236,7 @@ def umap(  # noqa: PLR0913, PLR0915
             "`method='rapids'` is deprecated. "
             "Use `rapids_singlecell.tl.louvain` instead."
         )
-        warnings.warn(msg, FutureWarning, stacklevel=2)
+        warn(msg, FutureWarning)
         metric = neigh_params.get("metric", "euclidean")
         if metric != "euclidean":
             msg = (

--- a/src/scanpy/tools/_utils.py
+++ b/src/scanpy/tools/_utils.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
 
 from .. import logging as logg
+from .._compat import warn
 from .._settings import settings
 from .._utils import _choose_graph
 
@@ -64,12 +64,12 @@ def _get_pca_or_small_x(adata: AnnData, n_pcs: int | None) -> np.ndarray | CSRBa
 
     from ..preprocessing import pca
 
-    warnings.warn(
+    msg = (
         f"You’re trying to run this on {adata.n_vars} dimensions of `.X`, "
         "if you really want this, set `use_rep='X'`.\n         "
-        "Falling back to preprocessing with `sc.pp.pca` and default params.",
-        stacklevel=3,
+        "Falling back to preprocessing with `sc.pp.pca` and default params."
     )
+    warn(msg, UserWarning)
     n_pcs_pca = n_pcs if n_pcs is not None else settings.N_PCS
     pca(adata, n_comps=n_pcs_pca)
     return adata.obsm["X_pca"]

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -364,6 +364,7 @@ def test_pca_chunked():
     np.testing.assert_allclose(
         np.abs(chunked.uns["pca"]["variance_ratio"]),
         np.abs(default.uns["pca"]["variance_ratio"]),
+        rtol=1e-6,
     )
 
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3871
- [x] [Tests][] included or not required because: no idea how to test this, but I checked manually
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

demo:

```py
import scanpy as sc

print(sc.__version__)

sc.datasets.blobs(10)
```

output:

```pytb
…/lib.py:5: FutureWarning: `__version__` is deprecated, use `importlib.metadata.version('scanpy')` instead
  print(sc.__version__)
1.12.0.dev150+g70a42cb8a.d20251104
…/lib.py:7: FutureWarning: The specified parameters ('n_variables',) are no longer positional. Please specify them like `n_variables=10`
  sc.datasets.blobs(10)
```
