### PR TITLE
fix: handle `as_sparse_dask_array` no longer exported from `anndata`

### DIFF
--- a/src/testing/scanpy/_helpers/__init__.py
+++ b/src/testing/scanpy/_helpers/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import warnings
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
+from importlib.metadata import version
 from importlib.util import find_spec
 from itertools import permutations
 from types import MappingProxyType
@@ -140,7 +141,10 @@ def as_dense_dask_array(*args, **kwargs) -> DaskArray:
 
 
 def as_sparse_dask_array(*args, **kwargs) -> DaskArray:
-    from anndata.tests.helpers import as_sparse_dask_array
+    if Version(version("anndata")) < Version("0.12.5"):
+        from anndata.tests.helpers import as_sparse_dask_array
+    else:
+        from anndata.tests.helpers import as_sparse_dask_matrix as as_sparse_dask_array
 
     return as_sparse_dask_array(*args, **kwargs)
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Handles https://github.com/scverse/anndata/pull/2201
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: not a public change

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
