### PR TITLE
docs: remove falsely advertised parameters from `sc.pl.scatter`

### DIFF
--- a/docs/release-notes/3894.docs.md
+++ b/docs/release-notes/3894.docs.md
@@ -1,0 +1,1 @@
+Remove a few falsely advertised parameters from {func}`scanpy.pl.scatter` {smaller}`P Angerer`

--- a/docs/release-notes/3894.fix.md
+++ b/docs/release-notes/3894.fix.md
@@ -1,1 +1,0 @@
-Support `colorbar_loc` in {func}`scanpy.pl.scatter` as intended {smaller}`P Angerer`

--- a/docs/release-notes/3894.fix.md
+++ b/docs/release-notes/3894.fix.md
@@ -1,0 +1,1 @@
+Support `colorbar_loc` in {func}`scanpy.pl.scatter` as intended {smaller}`P Angerer`

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -137,7 +137,6 @@ def scatter(  # noqa: PLR0913
     legend_fontweight: int | _FontWeight | None = None,
     legend_fontoutline: float | None = None,
     color_map: str | Colormap | None = None,
-    colorbar_loc: Literal["right", "left", "top", "bottom"] | None = None,
     palette: Cycler | ListedColormap | ColorLike | Sequence[ColorLike] | None = None,
     frameon: bool | None = None,
     right_margin: float | None = None,

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -137,6 +137,7 @@ def scatter(  # noqa: PLR0913
     legend_fontweight: int | _FontWeight | None = None,
     legend_fontoutline: float | None = None,
     color_map: str | Colormap | None = None,
+    colorbar_loc: Literal["right", "left", "top", "bottom"] | None = None,
     palette: Cycler | ListedColormap | ColorLike | Sequence[ColorLike] | None = None,
     frameon: bool | None = None,
     right_margin: float | None = None,
@@ -426,24 +427,27 @@ def _scatter_obs(  # noqa: PLR0912, PLR0913, PLR0915
             key.replace("_", " ") if not is_color_like(key) else "" for key in keys
         ]
 
-    axs: list[Axes] = scatter_base(
-        xy,
-        title=title,
-        alpha=alpha,
-        component_name=component_name,
-        axis_labels=axis_labels,
-        component_indexnames=components + 1,
-        projection=projection,
-        colors=color_ids,
-        highlights=highlights,
-        colorbars=colorbars,
-        right_margin=right_margin,
-        left_margin=left_margin,
-        sizes=[size for _ in keys],
-        markers=marker,
-        color_map=color_map,
-        show_ticks=show_ticks,
-        ax=ax,
+    axs = cast(
+        "list[Axes]",
+        scatter_base(
+            xy,
+            title=title,
+            alpha=alpha,
+            component_name=component_name,
+            axis_labels=axis_labels,
+            component_indexnames=components + 1,
+            projection=projection,
+            colors=color_ids,
+            highlights=highlights,
+            colorbars=colorbars,
+            right_margin=right_margin,
+            left_margin=left_margin,
+            sizes=[size for _ in keys],
+            markers=marker,
+            color_map=color_map,
+            show_ticks=show_ticks,
+            ax=ax,
+        ),
     )
 
     def add_centroid(centroids, name, xy, mask) -> None:

--- a/src/scanpy/plotting/_docs.py
+++ b/src/scanpy/plotting/_docs.py
@@ -90,9 +90,6 @@ legend_fontweight
 legend_fontoutline
     Line width of the legend font outline in pt. Draws a white outline using
     the path effect :class:`~matplotlib.patheffects.withStroke`.
-colorbar_loc
-    Where to place the colorbar for continous variables. If `None`, no colorbar
-    is added.
 size
     Point size. If `None`, is automatically computed as 120000 / n_cells.
     Can be a sequence containing the size for each cell. The order should be
@@ -166,6 +163,9 @@ return_fig
 # Docs for pl.pca, pl.tsne, … (everything in _tools.scatterplots)
 doc_scatter_embedding = f"""\
 {doc_scatter_basic}
+colorbar_loc
+    Where to place the colorbar for continous variables. If `None`, no colorbar
+    is added.
 na_color
     Color to use for null or masked values. Can be anything matplotlib accepts as a
     color. Used for all points if `color=None`.

--- a/src/scanpy/plotting/_docs.py
+++ b/src/scanpy/plotting/_docs.py
@@ -98,12 +98,6 @@ size
     Can be a sequence containing the size for each cell. The order should be
     the same as in adata.obs.
 {doc_cm_palette}
-na_color
-    Color to use for null or masked values. Can be anything matplotlib accepts as a
-    color. Used for all points if `color=None`.
-na_in_legend
-    If there are missing values, whether they get an entry in the legend. Currently
-    only implemented for categorical legends.
 frameon
     Draw a frame around the scatter plot. Defaults to value set in
     :func:`~scanpy.set_figure_params`, defaults to `True`.
@@ -172,6 +166,12 @@ return_fig
 # Docs for pl.pca, pl.tsne, … (everything in _tools.scatterplots)
 doc_scatter_embedding = f"""\
 {doc_scatter_basic}
+na_color
+    Color to use for null or masked values. Can be anything matplotlib accepts as a
+    color. Used for all points if `color=None`.
+na_in_legend
+    If there are missing values, whether they get an entry in the legend. Currently
+    only implemented for categorical legends.
 {doc_vbound_percentile}
 {doc_outline}
 {doc_panels}

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -100,7 +100,7 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
     legend_fontweight: int | _FontWeight = "bold",
     legend_loc: _LegendLoc | None = "right margin",
     legend_fontoutline: int | None = None,
-    colorbar_loc: str | None = "right",
+    colorbar_loc: Literal["right", "left", "top", "bottom"] | None = "right",
     vmax: VBound | Sequence[VBound] | None = None,
     vmin: VBound | Sequence[VBound] | None = None,
     vcenter: VBound | Sequence[VBound] | None = None,

--- a/src/scanpy/plotting/_utils.py
+++ b/src/scanpy/plotting/_utils.py
@@ -952,7 +952,7 @@ def circles(
     --------
     a = np.arange(11)
     circles(a, a, s=a*0.2, c=a, alpha=0.5, ec='none')
-    pl.colorbar()
+    plt.colorbar()
     License
     --------
     This code is under [The BSD 3-Clause License]


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3893
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

looks like all the hairy manual padding stuff would not play well with actually supporting it, so away it goes.