### PR TITLE
fix: skip `nan` in `sc.get.aggregate`

### DIFF
--- a/docs/release-notes/3906.fix.md
+++ b/docs/release-notes/3906.fix.md
@@ -1,0 +1,1 @@
+Fix {func}`scanpy.get.aggregate` when a `by` column misses data {smaller}`P Angerer`


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3903
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
