### PR TITLE
docs: add inline example of pca_variance_ratio

### DIFF
--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -206,6 +206,16 @@ def pca_variance_ratio(
         A string is appended to the default filename.
         Infer the filetype if ending on {`'.pdf'`, `'.png'`, `'.svg'`}.
 
+    Examples
+    --------
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc3k_processed()
+        sc.pl.pca_variance_ratio(adata, n_pcs=50, log=True)
+
     """
     ranking(
         adata,


### PR DESCRIPTION
Part of #1664

Add inline example for `sc.pl.pca_variance_ratio()`.

Done with @t-a-m-i and @polychromech.