### PR TITLE
docs: document array type support

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,0 +1,5 @@
+code.literal > a > code.literal {
+    border: none;
+    padding: 0;
+    font-size: inherit;
+}

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,12 +10,19 @@ import scanpy as sc
 Additional functionality is available in the broader {doc}`ecosystem <../ecosystem>`, with some tools being wrapped in the {mod}`scanpy.external` module.
 ```
 
+(array-support)=
+## Array type support
+
+Different APIs have different levels of support for array types,
+and this page lists the supported array types for each function:
+
 ```{eval-rst}
 .. array-support:: all
 ```
 
 ```{toctree}
 :maxdepth: 2
+:hidden:
 
 preprocessing
 tools

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -10,6 +10,10 @@ import scanpy as sc
 Additional functionality is available in the broader {doc}`ecosystem <../ecosystem>`, with some tools being wrapped in the {mod}`scanpy.external` module.
 ```
 
+```{eval-rst}
+.. array-support:: all
+```
+
 ```{toctree}
 :maxdepth: 2
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -170,7 +170,7 @@ intersphinx_mapping = dict(
 
 array_support: dict[str, tuple[list[str], list[str]]] = {
     "experimental.pp.highly_variable_genes": (["np", "sp"], []),
-    "get.aggregated": (["np", "sp", "da"], []),
+    "get.aggregate": (["np", "sp", "da"], []),
     "pp.calculate_qc_metrics": (["np", "sp", "da"], []),
     "pp.combat": (["np"], []),
     "pp.downsample_counts": (["np", "sp[csr]"], []),

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -168,6 +168,39 @@ intersphinx_mapping = dict(
 )
 
 
+array_support: dict[str, tuple[list[str], list[str]]] = {
+    "experimental.pp.highly_variable_genes": (["np", "sp"], []),
+    "get.aggregated": (["np", "sp", "da"], []),
+    "pp.calculate_qc_metrics": (["np", "sp", "da"], []),
+    "pp.combat": (["np"], []),
+    "pp.downsample_counts": (["np", "sp[csr]"], []),
+    "pp.filter_cells": (["np", "sp", "da"], []),
+    "pp.filter_genes": (["np", "sp", "da"], []),
+    "pp.highly_variable_genes": (["np", "sp", "da"], ["da[sp[csc]]"]),
+    "pp.log1p": (["np", "sp", "da"], []),
+    "pp.neighbors": (["np", "sp"], []),
+    "pp.normalize_total": (["np", "sp[csr]", "da"], []),
+    "pp.pca": (["np", "sp", "da"], ["da[sp[csc]]"]),
+    "pp.regress_out": (["np"], []),
+    "pp.sample": (["np", "sp", "da"], []),
+    "pp.scale": (["np", "sp", "da"], []),
+    "pp.scrublet": (["np", "sp"], []),
+    "pp.scrublet_simulate_doublets": (["np", "sp"], []),
+    "tl.dendrogram": (["np", "sp"], []),
+    "tl.diffmap": (["np", "sp"], []),
+    "tl.dpt": (["np", "sp"], []),
+    "tl.draw_graph": (["np", "sp"], []),  # only uses graph in obsp
+    "tl.embedding_density": (["np"], []),
+    "tl.ingest": (["np", "sp"], []),
+    "tl.leiden": (["np", "sp"], []),  # only uses graph in obsp
+    "tl.louvain": (["np", "sp"], []),  # only uses graph in obsp
+    "tl.paga": (["np", "sp"], []),
+    "tl.rank_genes_groups": (["np", "sp"], []),
+    "tl.tsne": (["np", "sp"], []),
+    "tl.umap": (["np", "sp"], []),
+}
+
+
 # -- Options for HTML output ----------------------------------------------
 
 # The theme is sphinx-book-theme, with patches for readthedocs-sphinx-search
@@ -183,7 +216,7 @@ html_logo = "_static/img/Scanpy_Logo_BrightFG.svg"
 html_title = "scanpy"
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> None:
     """App setup hook."""
     app.add_generic_role("small", partial(nodes.inline, classes=["small"]))
     app.add_generic_role("smaller", partial(nodes.inline, classes=["smaller"]))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -177,6 +177,7 @@ html_theme_options = {
     "use_repository_button": True,
 }
 html_static_path = ["_static"]
+html_css_files = ["custom.css"]
 html_show_sphinx = False
 html_logo = "_static/img/Scanpy_Logo_BrightFG.svg"
 html_title = "scanpy"

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -38,7 +38,7 @@ class ArraySupport(SphinxDirective):
                 f"API not in `array_support`, add it in `docs/conf.py`: {self.arguments[0]}"
             )
         array_types = list(_docs.parse(*self._array_support[self.arguments[0]]))
-        headers = ("Array type", "supported", "… in dask :class:`~dask.array.Array`")
+        headers = ("Array type", "supported", "… experimentally in dask :class:`~dask.array.Array`")
         data: list[tuple[_docs.Inner, bool, bool]] = []
         for array_type in ALL_INNER:
             dask_array_type = _docs.DaskArray(array_type)

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -52,7 +52,7 @@ class ArraySupport(SphinxDirective):
         return self._render_table(headers, rows)
 
     def _render_overview(self) -> list[nodes.Node]:
-        headers = ["Function", *(at.rst() for at in ALL_INNER)]
+        headers = ["Function", *(at.rst(short=True) for at in ALL_INNER)]
         rows: list[nodes.row] = []
         for fn, (include, exclude) in self._array_support.items():
             row_header, _ = self.parse_inline(f":func:`scanpy.{fn}`")

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -27,30 +27,42 @@ class ArraySupport(SphinxDirective):
 
     def run(self) -> list[nodes.Node]:  # noqa: D102
         array_types = list(_docs.parse(self.arguments, self.options.get("except", ())))
+        headers = ("Array type", "supported", "… in dask")
+        data: list[tuple[_docs.ArrayType, bool, bool]] = []
+        for array_type in _docs.parse(["np", "sp"], inner=True):
+            dask_array_type = _docs.DaskArray(array_type)
+            data.append((
+                array_type,
+                array_type in array_types,
+                dask_array_type in array_types,
+            ))
+
+        return self._render_table(headers, data)
+
+    def _render_table(
+        self,
+        headers: tuple[str, str, str],
+        data: list[tuple[_docs.ArrayType, bool, bool]],
+    ) -> list[nodes.Node]:
         colspecs = [nodes.colspec(stub=True), *(nodes.colspec() for _ in range(2))]
         thead = nodes.thead(
             "",
             nodes.row(
                 "",
-                *(
-                    nodes.entry("", nodes.paragraph("", t))
-                    for t in ["", "direct", "dask"]
-                ),
+                *(nodes.entry("", nodes.paragraph("", t)) for t in headers),
             ),
         )
         tbody = nodes.tbody()
-        for array_type in _docs.parse(["np", "sp"], inner=True):
-            dask_array_type = _docs.DaskArray(array_type)
-            tbody += [
-                nodes.row(
-                    "",
-                    nodes.entry("", nodes.paragraph("", str(array_type))),
-                    *(
-                        nodes.entry("", nodes.paragraph("", str(at in array_types)))
-                        for at in [array_type, dask_array_type]
-                    ),
-                )
+        for array_type, support, in_dask in data:
+            cells = [
+                self._render_array_type(array_type),
+                self._render_support(support),
+                self._render_support(in_dask),
             ]
+            children = (
+                nodes.entry("", nodes.paragraph("", "", *cell)) for cell in cells
+            )
+            tbody += [nodes.row("", *children)]
         return [
             nodes.table(
                 "",
@@ -58,6 +70,14 @@ class ArraySupport(SphinxDirective):
                 nodes.tgroup("", *colspecs, thead, tbody, cols=3),
             )
         ]
+
+    def _render_array_type(self, array_type: _docs.ArrayType, /) -> list[nodes.Node]:
+        nodes_, msgs = self.parse_inline(array_type.rst())
+        assert not msgs, msgs
+        return nodes_
+
+    def _render_support(self, support: bool, /) -> list[nodes.Node]:  # noqa: FBT001
+        return [nodes.Text("✅" if support else "❌")]
 
 
 def setup(app: Sphinx) -> None:

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from itertools import groupby
 from typing import TYPE_CHECKING
 
 from docutils import nodes
@@ -10,6 +11,7 @@ from sphinx.util.docutils import SphinxDirective
 from scanpy._utils import _docs
 
 if TYPE_CHECKING:
+    from collections.abc import Collection, Sequence
     from typing import ClassVar
 
     from sphinx.application import Sphinx
@@ -27,8 +29,8 @@ class ArraySupport(SphinxDirective):
 
     def run(self) -> list[nodes.Node]:  # noqa: D102
         array_types = list(_docs.parse(self.arguments, self.options.get("except", ())))
-        headers = ("Array type", "supported", "… in dask")
-        data: list[tuple[_docs.ArrayType, bool, bool]] = []
+        headers = ("Array type", "supported", "… in dask :class:`~dask.array.Array`")
+        data: list[tuple[_docs.Inner, bool, bool]] = []
         for array_type in _docs.parse(["np", "sp"], inner=True):
             dask_array_type = _docs.DaskArray(array_type)
             data.append((
@@ -42,34 +44,69 @@ class ArraySupport(SphinxDirective):
     def _render_table(
         self,
         headers: tuple[str, str, str],
-        data: list[tuple[_docs.ArrayType, bool, bool]],
+        data: list[tuple[_docs.Inner, bool, bool]],
     ) -> list[nodes.Node]:
+
         colspecs = [nodes.colspec(stub=True), *(nodes.colspec() for _ in range(2))]
         thead = nodes.thead(
             "",
             nodes.row(
                 "",
-                *(nodes.entry("", nodes.paragraph("", t)) for t in headers),
+                *(
+                    nodes.entry("", nodes.paragraph("", "", *self.parse_inline(t)[0]))
+                    for t in headers
+                ),
             ),
         )
         tbody = nodes.tbody()
-        for array_type, support, in_dask in data:
-            cells = [
-                self._render_array_type(array_type),
-                self._render_support(support),
-                self._render_support(in_dask),
-            ]
-            children = (
-                nodes.entry("", nodes.paragraph("", "", *cell)) for cell in cells
-            )
-            tbody += [nodes.row("", *children)]
+        for t, group in groupby(data, key=lambda r: type(r[0])):
+            group = list(group)  # noqa: PLW2901
+            if (  # if all sparse types have the same support, just one row
+                t is _docs.ScipySparse
+                and (support := one({s for _, s, _ in group})) is not None
+                and (in_dask := one({d for _, _, d in group})) is not None
+            ):
+                refs: list[nodes.Node] = [
+                    nodes.inline("", "scipy.sparse.{"),
+                    *self.parse_inline(":class:`csr <scipy.sparse.csr_array>`")[0],
+                    nodes.inline("", ","),
+                    *self.parse_inline(":class:`csc <scipy.sparse.csc_matrix>`")[0],
+                    nodes.inline("", "}_{"),
+                    *self.parse_inline(":class:`array <scipy.sparse.csc_array>`")[0],
+                    nodes.inline("", ","),
+                    *self.parse_inline(":class:`matrix <scipy.sparse.csr_matrix>`")[0],
+                    nodes.inline("", "}"),
+                ]
+                header = [nodes.literal("", "", *refs)]
+                tbody += [self._render_row(header, support=support, in_dask=in_dask)]
+            else:  # otherwise, show them individually
+                tbody += [
+                    self._render_row(
+                        self._render_array_type(array_type),
+                        support=support,
+                        in_dask=in_dask,
+                    )
+                    for array_type, support, in_dask in group
+                ]
         return [
             nodes.table(
                 "",
-                nodes.title("", "Array support"),
+                nodes.title("", "Array type support"),
                 nodes.tgroup("", *colspecs, thead, tbody, cols=3),
+                ids=["array-support"],
             )
         ]
+
+    def _render_row(
+        self, header: Sequence[nodes.Node], *, support: bool, in_dask: bool
+    ) -> nodes.Node:
+        cells: list[Sequence[nodes.Node]] = [
+            header,
+            self._render_support(support),
+            self._render_support(in_dask),
+        ]
+        children = (nodes.entry("", nodes.paragraph("", "", *cell)) for cell in cells)
+        return nodes.row("", *children)
 
     def _render_array_type(self, array_type: _docs.ArrayType, /) -> list[nodes.Node]:
         nodes_, msgs = self.parse_inline(array_type.rst())
@@ -78,6 +115,15 @@ class ArraySupport(SphinxDirective):
 
     def _render_support(self, support: bool, /) -> list[nodes.Node]:  # noqa: FBT001
         return [nodes.Text("✅" if support else "❌")]
+
+
+def one[T](arg: Collection[T]) -> T | None:
+    """Return the only item in `arg` or None if `arg` is not of length 1."""
+    try:
+        [item] = arg
+    except ValueError:
+        return None
+    return item
 
 
 def setup(app: Sphinx) -> None:

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -1,0 +1,65 @@
+"""Add `array-support` directive."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from docutils import nodes
+from sphinx.util.docutils import SphinxDirective
+
+from scanpy._utils import _docs
+
+if TYPE_CHECKING:
+    from typing import ClassVar
+
+    from sphinx.application import Sphinx
+
+
+class ArraySupport(SphinxDirective):
+    """In the scanpy-tutorials repo, this links to the canonical location (here!)."""
+
+    required_arguments: ClassVar = 1
+    optional_arguments: ClassVar = 999
+
+    option_spec: ClassVar = {
+        "except": lambda arg: arg.split(" "),
+    }
+
+    def run(self) -> list[nodes.Node]:  # noqa: D102
+        array_types = list(_docs.parse(self.arguments, self.options.get("except", ())))
+        colspecs = [nodes.colspec(stub=True), *(nodes.colspec() for _ in range(2))]
+        thead = nodes.thead(
+            "",
+            nodes.row(
+                "",
+                *(
+                    nodes.entry("", nodes.paragraph("", t))
+                    for t in ["", "direct", "dask"]
+                ),
+            ),
+        )
+        tbody = nodes.tbody()
+        for array_type in _docs.parse(["np", "sp"], inner=True):
+            dask_array_type = _docs.DaskArray(array_type)
+            tbody += [
+                nodes.row(
+                    "",
+                    nodes.entry("", nodes.paragraph("", str(array_type))),
+                    *(
+                        nodes.entry("", nodes.paragraph("", str(at in array_types)))
+                        for at in [array_type, dask_array_type]
+                    ),
+                )
+            ]
+        return [
+            nodes.table(
+                "",
+                nodes.title("", "Array support"),
+                nodes.tgroup("", *colspecs, thead, tbody, cols=3),
+            )
+        ]
+
+
+def setup(app: Sphinx) -> None:
+    """App setup hook."""
+    app.add_directive("array-support", ArraySupport)

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -38,7 +38,11 @@ class ArraySupport(SphinxDirective):
                 f"API not in `array_support`, add it in `docs/conf.py`: {self.arguments[0]}"
             )
         array_types = list(_docs.parse(*self._array_support[self.arguments[0]]))
-        headers = ("Array type", "supported", "… experimentally in dask :class:`~dask.array.Array`")
+        headers = (
+            "Array type",
+            "supported",
+            "… experimentally in dask :class:`~dask.array.Array`",
+        )
         data: list[tuple[_docs.Inner, bool, bool]] = []
         for array_type in ALL_INNER:
             dask_array_type = _docs.DaskArray(array_type)

--- a/docs/extensions/array_support.py
+++ b/docs/extensions/array_support.py
@@ -18,17 +18,17 @@ if TYPE_CHECKING:
 
 
 class ArraySupport(SphinxDirective):
-    """In the scanpy-tutorials repo, this links to the canonical location (here!)."""
+    """Document array support."""
 
     required_arguments: ClassVar = 1
-    optional_arguments: ClassVar = 999
-
-    option_spec: ClassVar = {
-        "except": lambda arg: arg.split(" "),
-    }
 
     def run(self) -> list[nodes.Node]:  # noqa: D102
-        array_types = list(_docs.parse(self.arguments, self.options.get("except", ())))
+        array_support = self.config.array_support
+        if not self.arguments[0] not in array_support:
+            self.error(
+                f"API not in `array_support`, add it in `docs/conf.py`: {self.arguments[0]}"
+            )
+        array_types = list(_docs.parse(*array_support[self.arguments[0]]))
         headers = ("Array type", "supported", "… in dask :class:`~dask.array.Array`")
         data: list[tuple[_docs.Inner, bool, bool]] = []
         for array_type in _docs.parse(["np", "sp"], inner=True):
@@ -129,3 +129,4 @@ def one[T](arg: Collection[T]) -> T | None:
 def setup(app: Sphinx) -> None:
     """App setup hook."""
     app.add_directive("array-support", ArraySupport)
+    app.add_config_value("array_support", {}, "env")

--- a/docs/release-notes/3895.docs.md
+++ b/docs/release-notes/3895.docs.md
@@ -1,0 +1,1 @@
+Document array type support for most functions in {mod}`~scanpy.pp` and {mod}`~scanpy.tl` {smaller}`P Angerer`

--- a/src/scanpy/_utils/_docs.py
+++ b/src/scanpy/_utils/_docs.py
@@ -1,0 +1,98 @@
+"""Add `array-support` directive."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from itertools import product
+from typing import TYPE_CHECKING, overload
+
+if TYPE_CHECKING:
+    from collections.abc import Collection, Generator
+    from typing import Literal
+
+
+__all__ = ["ArrayType", "DaskArray", "Numpy", "ScipySparse", "parse"]
+
+
+@dataclass(unsafe_hash=True, frozen=True)
+class ArrayType:
+    pass
+
+
+@dataclass(unsafe_hash=True, frozen=True)
+class Numpy(ArrayType):
+    pass
+
+
+@dataclass(unsafe_hash=True, frozen=True)
+class ScipySparse(ArrayType):
+    format: Literal["csr", "csc"]
+    container: Literal["array", "matrix"]
+
+
+type Inner = Numpy | ScipySparse
+
+
+@dataclass(unsafe_hash=True, frozen=True)
+class DaskArray(ArrayType):
+    chunk: Inner
+
+
+@overload
+def parse(
+    include: Collection[str],
+    exclude: Collection[str] = (),
+    *,
+    inner: Literal[False] = False,
+) -> Generator[ArrayType]: ...
+@overload
+def parse(
+    include: Collection[str], exclude: Collection[str] = (), *, inner: Literal[True]
+) -> Generator[Inner]: ...
+def parse(
+    include: Collection[str], exclude: Collection[str] = (), *, inner: bool = False
+) -> Generator[ArrayType]:
+    if exclude:
+        excluded = dict.fromkeys(parse(exclude)).keys()
+        yield from (t for t in parse(include) if t not in excluded)
+        return
+
+    inner_includes = [i for i in include if not i.startswith("da")]
+    for t in include:
+        if (match := re.fullmatch(r"([^\[]+)(?:\[(.+)\])?", t)) is None:
+            msg = f"invalid {t!r}"
+            raise ValueError(msg)
+        mod, tags = match.groups("")
+        if mod == "da" and inner:
+            msg = "Can’t nest dask arrays"
+            raise ValueError(msg)
+        tags = set(re.split(r",(?![^\[]+\])", tags)) if tags else set()
+        yield from _parse_mod(mod, tags, inner_includes=inner_includes)
+
+
+def _parse_mod(
+    mod: str, tags: set[str], *, inner_includes: Collection[str]
+) -> Generator[ArrayType]:
+    match mod:
+        case "np":
+            if tags:
+                msg = f"`np` takes no tags {tags!r}"
+                raise ValueError(msg)
+            yield Numpy()
+        case "sp":
+            if tags - {"csr", "csc", "array", "matrix"}:
+                msg = f"invalid tags {tags!r}"
+                raise ValueError(msg)
+            for format, container in product(("csr", "csc"), ("array", "matrix")):
+                if tags & {"csr", "csc"} and format not in tags:
+                    continue
+                if tags & {"array", "matrix"} and container not in tags:
+                    continue
+                yield ScipySparse(format=format, container=container)
+        case "da":
+            for chunk in parse(tags if tags else inner_includes, inner=True):
+                yield DaskArray(chunk=chunk)
+        case _:
+            msg = f"invalid module {mod!r}"
+            raise ValueError(msg)

--- a/src/scanpy/_utils/_docs.py
+++ b/src/scanpy/_utils/_docs.py
@@ -1,4 +1,4 @@
-"""Add `array-support` directive."""
+"""Utilities for `array-support` directive (see `/docs/extensions/array_support.py`)."""
 
 from __future__ import annotations
 

--- a/src/scanpy/_utils/_docs.py
+++ b/src/scanpy/_utils/_docs.py
@@ -17,8 +17,8 @@ __all__ = ["ArrayType", "DaskArray", "Numpy", "ScipySparse", "parse"]
 
 
 class ArrayType(ABC):
-    def rst(self) -> str:  # pragma: no cover
-        return f":class:`{self}`"
+    def rst(self, *, short: bool = False) -> str:  # pragma: no cover
+        return f":class:`{'~' if short else ''}{self}`"
 
     @abstractmethod
     def __hash__(self) -> int: ...
@@ -29,8 +29,8 @@ class Numpy(ArrayType):
     def __str__(self) -> str:  # pragma: no cover
         return "numpy.ndarray"
 
-    def rst(self) -> str:  # pragma: no cover
-        return f":class:`{self}`"
+    def rst(self, *, short: bool = False) -> str:  # pragma: no cover
+        return f":class:`{'~' if short else ''}{self}`"
 
 
 @dataclass(unsafe_hash=True, frozen=True)
@@ -52,8 +52,8 @@ class DaskArray(ArrayType):
     def __str__(self) -> str:  # pragma: no cover
         return f"dask.array.Array[{self.chunk}]"
 
-    def rst(self) -> str:  # pragma: no cover
-        return rf":class:`dask.array.Array`\ \[{self.chunk.rst()}\]"
+    def rst(self, *, short: bool = False) -> str:  # pragma: no cover
+        return rf":class:`{'~' if short else ''}dask.array.Array`\ \[{self.chunk.rst(short=short)}\]"
 
 
 @overload

--- a/src/scanpy/_utils/_docs.py
+++ b/src/scanpy/_utils/_docs.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import re
+from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from itertools import product
 from typing import TYPE_CHECKING, overload
@@ -15,20 +16,30 @@ if TYPE_CHECKING:
 __all__ = ["ArrayType", "DaskArray", "Numpy", "ScipySparse", "parse"]
 
 
-@dataclass(unsafe_hash=True, frozen=True)
-class ArrayType:
-    pass
+class ArrayType(ABC):
+    def rst(self) -> str:
+        return f":class:`{self}`"
+
+    @abstractmethod
+    def __hash__(self) -> int: ...
 
 
 @dataclass(unsafe_hash=True, frozen=True)
 class Numpy(ArrayType):
-    pass
+    def __str__(self) -> str:
+        return "numpy.ndarray"
+
+    def rst(self) -> str:
+        return f":class:`{self}`"
 
 
 @dataclass(unsafe_hash=True, frozen=True)
 class ScipySparse(ArrayType):
     format: Literal["csr", "csc"]
     container: Literal["array", "matrix"]
+
+    def __str__(self) -> str:
+        return f"scipy.sparse.{self.format}_{self.container}"
 
 
 type Inner = Numpy | ScipySparse
@@ -37,6 +48,12 @@ type Inner = Numpy | ScipySparse
 @dataclass(unsafe_hash=True, frozen=True)
 class DaskArray(ArrayType):
     chunk: Inner
+
+    def __str__(self) -> str:
+        return f"dask.array.Array[{self.chunk}]"
+
+    def rst(self) -> str:
+        return rf":class:`dask.array.Array`\ \[{self.chunk.rst()}\]"
 
 
 @overload

--- a/src/scanpy/_utils/_docs.py
+++ b/src/scanpy/_utils/_docs.py
@@ -17,7 +17,7 @@ __all__ = ["ArrayType", "DaskArray", "Numpy", "ScipySparse", "parse"]
 
 
 class ArrayType(ABC):
-    def rst(self) -> str:
+    def rst(self) -> str:  # pragma: no cover
         return f":class:`{self}`"
 
     @abstractmethod
@@ -26,10 +26,10 @@ class ArrayType(ABC):
 
 @dataclass(unsafe_hash=True, frozen=True)
 class Numpy(ArrayType):
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no cover
         return "numpy.ndarray"
 
-    def rst(self) -> str:
+    def rst(self) -> str:  # pragma: no cover
         return f":class:`{self}`"
 
 
@@ -38,7 +38,7 @@ class ScipySparse(ArrayType):
     format: Literal["csr", "csc"]
     container: Literal["array", "matrix"]
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no cover
         return f"scipy.sparse.{self.format}_{self.container}"
 
 
@@ -49,10 +49,10 @@ type Inner = Numpy | ScipySparse
 class DaskArray(ArrayType):
     chunk: Inner
 
-    def __str__(self) -> str:
+    def __str__(self) -> str:  # pragma: no cover
         return f"dask.array.Array[{self.chunk}]"
 
-    def rst(self) -> str:
+    def rst(self) -> str:  # pragma: no cover
         return rf":class:`dask.array.Array`\ \[{self.chunk.rst()}\]"
 
 
@@ -77,11 +77,13 @@ def parse(
 
     inner_includes = [i for i in include if not i.startswith("da")]
     for t in include:
-        if (match := re.fullmatch(r"([^\[]+)(?:\[(.+)\])?", t)) is None:
+        if (
+            match := re.fullmatch(r"([^\[]+)(?:\[(.+)\])?", t)
+        ) is None:  # pragma: no cover
             msg = f"invalid {t!r}"
             raise ValueError(msg)
         mod, tags = match.groups("")
-        if mod == "da" and inner:
+        if mod == "da" and inner:  # pragma: no cover
             msg = "Can’t nest dask arrays"
             raise ValueError(msg)
         tags = set(re.split(r",(?![^\[]+\])", tags)) if tags else set()
@@ -93,12 +95,12 @@ def _parse_mod(
 ) -> Generator[ArrayType]:
     match mod:
         case "np":
-            if tags:
+            if tags:  # pragma: no cover
                 msg = f"`np` takes no tags {tags!r}"
                 raise ValueError(msg)
             yield Numpy()
         case "sp":
-            if tags - {"csr", "csc", "array", "matrix"}:
+            if tags - {"csr", "csc", "array", "matrix"}:  # pragma: no cover
                 msg = f"invalid tags {tags!r}"
                 raise ValueError(msg)
             for format, container in product(("csr", "csc"), ("array", "matrix")):
@@ -110,6 +112,6 @@ def _parse_mod(
         case "da":
             for chunk in parse(tags if tags else inner_includes, inner=True):
                 yield DaskArray(chunk=chunk)
-        case _:
+        case _:  # pragma: no cover
             msg = f"invalid module {mod!r}"
             raise ValueError(msg)

--- a/src/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/src/scanpy/experimental/pp/_highly_variable_genes.py
@@ -320,6 +320,8 @@ def highly_variable_genes(  # noqa: PLR0913
 
     Expects raw count input.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     {adata}

--- a/src/scanpy/experimental/pp/_highly_variable_genes.py
+++ b/src/scanpy/experimental/pp/_highly_variable_genes.py
@@ -320,7 +320,7 @@ def highly_variable_genes(  # noqa: PLR0913
 
     Expects raw count input.
 
-    .. array-support:: np sp
+    .. array-support:: experimental.pp.highly_variable_genes
 
     Parameters
     ----------

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -206,6 +206,8 @@ def aggregate(  # noqa: PLR0912
     ------
     adata
         :class:`~anndata.AnnData` to be aggregated.
+
+        .. array-support:: np sp da
     by
         Key of the column to be grouped-by.
     func

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -202,7 +202,7 @@ def aggregate(  # noqa: PLR0912
 
     If none of `layer`, `obsm`, or `varm` are passed in, `X` will be used for aggregation data.
 
-    .. array-support:: np sp da
+    .. array-support:: get.aggregated
 
     Params
     ------

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -202,12 +202,12 @@ def aggregate(  # noqa: PLR0912
 
     If none of `layer`, `obsm`, or `varm` are passed in, `X` will be used for aggregation data.
 
+    .. array-support:: np sp da
+
     Params
     ------
     adata
         :class:`~anndata.AnnData` to be aggregated.
-
-        .. array-support:: np sp da
     by
         Key of the column to be grouped-by.
     func

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -202,7 +202,7 @@ def aggregate(  # noqa: PLR0912
 
     If none of `layer`, `obsm`, or `varm` are passed in, `X` will be used for aggregation data.
 
-    .. array-support:: get.aggregated
+    .. array-support:: get.aggregate
 
     Params
     ------

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -91,7 +91,7 @@ def neighbors(  # noqa: PLR0913
     in the adaption of :cite:t:`Haghverdi2016`.
     If `method=='jaccard'`, connectivities are computed as in PhenoGraph :cite:p:`Levine2015`.
 
-    .. array-support:: np sp
+    .. array-support:: pp.neighbors
 
     Parameters
     ----------

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -91,6 +91,8 @@ def neighbors(  # noqa: PLR0913
     in the adaption of :cite:t:`Haghverdi2016`.
     If `method=='jaccard'`, connectivities are computed as in PhenoGraph :cite:p:`Levine2015`.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/preprocessing/_combat.py
+++ b/src/scanpy/preprocessing/_combat.py
@@ -149,7 +149,7 @@ def combat(  # noqa: PLR0915
 
     .. _combat.py: https://github.com/brentp/combat.py
 
-    .. array-support:: np
+    .. array-support:: pp.combat
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_combat.py
+++ b/src/scanpy/preprocessing/_combat.py
@@ -149,6 +149,8 @@ def combat(  # noqa: PLR0915
 
     .. _combat.py: https://github.com/brentp/combat.py
 
+    .. array-support:: np
+
     Parameters
     ----------
     adata

--- a/src/scanpy/preprocessing/_highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_highly_variable_genes.py
@@ -662,8 +662,7 @@ def highly_variable_genes(  # noqa: PLR0913
     See also `scanpy.experimental.pp._highly_variable_genes` for additional flavors
     (e.g. Pearson residuals).
 
-    .. array-support:: np sp da
-       :except: da[sp[csc]]
+    .. array-support:: pp.highly_variable_genes
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_highly_variable_genes.py
@@ -662,6 +662,8 @@ def highly_variable_genes(  # noqa: PLR0913
     See also `scanpy.experimental.pp._highly_variable_genes` for additional flavors
     (e.g. Pearson residuals).
 
+    .. array-support:: np sp da
+
     Parameters
     ----------
     adata

--- a/src/scanpy/preprocessing/_highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_highly_variable_genes.py
@@ -663,6 +663,7 @@ def highly_variable_genes(  # noqa: PLR0913
     (e.g. Pearson residuals).
 
     .. array-support:: np sp da
+       :except: da[sp[csc]]
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -158,6 +158,8 @@ def normalize_total(  # noqa: PLR0912
     Similar functions are used, for example, by Seurat :cite:p:`Satija2015`, Cell Ranger
     :cite:p:`Zheng2017` or SPRING :cite:p:`Weinreb2017`.
 
+    .. array-support:: np sp da
+
     .. note::
         When used with a :class:`~dask.array.Array` in `adata.X`, this function will have to
         call functions that trigger `.compute()` on the :class:`~dask.array.Array` if `exclude_highly_expressed`

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -158,7 +158,7 @@ def normalize_total(  # noqa: PLR0912
     Similar functions are used, for example, by Seurat :cite:p:`Satija2015`, Cell Ranger
     :cite:p:`Zheng2017` or SPRING :cite:p:`Weinreb2017`.
 
-    .. array-support:: np sp[csr] da
+    .. array-support:: pp.normalize_total
 
     .. note::
         When used with a :class:`~dask.array.Array` in `adata.X`, this function will have to

--- a/src/scanpy/preprocessing/_normalization.py
+++ b/src/scanpy/preprocessing/_normalization.py
@@ -158,7 +158,7 @@ def normalize_total(  # noqa: PLR0912
     Similar functions are used, for example, by Seurat :cite:p:`Satija2015`, Cell Ranger
     :cite:p:`Zheng2017` or SPRING :cite:p:`Weinreb2017`.
 
-    .. array-support:: np sp da
+    .. array-support:: np sp[csr] da
 
     .. note::
         When used with a :class:`~dask.array.Array` in `adata.X`, this function will have to

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -99,6 +99,9 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     .. [#dense-only] This implementation can not handle sparse chunks, try manually densifying them.
     .. [#densifies] This implementation densifies sparse chunks and therefore has increased memory usage.
 
+    .. array-support:: np sp da
+       :except: da[sp[csc]]
+
     Parameters
     ----------
     data

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -99,8 +99,7 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
     .. [#dense-only] This implementation can not handle sparse chunks, try manually densifying them.
     .. [#densifies] This implementation densifies sparse chunks and therefore has increased memory usage.
 
-    .. array-support:: np sp da
-       :except: da[sp[csc]]
+    .. array-support:: pp.pca
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -225,7 +225,7 @@ def calculate_qc_metrics(
     Note that this method can take a while to compile on the first call. That
     result is then cached to disk to be used later.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.calculate_qc_metrics
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_qc.py
+++ b/src/scanpy/preprocessing/_qc.py
@@ -225,6 +225,8 @@ def calculate_qc_metrics(
     Note that this method can take a while to compile on the first call. That
     result is then cached to disk to be used later.
 
+    .. array-support:: np sp da
+
     Parameters
     ----------
     {doc_adata_basic}

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -87,7 +87,7 @@ def scale[A: _Array](
         all observations) are retained and (for zero_center==True) set to 0
         during this operation. In the future, they might be set to NaNs.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.scale
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -87,6 +87,8 @@ def scale[A: _Array](
         all observations) are retained and (for zero_center==True) set to 0
         during this operation. In the future, they might be set to NaNs.
 
+    .. array-support:: np sp da
+
     Parameters
     ----------
     data

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -73,6 +73,8 @@ def scrublet(  # noqa: PLR0913
     :func:`~scanpy.pp.scrublet_simulate_doublets`, and run the core scrublet
     function :func:`~scanpy.pp.scrublet` with ``adata_sim`` set.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata
@@ -322,6 +324,8 @@ def _scrublet_call_doublets(  # noqa: PLR0913
 
     Predict cell doublets using a nearest-neighbor classifier of observed
     transcriptomes and simulated doublets.
+
+    .. array-support:: np sp
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -73,7 +73,7 @@ def scrublet(  # noqa: PLR0913
     :func:`~scanpy.pp.scrublet_simulate_doublets`, and run the core scrublet
     function :func:`~scanpy.pp.scrublet` with ``adata_sim`` set.
 
-    .. array-support:: np sp
+    .. array-support:: pp.scrublet
 
     Parameters
     ----------
@@ -325,8 +325,6 @@ def _scrublet_call_doublets(  # noqa: PLR0913
     Predict cell doublets using a nearest-neighbor classifier of observed
     transcriptomes and simulated doublets.
 
-    .. array-support:: np sp
-
     Parameters
     ----------
     adata_obs
@@ -515,6 +513,8 @@ def scrublet_simulate_doublets(
     random_seed: _LegacyRandom = 0,
 ) -> AnnData:
     """Simulate doublets by adding the counts of random observed transcriptome pairs.
+
+    .. array-support:: pp.scrublet_simulate_doublets
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -94,7 +94,7 @@ def filter_cells(
         Depending on what was thresholded (`counts` or `genes`),
         the array stores `n_counts` or `n_genes` per cell.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.filter_cells
 
     Examples
     --------
@@ -215,7 +215,7 @@ def filter_genes(
     Only provide one of the optional parameters `min_counts`, `min_cells`,
     `max_counts`, `max_cells` per call.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.filter_genes
 
     Parameters
     ----------
@@ -323,7 +323,7 @@ def log1p(
     Computes :math:`X = \log(X + 1)`,
     where :math:`log` denotes the natural logarithm unless a different base is given.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.log1p
 
     Parameters
     ----------
@@ -687,7 +687,7 @@ def regress_out(
     function in R :cite:p:`Satija2015`. Note that this function tends to overcorrect
     in certain circumstances as described in :issue:`526`.
 
-    .. array-support:: np
+    .. array-support:: pp.regress_out
 
     Parameters
     ----------
@@ -896,7 +896,7 @@ def sample(  # noqa: PLR0912
 ) -> AnnData | None | tuple[np.ndarray | CSBase | DaskArray, NDArray[np.int64]]:
     r"""Sample observations or variables with or without replacement.
 
-    .. array-support:: np sp da
+    .. array-support:: pp.sample
 
     Parameters
     ----------
@@ -1006,7 +1006,7 @@ def downsample_counts(
     If `total_counts` is specified, expression matrix will be downsampled to
     contain at most `total_counts`.
 
-    .. array-support:: np sp[csr]
+    .. array-support:: pp.downsample_counts
 
     Parameters
     ----------

--- a/src/scanpy/preprocessing/_simple.py
+++ b/src/scanpy/preprocessing/_simple.py
@@ -94,6 +94,8 @@ def filter_cells(
         Depending on what was thresholded (`counts` or `genes`),
         the array stores `n_counts` or `n_genes` per cell.
 
+    .. array-support:: np sp da
+
     Examples
     --------
     >>> import scanpy as sc
@@ -213,6 +215,8 @@ def filter_genes(
     Only provide one of the optional parameters `min_counts`, `min_cells`,
     `max_counts`, `max_cells` per call.
 
+    .. array-support:: np sp da
+
     Parameters
     ----------
     data
@@ -318,6 +322,8 @@ def log1p(
 
     Computes :math:`X = \log(X + 1)`,
     where :math:`log` denotes the natural logarithm unless a different base is given.
+
+    .. array-support:: np sp da
 
     Parameters
     ----------
@@ -681,6 +687,8 @@ def regress_out(
     function in R :cite:p:`Satija2015`. Note that this function tends to overcorrect
     in certain circumstances as described in :issue:`526`.
 
+    .. array-support:: np
+
     Parameters
     ----------
     adata
@@ -888,6 +896,8 @@ def sample(  # noqa: PLR0912
 ) -> AnnData | None | tuple[np.ndarray | CSBase | DaskArray, NDArray[np.int64]]:
     r"""Sample observations or variables with or without replacement.
 
+    .. array-support:: np sp da
+
     Parameters
     ----------
     data
@@ -996,6 +1006,8 @@ def downsample_counts(
     If `total_counts` is specified, expression matrix will be downsampled to
     contain at most `total_counts`.
 
+    .. array-support:: np sp[csr]
+
     Parameters
     ----------
     adata
@@ -1045,7 +1057,7 @@ def downsample_counts(
 
 
 def _downsample_per_cell(
-    x: CSBase,
+    x: np.ndarray | CSBase,
     /,
     counts_per_cell: int,
     *,
@@ -1101,7 +1113,7 @@ def _downsample_per_cell(
 
 
 def _downsample_total_counts(
-    x: CSBase,
+    x: np.ndarray | CSBase,
     /,
     total_counts: int,
     *,

--- a/src/scanpy/tools/_dendrogram.py
+++ b/src/scanpy/tools/_dendrogram.py
@@ -67,6 +67,8 @@ def dendrogram(  # noqa: PLR0913
         groups and not per cell. The correlation matrix is computed using by
         default pearson but other methods are available.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_dendrogram.py
+++ b/src/scanpy/tools/_dendrogram.py
@@ -67,7 +67,7 @@ def dendrogram(  # noqa: PLR0913
         groups and not per cell. The correlation matrix is computed using by
         default pearson but other methods are available.
 
-    .. array-support:: np sp
+    .. array-support:: tl.dendrogram
 
     Parameters
     ----------

--- a/src/scanpy/tools/_diffmap.py
+++ b/src/scanpy/tools/_diffmap.py
@@ -34,7 +34,7 @@ def diffmap(
     `method=='umap'`. Differences between these options shouldn't usually be
     dramatic.
 
-    .. array-support:: np sp
+    .. array-support:: tl.diffmap
 
     Parameters
     ----------

--- a/src/scanpy/tools/_diffmap.py
+++ b/src/scanpy/tools/_diffmap.py
@@ -34,6 +34,8 @@ def diffmap(
     `method=='umap'`. Differences between these options shouldn't usually be
     dramatic.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_dpt.py
+++ b/src/scanpy/tools/_dpt.py
@@ -76,6 +76,8 @@ def dpt(
     you need to pass ``n_comps=10`` in :func:`~scanpy.tl.diffmap` in order
     to exactly reproduce previous :func:`~scanpy.tl.dpt` results.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_dpt.py
+++ b/src/scanpy/tools/_dpt.py
@@ -76,7 +76,7 @@ def dpt(
     you need to pass ``n_comps=10`` in :func:`~scanpy.tl.diffmap` in order
     to exactly reproduce previous :func:`~scanpy.tl.dpt` results.
 
-    .. array-support:: np sp
+    .. array-support:: tl.dpt
 
     Parameters
     ----------

--- a/src/scanpy/tools/_draw_graph.py
+++ b/src/scanpy/tools/_draw_graph.py
@@ -68,8 +68,7 @@ def draw_graph(  # noqa: PLR0913
     .. _fa2-modified: https://github.com/AminAlam/fa2_modified
     .. _Force-directed graph drawing: https://en.wikipedia.org/wiki/Force-directed_graph_drawing
 
-    .. only uses graph in obsp
-    .. array-support:: np sp
+    .. array-support:: tl.draw_graph
 
     Parameters
     ----------

--- a/src/scanpy/tools/_draw_graph.py
+++ b/src/scanpy/tools/_draw_graph.py
@@ -68,6 +68,9 @@ def draw_graph(  # noqa: PLR0913
     .. _fa2-modified: https://github.com/AminAlam/fa2_modified
     .. _Force-directed graph drawing: https://en.wikipedia.org/wiki/Force-directed_graph_drawing
 
+    .. only uses graph in obsp
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_embedding_density.py
+++ b/src/scanpy/tools/_embedding_density.py
@@ -59,6 +59,8 @@ def embedding_density(  # noqa: PLR0912
     This function was written by Sophie Tritschler and implemented into
     Scanpy by Malte Luecken.
 
+    .. array-support:: np
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_embedding_density.py
+++ b/src/scanpy/tools/_embedding_density.py
@@ -59,7 +59,7 @@ def embedding_density(  # noqa: PLR0912
     This function was written by Sophie Tritschler and implemented into
     Scanpy by Malte Luecken.
 
-    .. array-support:: np
+    .. array-support:: tl.embedding_density
 
     Parameters
     ----------

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -63,6 +63,8 @@ def ingest(
     You need to run :func:`~scanpy.pp.neighbors` on `adata_ref` before
     passing it.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata
@@ -365,7 +367,7 @@ class Ingest:
             return adata.obsm[self._use_rep]
         return adata.X
 
-    def fit(self, adata_new):
+    def fit(self, adata_new: AnnData) -> None:
         """Map `adata_new` to the same representation as `adata`.
 
         This function identifies the representation which was used to

--- a/src/scanpy/tools/_ingest.py
+++ b/src/scanpy/tools/_ingest.py
@@ -63,7 +63,7 @@ def ingest(
     You need to run :func:`~scanpy.pp.neighbors` on `adata_ref` before
     passing it.
 
-    .. array-support:: np sp
+    .. array-support:: tl.ingest
 
     Parameters
     ----------

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -56,8 +56,7 @@ def leiden(  # noqa: PLR0912, PLR0913, PLR0915
     This requires having run :func:`~scanpy.pp.neighbors` or
     :func:`~scanpy.external.pp.bbknn` first.
 
-    .. only uses graph in obsp
-    .. array-support:: np sp
+    .. array-support:: tl.leiden
 
     Parameters
     ----------

--- a/src/scanpy/tools/_leiden.py
+++ b/src/scanpy/tools/_leiden.py
@@ -56,6 +56,9 @@ def leiden(  # noqa: PLR0912, PLR0913, PLR0915
     This requires having run :func:`~scanpy.pp.neighbors` or
     :func:`~scanpy.external.pp.bbknn` first.
 
+    .. only uses graph in obsp
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -76,6 +76,9 @@ def louvain(  # noqa: PLR0912, PLR0913, PLR0915
     :func:`~scanpy.external.pp.bbknn` first,
     or explicitly passing a ``adjacency`` matrix.
 
+    .. only uses graph in obsp
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -76,8 +76,7 @@ def louvain(  # noqa: PLR0912, PLR0913, PLR0915
     :func:`~scanpy.external.pp.bbknn` first,
     or explicitly passing a ``adjacency`` matrix.
 
-    .. only uses graph in obsp
-    .. array-support:: np sp
+    .. array-support:: tl.louvain
 
     Parameters
     ----------

--- a/src/scanpy/tools/_marker_gene_overlap.py
+++ b/src/scanpy/tools/_marker_gene_overlap.py
@@ -81,7 +81,7 @@ def marker_gene_overlap(  # noqa: PLR0912, PLR0915
     adj_pval_threshold: float | None = None,
     key_added: str = "marker_gene_overlap",
     inplace: bool = False,
-):
+) -> pd.DataFrame:
     """Calculate an overlap score between data-derived marker genes and provided markers.
 
     Marker gene overlap scores can be quoted as overlap counts, overlap

--- a/src/scanpy/tools/_paga.py
+++ b/src/scanpy/tools/_paga.py
@@ -52,6 +52,8 @@ def paga(
         `init_pos='paga'` to get single-cell embeddings that are typically more
         faithful to the global topology.
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_paga.py
+++ b/src/scanpy/tools/_paga.py
@@ -52,7 +52,7 @@ def paga(
         `init_pos='paga'` to get single-cell embeddings that are typically more
         faithful to the global topology.
 
-    .. array-support:: np sp
+    .. array-support:: tl.paga
 
     Parameters
     ----------

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -526,10 +526,12 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
 
     Expects logarithmized data.
 
+    .. array-support:: np sp
+
     ..  warning::
 
         Comparing between cells leads to highly inflated p-values,
-        since cells are not independent observations :cite:p`Squair2021`.
+        since cells are not independent observations :cite:p:`Squair2021`.
         Especially in single-cell data, consider instead to use more appropriate methods such as combining pseudobulking with :doc:`pydeseq2:index`.
 
         :func:`decoupler.pp.pseudobulk` or :func:`scanpy.get.aggregate` can be used to aggregate samples for pseudobulking.

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -526,7 +526,7 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
 
     Expects logarithmized data.
 
-    .. array-support:: np sp
+    .. array-support:: tl.rank_genes_groups
 
     ..  warning::
 

--- a/src/scanpy/tools/_tsne.py
+++ b/src/scanpy/tools/_tsne.py
@@ -52,6 +52,8 @@ def tsne(  # noqa: PLR0913
 
     .. _multicore-tsne: https://github.com/DmitryUlyanov/Multicore-TSNE
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_tsne.py
+++ b/src/scanpy/tools/_tsne.py
@@ -52,7 +52,7 @@ def tsne(  # noqa: PLR0913
 
     .. _multicore-tsne: https://github.com/DmitryUlyanov/Multicore-TSNE
 
-    .. array-support:: np sp
+    .. array-support:: tl.tsne
 
     Parameters
     ----------

--- a/src/scanpy/tools/_umap.py
+++ b/src/scanpy/tools/_umap.py
@@ -71,6 +71,8 @@ def umap(  # noqa: PLR0913, PLR0915
 
     .. _umap-learn: https://github.com/lmcinnes/umap
 
+    .. array-support:: np sp
+
     Parameters
     ----------
     adata

--- a/src/scanpy/tools/_umap.py
+++ b/src/scanpy/tools/_umap.py
@@ -71,7 +71,7 @@ def umap(  # noqa: PLR0913, PLR0915
 
     .. _umap-learn: https://github.com/lmcinnes/umap
 
-    .. array-support:: np sp
+    .. array-support:: tl.umap
 
     Parameters
     ----------

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -169,9 +169,7 @@ def getsourcelines(obj):
     return getsourcelines(obj)
 
 
-ALL_SPS = [
-    _docs.ScipySparse(fmt, c) for fmt in ("csr", "csc") for c in ("array", "matrix")
-]
+ALL_SPS = [_docs.ScipySparse(fmt) for fmt in ("csr", "csc")]
 
 
 @pytest.mark.parametrize(
@@ -188,29 +186,20 @@ ALL_SPS = [
         pytest.param(
             "sp da[sp[csr]]",
             [],
-            [
-                *ALL_SPS,
-                *(
-                    _docs.DaskArray(_docs.ScipySparse("csr", c))
-                    for c in ("array", "matrix")
-                ),
-            ],
+            [*ALL_SPS, _docs.DaskArray(_docs.ScipySparse("csr"))],
             id="include_fewer_nested",
         ),
         pytest.param(
             "da[sp[csc]]",
             [],
-            [_docs.DaskArray(_docs.ScipySparse("csc", c)) for c in ("array", "matrix")],
+            [_docs.DaskArray(_docs.ScipySparse("csc"))],
             id="include_only_nested",
         ),
         pytest.param("da[sp[csc]]", "sp da", [], id="remove_more"),
         pytest.param(
             "sp da",
-            "sp da[sp[matrix]]",
-            [
-                _docs.DaskArray(_docs.ScipySparse(fmt, "array"))
-                for fmt in ("csr", "csc")
-            ],
+            "sp da[sp[csr]]",
+            [_docs.DaskArray(_docs.ScipySparse("csc"))],
             id="only_dask_subset",
         ),
     ],

--- a/tests/test_package_structure.py
+++ b/tests/test_package_structure.py
@@ -11,7 +11,7 @@ from anndata import AnnData
 
 # CLI is locally not imported by default but on travis it is?
 import scanpy.cli
-from scanpy._utils import descend_classes_and_funcs, import_name
+from scanpy._utils import _docs, descend_classes_and_funcs, import_name
 
 if TYPE_CHECKING:
     from types import FunctionType
@@ -167,3 +167,57 @@ def getsourcelines(obj):
         return getsourcelines(wrapped)
 
     return getsourcelines(obj)
+
+
+ALL_SPS = [
+    _docs.ScipySparse(fmt, c) for fmt in ("csr", "csc") for c in ("array", "matrix")
+]
+
+
+@pytest.mark.parametrize(
+    ("include", "exclude", "expected"),
+    [
+        pytest.param("np", "", [_docs.Numpy()], id="np"),
+        pytest.param("np", "np", [], id="remove_identical"),
+        pytest.param(
+            "np da",
+            "",
+            [_docs.Numpy(), _docs.DaskArray(_docs.Numpy())],
+            id="dask_inherits",
+        ),
+        pytest.param(
+            "sp da[sp[csr]]",
+            [],
+            [
+                *ALL_SPS,
+                *(
+                    _docs.DaskArray(_docs.ScipySparse("csr", c))
+                    for c in ("array", "matrix")
+                ),
+            ],
+            id="include_fewer_nested",
+        ),
+        pytest.param(
+            "da[sp[csc]]",
+            [],
+            [_docs.DaskArray(_docs.ScipySparse("csc", c)) for c in ("array", "matrix")],
+            id="include_only_nested",
+        ),
+        pytest.param("da[sp[csc]]", "sp da", [], id="remove_more"),
+        pytest.param(
+            "sp da",
+            "sp da[sp[matrix]]",
+            [
+                _docs.DaskArray(_docs.ScipySparse(fmt, "array"))
+                for fmt in ("csr", "csc")
+            ],
+            id="only_dask_subset",
+        ),
+    ],
+)
+def test_array_type_selector(
+    include: str, exclude: str, expected: list[_docs.ArrayType]
+) -> None:
+    inc, exc = (i.split(" ") if i else [] for i in (include, exclude))
+    received = list(_docs.parse(inc, exc))
+    assert received == expected

--- a/tests/test_paga.py
+++ b/tests/test_paga.py
@@ -26,11 +26,13 @@ SKIP_IF_OLD_IGRAPH = pytest.mark.skipif(
 pytestmark = [needs.igraph]
 
 
-@pytest.fixture(scope="module")
-def pbmc_session():
+@pytest.fixture(scope="module", params=["dense", "sparse"])
+def pbmc_session(request: pytest.FixtureRequest) -> sc.AnnData:
     pbmc = pbmc68k_reduced()
-    sc.tl.paga(pbmc, groups="bulk_labels")
     pbmc.obs["cool_feature"] = pbmc[:, "CST3"].X.squeeze().copy()
+    if request.param == "sparse":
+        pbmc.X = pbmc.raw.X.tocsr()
+    sc.tl.paga(pbmc, groups="bulk_labels")
     assert not pbmc.obs["cool_feature"].isna().all()
     return pbmc
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3892
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

I double-checked everything in #2578 and mostly winged it for the rest.

Would be nice if one of you could take a look if I mis-specified something.

- I didn’t check if some flavors of `highly_variable_genes` supports only CSR. Any idea?
- I tried to document things that implicitly convert to `csr` as “not supporting csc”, except when that’s conditional (i.e `sc.pp.scale` supports CSC if you don’t specify `mask_obs`, so that’s detailed in `mask_obs`).