### PR TITLE
chore: fix #3881’s confusing naming

### DIFF
--- a/src/testing/scanpy/_helpers/__init__.py
+++ b/src/testing/scanpy/_helpers/__init__.py
@@ -141,10 +141,10 @@ def as_dense_dask_array(*args, **kwargs) -> DaskArray:
 
 
 def as_sparse_dask_matrix(*args, **kwargs) -> DaskArray:
-    if Version(version("anndata")) < Version("0.12.6"):
-        from anndata.tests.helpers import as_sparse_dask_array as as_sparse_dask_matrix
-    else:
+    if Version(version("anndata")) >= Version("0.12.6"):
         from anndata.tests.helpers import as_sparse_dask_matrix
+    else:
+        from anndata.tests.helpers import as_sparse_dask_array as as_sparse_dask_matrix
 
     return as_sparse_dask_matrix(*args, **kwargs)
 

--- a/src/testing/scanpy/_helpers/__init__.py
+++ b/src/testing/scanpy/_helpers/__init__.py
@@ -140,13 +140,13 @@ def as_dense_dask_array(*args, **kwargs) -> DaskArray:
     return a
 
 
-def as_sparse_dask_array(*args, **kwargs) -> DaskArray:
-    if Version(version("anndata")) < Version("0.12.5"):
-        from anndata.tests.helpers import as_sparse_dask_array
+def as_sparse_dask_matrix(*args, **kwargs) -> DaskArray:
+    if Version(version("anndata")) < Version("0.12.6"):
+        from anndata.tests.helpers import as_sparse_dask_array as as_sparse_dask_matrix
     else:
-        from anndata.tests.helpers import as_sparse_dask_matrix as as_sparse_dask_array
+        from anndata.tests.helpers import as_sparse_dask_matrix
 
-    return as_sparse_dask_array(*args, **kwargs)
+    return as_sparse_dask_matrix(*args, **kwargs)
 
 
 @dataclass(init=False)

--- a/src/testing/scanpy/_pytest/params.py
+++ b/src/testing/scanpy/_pytest/params.py
@@ -11,7 +11,7 @@ from anndata.tests.helpers import asarray
 from packaging.version import Version
 from scipy import sparse
 
-from .._helpers import as_dense_dask_array, as_sparse_dask_array
+from .._helpers import as_dense_dask_array, as_sparse_dask_matrix
 from .._pytest.marks import needs
 
 if TYPE_CHECKING:
@@ -74,7 +74,7 @@ MAP_ARRAY_TYPES: dict[
     ),
     ("dask", "sparse"): tuple(
         pytest.param(
-            wrapper(as_sparse_dask_array),
+            wrapper(as_sparse_dask_matrix),
             marks=[needs.dask],
             id=f"dask_array_sparse{suffix}",
         )

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -16,7 +16,7 @@ from scanpy.preprocessing._qc import (
     top_proportions,
     top_segment_proportions,
 )
-from testing.scanpy._helpers import as_sparse_dask_array, maybe_dask_process_context
+from testing.scanpy._helpers import as_sparse_dask_matrix, maybe_dask_process_context
 from testing.scanpy._pytest.marks import needs
 from testing.scanpy._pytest.params import ARRAY_TYPES, ARRAY_TYPES_MEM
 
@@ -188,7 +188,7 @@ def test_qc_metrics_no_log1p(adata_prepared: AnnData):
 @pytest.mark.parametrize("log1p", [True, False], ids=["log1p", "no_log1p"])
 def test_dask_against_in_memory(adata, log1p):
     adata_as_dask = adata.copy()
-    adata_as_dask.X = as_sparse_dask_array(adata.X)
+    adata_as_dask.X = as_sparse_dask_matrix(adata.X)
     adata = prepare_adata(adata)
     adata_as_dask = prepare_adata(adata_as_dask)
     with maybe_dask_process_context():


### PR DESCRIPTION
- [x] Release notes not necessary because: unreleased

otherwise we have a different naming schema from anndata.

we should also integrate this with the tests in https://github.com/scverse/scanpy/pull/3563, but not in this PR, since this one is going to be backported to the 1.11.x branch