### PR TITLE
fix: avoid cumulative size reordering across multi-color subplots

### DIFF
--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -294,9 +294,9 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
         elif sort_order and color_type == "cat":
             # Null points go on bottom
             order = np.argsort(~pd.isnull(color_source_vector), kind="stable")
-        # Set orders
-        if isinstance(size, np.ndarray):
-            size = np.array(size)[order]
+        # Set orders — use a local to avoid cumulative reordering across
+        # subplots when multiple color keys are given.
+        _size = np.array(size)[order] if isinstance(size, np.ndarray) else size
         color_source_vector = color_source_vector[order]
         color_vector = color_vector[order]
         coords = basis_values[:, dims][order, :]
@@ -348,10 +348,10 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
             )
         else:
             scatter = (
-                partial(ax.scatter, s=size, plotnonfinite=True)
+                partial(ax.scatter, s=_size, plotnonfinite=True)
                 if scale_factor is None
                 else partial(
-                    circles, s=size, ax=ax, scale_factor=scale_factor
+                    circles, s=_size, ax=ax, scale_factor=scale_factor
                 )  # size in circles is radius
             )
 
@@ -366,7 +366,7 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
                 # with some transparency.
 
                 bg_width, gap_width = outline_width
-                point = np.sqrt(size)
+                point = np.sqrt(_size)
                 gap_size = (point + (point * gap_width) * 2) ** 2
                 bg_size = (np.sqrt(gap_size) + (point * bg_width) * 2) ** 2
                 # the default black and white colors can be changes using


### PR DESCRIPTION
- [x] Closes #4024
- [x] [Tests][] included or not required because: the fix is a one-line variable rename (loop-local `_size` instead of mutating `size`); existing tests pass and the bug is visual (per-point size arrays scrambled across subplots).
- [x] [Release notes][] not necessary because: this is a minimal internal bugfix with no API change.

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

---

When `sc.pl.embedding` (or `sc.pl.umap`, etc.) is called with multiple `color` keys and a per-point `size` array, the `size` variable is cumulatively reordered across loop iterations:

```python
# line 299 in scatterplots.py
if isinstance(size, np.ndarray):
    size = np.array(size)[order]  # mutates loop variable!
```

Each subplot computes its own `order` (for z-ordering by color value), but applies it to the *already-reordered* `size` from the previous iteration. This means:

- Subplot 1: correct sizes
- Subplot 2: sizes scrambled by order1 × order2
- Subplot 3: sizes scrambled by order1 × order2 × order3
- etc.

**Fix**: use a loop-local `_size` variable so each iteration reorders from the original `size` array. The same pattern is applied to the `scatter` call and `add_outline` code that consume the size.

Minimal reproduction:

```python
import scanpy as sc
import numpy as np

adata = sc.datasets.pbmc3k_processed()
sizes = np.random.default_rng(0).uniform(10, 200, size=adata.n_obs)
sc.pl.umap(adata, color=["louvain", "n_genes", "n_counts"], size=sizes)
# Dot sizes visibly differ across panels despite being the same array
```