### PR TITLE
feat: add `sparse_format='csr'` parameter to `read_10x_mtx`

### DIFF
--- a/docs/release-notes/4017.feat.md
+++ b/docs/release-notes/4017.feat.md
@@ -1,0 +1,1 @@
+add `sparse_format` parameter to `~scanpy.read_10x_mtx` defaulting to CSR {smaller}`E. Provo`

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -612,6 +612,7 @@ def _read_10x_mtx(
         cache=cache,
         cache_compression=cache_compression,
     ).T  # transpose the data
+    adata.X = adata.X.tocsr()
     genes = pd.read_csv(
         path / f"{prefix}{'genes' if is_legacy else 'features'}.tsv{suffix}",
         header=None,

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -27,7 +27,6 @@ if pkg_version("anndata") >= Version("0.11.0rc2"):
         read_h5ad,
         read_hdf,
         read_loom,
-        read_mtx,
         read_text,
         read_zarr,
     )
@@ -38,7 +37,6 @@ else:
         read_h5ad,
         read_hdf,
         read_loom,
-        read_mtx,
         read_text,
         read_zarr,
     )
@@ -599,22 +597,7 @@ def _read_mtx(
     dtype: str = "float32",
     sparse_format: Literal["csr", "csc", "coo"] = "csc",
 ) -> AnnData:
-    """Read `.mtx` file with configurable sparse format.
-
-    Inlines the logic from :func:`anndata.read_mtx` to allow choosing the
-    sparse format directly, avoiding unnecessary conversions when the result
-    will be transposed (e.g., for 10x data where ``CSC.T → CSR``).
-
-    Parameters
-    ----------
-    filename
-        Path to the ``.mtx`` file.
-    dtype
-        Numpy data type.
-    sparse_format
-        Sparse matrix format for the output. Defaults to ``'csc'`` so that
-        a subsequent ``.T`` produces a CSR matrix with no extra conversion.
-    """
+    """Read ``.mtx`` file, choosing sparse format to avoid extra conversions."""
     from scipy.io import mmread
     from scipy.sparse import csc_matrix, csr_matrix  # noqa: TID251
 
@@ -642,28 +625,11 @@ def _read_10x_mtx(
     """Read mex from output from Cell Ranger v2- or v3+."""
     # Only append .gz if not a legacy file AND compression is requested
     suffix = "" if is_legacy else (".gz" if compressed else "")
-    mtx_file = path / f"{prefix}matrix.mtx{suffix}"
-    ext = f"mtx{suffix}"
-
-    if cache:
-        path_cache: Path = settings.cachedir / _slugify(mtx_file).replace(
-            f".{ext}", ".h5ad"
-        )
-        if path_cache.is_file():
-            logg.info(f"... reading from cache file {path_cache}")
-            adata = read_h5ad(path_cache)
-        else:
-            adata = _read_mtx(mtx_file, sparse_format="csc")
-            if isinstance(cache_compression, Default):
-                cache_compression = settings.cache_compression
-            if not path_cache.parent.is_dir():
-                path_cache.parent.mkdir(parents=True)
-            adata.write(path_cache, compression=cache_compression)
-    else:
-        # Read MTX as CSC so that .T yields CSR (one conversion, not two)
-        adata = _read_mtx(mtx_file, sparse_format="csc")
-
-    adata = adata.T  # transpose: 10x stores var×obs, anndata uses obs×var
+    adata = read(
+        path / f"{prefix}matrix.mtx{suffix}",
+        cache=cache,
+        cache_compression=cache_compression,
+    ).T  # transpose the data
     genes = pd.read_csv(
         path / f"{prefix}{'genes' if is_legacy else 'features'}.tsv{suffix}",
         header=None,
@@ -911,7 +877,7 @@ def _read(  # noqa: PLR0912, PLR0915
         else:
             adata = read_excel(filename, sheet)
     elif ext in {"mtx", "mtx.gz"}:
-        adata = read_mtx(filename)
+        adata = _read_mtx(filename)
     elif ext == "csv":
         if delimiter is None:
             delimiter = ","

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -593,6 +593,41 @@ def read_10x_mtx(
     return adata[:, gex_rows].copy()
 
 
+def _read_mtx(
+    filename: Path,
+    *,
+    dtype: str = "float32",
+    sparse_format: Literal["csr", "csc", "coo"] = "csc",
+) -> AnnData:
+    """Read `.mtx` file with configurable sparse format.
+
+    Inlines the logic from :func:`anndata.read_mtx` to allow choosing the
+    sparse format directly, avoiding unnecessary conversions when the result
+    will be transposed (e.g., for 10x data where ``CSC.T → CSR``).
+
+    Parameters
+    ----------
+    filename
+        Path to the ``.mtx`` file.
+    dtype
+        Numpy data type.
+    sparse_format
+        Sparse matrix format for the output. Defaults to ``'csc'`` so that
+        a subsequent ``.T`` produces a CSR matrix with no extra conversion.
+    """
+    from scipy.io import mmread
+    from scipy.sparse import csc_matrix, csr_matrix  # noqa: TID251
+
+    x = mmread(filename)
+    if x.dtype != np.dtype(dtype):
+        x = x.astype(dtype)
+    if sparse_format == "csr":
+        x = csr_matrix(x)
+    elif sparse_format == "csc":
+        x = csc_matrix(x)
+    return AnnData(x)
+
+
 def _read_10x_mtx(
     path: Path,
     *,
@@ -607,12 +642,28 @@ def _read_10x_mtx(
     """Read mex from output from Cell Ranger v2- or v3+."""
     # Only append .gz if not a legacy file AND compression is requested
     suffix = "" if is_legacy else (".gz" if compressed else "")
-    adata = read(
-        path / f"{prefix}matrix.mtx{suffix}",
-        cache=cache,
-        cache_compression=cache_compression,
-    ).T  # transpose the data
-    adata.X = adata.X.tocsr()
+    mtx_file = path / f"{prefix}matrix.mtx{suffix}"
+    ext = f"mtx{suffix}"
+
+    if cache:
+        path_cache: Path = settings.cachedir / _slugify(mtx_file).replace(
+            f".{ext}", ".h5ad"
+        )
+        if path_cache.is_file():
+            logg.info(f"... reading from cache file {path_cache}")
+            adata = read_h5ad(path_cache)
+        else:
+            adata = _read_mtx(mtx_file, sparse_format="csc")
+            if isinstance(cache_compression, Default):
+                cache_compression = settings.cache_compression
+            if not path_cache.parent.is_dir():
+                path_cache.parent.mkdir(parents=True)
+            adata.write(path_cache, compression=cache_compression)
+    else:
+        # Read MTX as CSC so that .T yields CSR (one conversion, not two)
+        adata = _read_mtx(mtx_file, sparse_format="csc")
+
+    adata = adata.T  # transpose: 10x stores var×obs, anndata uses obs×var
     genes = pd.read_csv(
         path / f"{prefix}{'genes' if is_legacy else 'features'}.tsv{suffix}",
         header=None,

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -534,6 +534,7 @@ def read_10x_mtx(
     gex_only: bool = True,
     prefix: str | None = None,
     compressed: bool = True,
+    sparse_format: Literal["csr", "csc", "coo"] = "csr",
 ) -> AnnData:
     """Read 10x-Genomics-formatted mtx directory.
 
@@ -565,6 +566,8 @@ def read_10x_mtx(
         to be gzipped. If True, '.gz' suffix is appended to filenames.
         Set to False for STARsolo output.
         Has no effect on legacy (v2-) files.
+    sparse_format
+        The sparse matrix format.
 
     Returns
     -------
@@ -586,6 +589,7 @@ def read_10x_mtx(
             prefix=prefix,
             is_legacy=is_legacy,
             compressed=compressed,
+            sparse_format=sparse_format,
         )
     if is_legacy or not gex_only:
         return adata
@@ -623,6 +627,7 @@ def _read_10x_mtx(
     prefix: str,
     is_legacy: bool,
     compressed: bool,
+    sparse_format: Literal["csr", "csc", "coo"],
 ) -> AnnData:
     """Read mex from output from Cell Ranger v2- or v3+."""
     # Only append .gz if not a legacy file AND compression is requested
@@ -631,7 +636,8 @@ def _read_10x_mtx(
         path / f"{prefix}matrix.mtx{suffix}",
         cache=cache,
         cache_compression=cache_compression,
-        sparse_format="csc",
+        # transposing will convert e.g. CSR to CSC and vice versa
+        sparse_format=dict(csr="csc", csc="csr", coo="coo")[sparse_format],
     ).T  # transpose the data
     genes = pd.read_csv(
         path / f"{prefix}{'genes' if is_legacy else 'features'}.tsv{suffix}",

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -46,6 +46,8 @@ if TYPE_CHECKING:
     from os import PathLike
     from typing import IO, Literal
 
+    from numpy.typing import DTypeLike
+
 # .gz and .bz2 suffixes are also allowed for text formats
 text_exts = {
     "csv",
@@ -126,7 +128,7 @@ def read(
         See the h5py :ref:`dataset_compression`.
         (Default: `settings.cache_compression`)
     kwargs
-        Parameters passed to :func:`~anndata.io.read_loom`.
+        Parameters passed to the underlying function.
 
     Returns
     -------
@@ -594,8 +596,8 @@ def read_10x_mtx(
 def _read_mtx(
     filename: Path,
     *,
-    dtype: str = "float32",
-    sparse_format: Literal["csr", "csc", "coo"] = "csc",
+    dtype: DTypeLike,
+    sparse_format: Literal["csr", "csc", "coo"],
 ) -> AnnData:
     """Read ``.mtx`` file, choosing sparse format to avoid extra conversions."""
     from scipy.io import mmread
@@ -629,6 +631,7 @@ def _read_10x_mtx(
         path / f"{prefix}matrix.mtx{suffix}",
         cache=cache,
         cache_compression=cache_compression,
+        sparse_format="csc",
     ).T  # transpose the data
     genes = pd.read_csv(
         path / f"{prefix}{'genes' if is_legacy else 'features'}.tsv{suffix}",
@@ -877,7 +880,9 @@ def _read(  # noqa: PLR0912, PLR0915
         else:
             adata = read_excel(filename, sheet)
     elif ext in {"mtx", "mtx.gz"}:
-        adata = _read_mtx(filename)
+        kwargs.setdefault("sparse_format", "csr")
+        kwargs.setdefault("dtype", "float32")
+        adata = _read_mtx(filename, **kwargs)
     elif ext == "csv":
         if delimiter is None:
             delimiter = ","

--- a/tests/test_read_10x.py
+++ b/tests/test_read_10x.py
@@ -9,9 +9,9 @@ import h5py
 import numpy as np
 import pandas as pd
 import pytest
-from scipy.sparse import csr_matrix
 
 import scanpy as sc
+from scanpy._compat import CSRBase
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -65,7 +65,7 @@ def test_read_10x(
         h5.var.drop(columns="genome", inplace=True)
 
     # Verify CSR format (not CSC from transpose)
-    assert isinstance(mtx.X, csr_matrix), f"Expected CSR matrix, got {type(mtx.X)}"
+    assert isinstance(mtx.X, CSRBase), f"Expected CSR matrix, got {type(mtx.X)}"
 
     # Check equivalence
     assert_anndata_equal(mtx, h5)

--- a/tests/test_read_10x.py
+++ b/tests/test_read_10x.py
@@ -9,6 +9,7 @@ import h5py
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.sparse import csr_matrix
 
 import scanpy as sc
 
@@ -62,6 +63,9 @@ def test_read_10x(
     # Drop genome column for comparing v3
     if "3.0.0" in str(h5_path):
         h5.var.drop(columns="genome", inplace=True)
+
+    # Verify CSR format (not CSC from transpose)
+    assert isinstance(mtx.X, csr_matrix), f"Expected CSR matrix, got {type(mtx.X)}"
 
     # Check equivalence
     assert_anndata_equal(mtx, h5)


### PR DESCRIPTION
## Summary
Ensure `read_10x_mtx()` returns an AnnData object with a CSR sparse matrix instead of CSC.

## Motivation
Fixes #4016

When `_read_10x_mtx()` transposes the matrix read by `anndata.read_mtx()`, scipy automatically converts the CSR matrix to CSC format (this is how scipy sparse transpose works — CSR.T → CSC). Most downstream scanpy operations expect CSR format.

## Changes
- Add `adata.X = adata.X.tocsr()` after the `.T` transpose in `_read_10x_mtx()` (`src/scanpy/readwrite.py`)
- Add CSR format assertion to `test_read_10x` (`tests/test_read_10x.py`)

## Testing
- All 4 `test_read_10x` parametrized cases pass locally (v1.2.0 + v3.0.0, with and without prefix)
- New assertion verifies the matrix is CSR after reading

## Notes for reviewers
- First contribution to scanpy
- Single-line fix + test assertion, minimal scope