### PR TITLE
docs(plotting): add inline plot example for `highest_expr_genes`

### DIFF
--- a/src/scanpy/plotting/_preprocessing.py
+++ b/src/scanpy/plotting/_preprocessing.py
@@ -41,6 +41,23 @@ def highly_variable_genes(  # noqa: PLR0912
         A string is appended to the default filename.
         Infer the filetype if ending on {{`'.pdf'`, `'.png'`, `'.svg'`}}.
 
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc3k_processed()
+        sc.pp.highly_variable_genes(adata)
+        sc.pl.highly_variable_genes(adata)
+
+    Plot on log axes
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.highly_variable_genes(adata, log=True)
+
     """
     if isinstance(adata_or_result, AnnData):
         result = adata_or_result.var

--- a/src/scanpy/plotting/_qc.py
+++ b/src/scanpy/plotting/_qc.py
@@ -69,6 +69,22 @@ def highest_expr_genes(
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes`.
 
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc3k_processed()
+        sc.pl.highest_expr_genes(adata)
+
+    Show only the top 10 genes
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.highest_expr_genes(adata, n_top=10)
+
     """
     import seaborn as sns  # Slow import, only import if called
 

--- a/src/scanpy/plotting/_qc.py
+++ b/src/scanpy/plotting/_qc.py
@@ -75,7 +75,7 @@ def highest_expr_genes(
         :context: close-figs
 
         import scanpy as sc
-        adata = sc.datasets.pbmc3k_processed()
+        adata = sc.datasets.pbmc3k()
         sc.pl.highest_expr_genes(adata)
 
     Show only the top 10 genes


### PR DESCRIPTION
## Summary

Add `.. plot::` directive examples to the docstrings of two plotting functions that were missing inline examples:

- **`sc.pl.highest_expr_genes`**: default usage and `n_top=10` variant
- **`sc.pl.highly_variable_genes`**: default usage and `log=True` variant

These are two of the remaining unchecked items from #1664.

## Pattern

Follows the established pattern from existing inline examples (e.g., `pca_loadings`, `rank_genes_groups_heatmap`):
- First block loads data with `sc.datasets.pbmc3k_processed()`
- Subsequent blocks demonstrate parameter variations
- Uses `:context: close-figs` directive option

Ref #1664