### PR TITLE
docs: add inline example plot to sc.pl.highly_variable_genes

### DIFF
--- a/src/scanpy/plotting/_preprocessing.py
+++ b/src/scanpy/plotting/_preprocessing.py
@@ -41,6 +41,27 @@ def highly_variable_genes(  # noqa: PLR0912
         A string is appended to the default filename.
         Infer the filetype if ending on {{`'.pdf'`, `'.png'`, `'.svg'`}}.
 
+    Examples
+    --------
+    Compute and plot highly variable genes from raw PBMC data.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc3k()
+        sc.pp.normalize_total(adata, target_sum=1e4)
+        sc.pp.log1p(adata)
+        sc.pp.highly_variable_genes(adata, min_mean=0.0125, max_mean=3, min_disp=0.5)
+        sc.pl.highly_variable_genes(adata)
+
+    Plot on logarithmic axes.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.highly_variable_genes(adata, log=True)
+
     """
     if isinstance(adata_or_result, AnnData):
         result = adata_or_result.var


### PR DESCRIPTION
Adds an `Examples` section to the `sc.pl.highly_variable_genes` docstring with two inline plot blocks:

1. Minimal pipeline: load PBMC 3k, normalise, log-transform, compute HVGs, plot
2. Same data with `log=True` to demonstrate the parameter

Uses `sc.datasets.pbmc3k()` (same dataset as `sc.pp.calculate_qc_metrics` example) and `:context: close-figs` following the pattern established in merged contributions to this checklist.

Checklist item from #1664.