### PR TITLE
perf: run umap in parallel when `rng=None` is passed

### DIFF
--- a/benchmarks/benchmarks/tools.py
+++ b/benchmarks/benchmarks/tools.py
@@ -22,10 +22,10 @@ class ToolsSuite:  # noqa: D101
         self.adata = ad.read_h5ad("adata.h5ad")
 
     def time_umap(self) -> None:
-        sc.tl.umap(self.adata)
+        sc.tl.umap(self.adata, rng=None)
 
     def peakmem_umap(self) -> None:
-        sc.tl.umap(self.adata)
+        sc.tl.umap(self.adata, rng=None)
 
     def time_diffmap(self) -> None:
         sc.tl.diffmap(self.adata)

--- a/docs/release-notes/4036.perf.md
+++ b/docs/release-notes/4036.perf.md
@@ -1,0 +1,1 @@
+Run {func}`scanpy.tl.umap` in parallel when possible {smaller}`P Angerer`

--- a/src/scanpy/tools/_umap.py
+++ b/src/scanpy/tools/_umap.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import warnings
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -147,6 +146,7 @@ def umap(  # noqa: PLR0913
         UMAP parameters.
 
     """
+    non_deterministic = rng is None
     rng = np.random.default_rng(rng)
     adata = adata.copy() if copy else adata
 
@@ -166,11 +166,6 @@ def umap(  # noqa: PLR0913
         logg.warning(
             f'.obsp["{neighbors["connectivities_key"]}"] have not been computed using umap'
         )
-
-    with warnings.catch_warnings():
-        # umap 0.5.0
-        warnings.filterwarnings("ignore", message=r"Tensorflow not installed")
-        import umap
 
     from umap.umap_ import find_ab_params, simplicial_set_embedding
 
@@ -215,6 +210,7 @@ def umap(  # noqa: PLR0913
             n_epochs=n_epochs,
             init=init_coords,
             random_state=_legacy_random_state(rng, always_state=True),
+            parallel=non_deterministic,  # if True, random_state is ignored
             metric=neigh_params.get("metric", "euclidean"),
             metric_kwds=neigh_params.get("metric_kwds", {}),
             densmap=False,


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #3211
- [x] [Tests][] included or not required because: preformance-only change, see benchmark
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

milestone 1.13.0, since 1.12.x doesn’t have `rng`.

scanpy 2.0 will have `rng=None` by default and therefore the speedup.