### PR TITLE
fix: copy size array before reorder in multi-color scatter plots

### DIFF
--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -295,8 +295,9 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
             # Null points go on bottom
             order = np.argsort(~pd.isnull(color_source_vector), kind="stable")
         # Set orders
-        if isinstance(size, np.ndarray):
-            size = np.array(size)[order]
+        # Copy size before reordering so the original array is preserved
+        # across loop iterations (fixes #4024)
+        _size = size[order] if isinstance(size, np.ndarray) else size
         color_source_vector = color_source_vector[order]
         color_vector = color_vector[order]
         coords = basis_values[:, dims][order, :]
@@ -348,10 +349,10 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
             )
         else:
             scatter = (
-                partial(ax.scatter, s=size, plotnonfinite=True)
+                partial(ax.scatter, s=_size, plotnonfinite=True)
                 if scale_factor is None
                 else partial(
-                    circles, s=size, ax=ax, scale_factor=scale_factor
+                    circles, s=_size, ax=ax, scale_factor=scale_factor
                 )  # size in circles is radius
             )
 
@@ -366,7 +367,7 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
                 # with some transparency.
 
                 bg_width, gap_width = outline_width
-                point = np.sqrt(size)
+                point = np.sqrt(_size)
                 gap_size = (point + (point * gap_width) * 2) ** 2
                 bg_size = (np.sqrt(gap_size) + (point * bg_width) * 2) ** 2
                 # the default black and white colors can be changes using

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -294,10 +294,8 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
         elif sort_order and color_type == "cat":
             # Null points go on bottom
             order = np.argsort(~pd.isnull(color_source_vector), kind="stable")
-        # Set orders
-        # Copy size before reordering so the original array is preserved
-        # across loop iterations (fixes #4024)
-        _size = size[order] if isinstance(size, np.ndarray) else size
+        # `size` is not a loop variable, so don’t overwrite it here
+        size_plot = size[order] if isinstance(size, np.ndarray) else size
         color_source_vector = color_source_vector[order]
         color_vector = color_vector[order]
         coords = basis_values[:, dims][order, :]
@@ -349,11 +347,10 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
             )
         else:
             scatter = (
-                partial(ax.scatter, s=_size, plotnonfinite=True)
+                partial(ax.scatter, s=size_plot, plotnonfinite=True)
                 if scale_factor is None
-                else partial(
-                    circles, s=_size, ax=ax, scale_factor=scale_factor
-                )  # size in circles is radius
+                # size in circles is radius
+                else partial(circles, s=size_plot, ax=ax, scale_factor=scale_factor)
             )
 
             if add_outline:
@@ -367,7 +364,7 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
                 # with some transparency.
 
                 bg_width, gap_width = outline_width
-                point = np.sqrt(_size)
+                point = np.sqrt(size_plot)
                 gap_size = (point + (point * gap_width) * 2) ** 2
                 bg_size = (np.sqrt(gap_size) + (point * bg_width) * 2) ** 2
                 # the default black and white colors can be changes using

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1875,6 +1875,25 @@ def test_umap_mask_no_modification():
     pd.testing.assert_series_equal(pbmc.obs["louvain"], data_copy)
 
 
+def test_scatter_size_not_mutated_across_panels():
+    """Per-point size array must not be cumulatively reordered across subplots.
+
+    Regression test for https://github.com/scverse/scanpy/issues/4024
+    """
+    pbmc = pbmc3k_processed()
+    rng = np.random.default_rng(0)
+    sizes = rng.uniform(10, 200, size=pbmc.n_obs)
+    sizes_original = sizes.copy()
+
+    axes = sc.pl.umap(
+        pbmc, color=["louvain", "n_genes"], size=sizes, show=False
+    )
+    plt.close()
+
+    # The input array must not be modified
+    np.testing.assert_array_equal(sizes, sizes_original)
+
+
 def test_string_mask(tmp_path, check_same_image):
     """Check that the same mask given as string or bool array provides the same result."""
     pbmc = pbmc3k_processed()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1875,38 +1875,6 @@ def test_umap_mask_no_modification():
     pd.testing.assert_series_equal(pbmc.obs["louvain"], data_copy)
 
 
-def test_scatter_size_not_mutated_across_panels():
-    """Per-point size array must not be cumulatively reordered across subplots.
-
-    Regression test for https://github.com/scverse/scanpy/issues/4024
-    Uses 3 panels (categorical + two continuous) to exercise cumulative reorder.
-    """
-    pbmc = pbmc3k_processed()
-    rng = np.random.default_rng(0)
-    sizes = rng.uniform(10, 200, size=pbmc.n_obs)
-    sizes_original = sizes.copy()
-
-    axes = sc.pl.umap(
-        pbmc,
-        color=["louvain", "n_genes", "n_counts"],
-        size=sizes,
-        show=False,
-    )
-
-    # The input array must not be modified
-    np.testing.assert_array_equal(sizes, sizes_original)
-
-    # Each panel must plot the correct per-point sizes (just reordered by
-    # z-order, not cumulatively scrambled).  Sorting makes the comparison
-    # independent of z-ordering.
-    expected_sorted = np.sort(sizes)
-    for ax in axes:
-        plotted = ax.collections[0].get_sizes()
-        np.testing.assert_allclose(np.sort(plotted), expected_sorted)
-
-    plt.close()
-
-
 def test_string_mask(tmp_path, check_same_image):
     """Check that the same mask given as string or bool array provides the same result."""
     pbmc = pbmc3k_processed()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1885,9 +1885,7 @@ def test_scatter_size_not_mutated_across_panels():
     sizes = rng.uniform(10, 200, size=pbmc.n_obs)
     sizes_original = sizes.copy()
 
-    axes = sc.pl.umap(
-        pbmc, color=["louvain", "n_genes"], size=sizes, show=False
-    )
+    axes = sc.pl.umap(pbmc, color=["louvain", "n_genes"], size=sizes, show=False)
     plt.close()
 
     # The input array must not be modified

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1875,6 +1875,38 @@ def test_umap_mask_no_modification():
     pd.testing.assert_series_equal(pbmc.obs["louvain"], data_copy)
 
 
+def test_scatter_size_not_mutated_across_panels():
+    """Per-point size array must not be cumulatively reordered across subplots.
+
+    Regression test for https://github.com/scverse/scanpy/issues/4024
+    Uses 3 panels (categorical + two continuous) to exercise cumulative reorder.
+    """
+    pbmc = pbmc3k_processed()
+    rng = np.random.default_rng(0)
+    sizes = rng.uniform(10, 200, size=pbmc.n_obs)
+    sizes_original = sizes.copy()
+
+    axes = sc.pl.umap(
+        pbmc,
+        color=["louvain", "n_genes", "n_counts"],
+        size=sizes,
+        show=False,
+    )
+
+    # The input array must not be modified
+    np.testing.assert_array_equal(sizes, sizes_original)
+
+    # Each panel must plot the correct per-point sizes (just reordered by
+    # z-order, not cumulatively scrambled).  Sorting makes the comparison
+    # independent of z-ordering.
+    expected_sorted = np.sort(sizes)
+    for ax in axes:
+        plotted = ax.collections[0].get_sizes()
+        np.testing.assert_allclose(np.sort(plotted), expected_sorted)
+
+    plt.close()
+
+
 def test_string_mask(tmp_path, check_same_image):
     """Check that the same mask given as string or bool array provides the same result."""
     pbmc = pbmc3k_processed()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1879,17 +1879,32 @@ def test_scatter_size_not_mutated_across_panels():
     """Per-point size array must not be cumulatively reordered across subplots.
 
     Regression test for https://github.com/scverse/scanpy/issues/4024
+    Uses 3 panels (categorical + two continuous) to exercise cumulative reorder.
     """
     pbmc = pbmc3k_processed()
     rng = np.random.default_rng(0)
     sizes = rng.uniform(10, 200, size=pbmc.n_obs)
     sizes_original = sizes.copy()
 
-    axes = sc.pl.umap(pbmc, color=["louvain", "n_genes"], size=sizes, show=False)
-    plt.close()
+    axes = sc.pl.umap(
+        pbmc,
+        color=["louvain", "n_genes", "n_counts"],
+        size=sizes,
+        show=False,
+    )
 
     # The input array must not be modified
     np.testing.assert_array_equal(sizes, sizes_original)
+
+    # Each panel must plot the correct per-point sizes (just reordered by
+    # z-order, not cumulatively scrambled).  Sorting makes the comparison
+    # independent of z-ordering.
+    expected_sorted = np.sort(sizes)
+    for ax in axes:
+        plotted = ax.collections[0].get_sizes()
+        np.testing.assert_allclose(np.sort(plotted), expected_sorted)
+
+    plt.close()
 
 
 def test_string_mask(tmp_path, check_same_image):


### PR DESCRIPTION
## Summary

Fixes #4024.

- **Root cause**: In `embedding()`, the per-point `size` array was reordered in-place (`size = np.array(size)[order]`) inside the per-color loop. Each iteration's z-order permutation was applied to the already-reordered array from the previous iteration, causing cumulative corruption of marker sizes across subplots.
- **Fix**: Use a loop-local variable `_size` so each iteration reorders from the original `size` array. This matches the behavior of `color_source_vector`, `color_vector`, and `coords`, which are all freshly derived each iteration.

## Changes

- `src/scanpy/plotting/_tools/scatterplots.py`: Replace in-place mutation of `size` with a loop-local `_size` variable; update all downstream references within the loop body.
- `tests/test_plotting.py`: Add `test_scatter_size_not_mutated_across_panels` regression test that verifies the input size array is not modified after plotting with multiple color keys.

## Test plan

- [ ] `test_scatter_size_not_mutated_across_panels` passes — confirms the size array is preserved
- [ ] Existing scatter/embedding tests continue to pass (no behavioral change for single-panel plots or scalar sizes)