### PR TITLE
Remove "n_genes_by_{expr_type}" typo from variable-level qc metrics docs

### DIFF
--- a/src/scanpy/preprocessing/_docs.py
+++ b/src/scanpy/preprocessing/_docs.py
@@ -72,8 +72,6 @@ Variable level metrics include:
 
 `total_{expr_type}`
     E.g. "total_counts". Sum of counts for a gene.
-`n_genes_by_{expr_type}`
-    E.g. "n_genes_by_counts". The number of genes with at least 1 count in a cell. Calculated for all cells.
 `mean_{expr_type}`
     E.g. "mean_counts". Mean expression over all cells.
 `n_cells_by_{expr_type}`


### PR DESCRIPTION
I'm orienting in this tool, and couldn't make sense of this. Then I realized it's not even a column that's created when the command is run. I think it's a copy-paste issue from the observation-level doc section.

Fwiw, `n_cells` is the only column not mentions, and so perhaps this was supposed to be that? Not sure, so I'll leave that part to someone else.

Thanks! Sorry if I'm doing this wrong -- it's my first PR, and nothing in the template seemed relevant to a docs typo fix 🙏 