### PR TITLE
docs: fix broken TypeAliasType support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,9 +50,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
           python-version: ${{ matrix.env.python }}
-          cache-dependency-glob: pyproject.toml
 
       - name: Cache downloaded data
         uses: actions/cache@v4
@@ -70,8 +68,6 @@ jobs:
         run: hatch run ${{ matrix.env.name }}:run
       - name: Run tests (coverage)
         if: matrix.env.test-type == 'coverage'
-        env:
-          COVERAGE_PROCESS_START: ${{ github.workspace }}/pyproject.toml
         run: |
           hatch run ${{ matrix.env.name }}:run-cov
           hatch run ${{ matrix.env.name }}:cov-combine

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -235,32 +235,6 @@ nitpick_ignore = [
     ("py:class", "numpy.int64"),  # documented as “attribute”
     ("py:class", "numpy._typing._dtype_like._SupportsDType"),
     ("py:class", "numpy._typing._dtype_like._DTypeDict"),
-    # TODO: remove once https://github.com/sphinx-doc/sphinx/pull/13508 is released
-    *(
-        ("py:class", f"scanpy.{submodule}.TypeAliasType")
-        for submodule in [
-            "tools._umap",
-            "tools._rank_genes_groups",
-            "tools._marker_gene_overlap",
-            "tools._draw_graph",
-            "preprocessing._scale",
-            "preprocessing._pca",
-            "plotting._utils",
-            "plotting._tools.paga",
-            "plotting._scrublet",
-            "plotting._baseplot_class",
-            "plotting._anndata",
-            "neighbors._types",
-            "metrics._common",
-            "get._aggregated",
-            "external.tl._pypairs",
-            "external.pp._dca",
-            "datasets._datasets",
-            "_utils.random",
-            "_types",
-            "_settings",
-        ]
-    ),
     # Will probably be documented
     ("py:class", "scanpy._settings.Verbosity"),
     ("py:class", "scanpy.neighbors.OnFlySymMatrix"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ test = [
 doc = [
     "sphinx>=8.2.3",
     "sphinx-book-theme>=1.1.0",
-    "scanpydoc>=0.15.3",
+    "scanpydoc>=0.16",
     "sphinx-autodoc-typehints>=1.25.2",
     "sphinx-issues>=5.0.1",
     "myst-parser>=2",
@@ -194,7 +194,7 @@ data_file = "test-data/raw-coverage"
 source_pkgs = [ "scanpy" ]
 omit = [ "tests/*", "src/testing/*" ]
 concurrency = [ "multiprocessing" ]
-parallel = true
+patch = [ "subprocess" ]
 [tool.coverage.xml]
 output = "test-data/coverage.xml"
 [tool.coverage.paths]

--- a/src/scanpy/plotting/_baseplot_class.py
+++ b/src/scanpy/plotting/_baseplot_class.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from .._utils import Empty
     from ._utils import ColorLike, _AxesSubplot
 
-type _VarNames = str | Sequence[str]
+    type _VarNames = str | Sequence[str]
 
 
 class VBoundNorm(NamedTuple):


### PR DESCRIPTION
- [x] Release notes not necessary because: unreleased

Docs were broken in #3874, this fixes them through https://github.com/theislab/scanpydoc/releases/tag/v0.16

before:
<img width="470" height="32" alt="grafik" src="https://github.com/user-attachments/assets/ec4d77b1-ad70-43de-93ec-72919b61c56a" />

after:
<img width="731" height="138" alt="grafik" src="https://github.com/user-attachments/assets/9562ce4b-fc08-41a6-8212-8f352c44749b" />
