### PR TITLE
docs: document public API clearly

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,19 @@ If you like scverse® and want to support our mission, please consider making a 
 </a>
 </div>
 
+## Public API
+
+Our public API is documented in the [API section][] of these docs.
+We cannot guarantee the stability of our internal APIs, whether it's the location of a function, its arguments, or something else.
+In other words, we do not officially support (or encourage users to do) something like `from scanpy.logging import debug` as `logging` is not documented, even though it does not contain a [leading underscore][].
+However, we are aware that many users do use these internal APIs and thus encourage them to [open an issue][] or migrate to the public API.
+That is, if something is missing from our public API as documented, for example a feature you wish to be exported publicly, please open an issue.
+
+[api section]: https://scanpy.readthedocs.io/en/stable/api.html
+[leading underscore]: https://peps.python.org/pep-0008/#public-and-internal-interfaces
+[open an issue]: https://github.com/scverse/scanpy/issues/new/choose
+
+
 
 ## Citation
 


### PR DESCRIPTION
Added documentation for the public API and internal API usage.

<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] From https://github.com/scverse/squidpy/issues/1081#issuecomment-3655139712
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: Just documentation

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
