### PR TITLE
docs: generate 1.12.1 release notes

### DIFF
--- a/docs/release-notes/1.12.1.md
+++ b/docs/release-notes/1.12.1.md
@@ -1,0 +1,14 @@
+(v1.12.1)=
+### 1.12.1 {small}`2026-04-10`
+
+#### Features
+
+- Use scverse S3 Cloudfront URLs for datasets {smaller}`zethson` ({pr}`4011`)
+
+#### Bug fixes
+
+- Prevent segfault when running {func}`scanpy.pp.highly_variable_genes` with `flavor='seurat_v3{,_paper}'` and some all-zero genes {smaller}`P Angerer` ({pr}`3980`)
+- {func}`scanpy.pp.combat` now raises a {class}`ValueError` when a batch contains fewer than 2 cells, instead of silently producing NaN values in the corrected data {smaller}`L Zhang` ({pr}`3994`)
+- Fix crashes when running numba in dask by using the threadsafe {func}`fast_array_utils.numba.njit` {smaller}`P Angerer` ({pr}`4015`)
+- {func}`scanpy.tl.umap` no longer silently mutates `adata.obsp['connectivities']` via a shared sparse buffer {smaller}`N Justice` ({pr}`4031`)
+- Make {func}`scanpy.metrics.modularity` actually use edge weights {smaller}`P Angerer` ({pr}`4045`)

--- a/docs/release-notes/3980.fix.md
+++ b/docs/release-notes/3980.fix.md
@@ -1,1 +1,0 @@
-Prevent segfault when running {func}`scanpy.pp.highly_variable_genes` with `flavor='seurat_v3{,_paper}'` and some all-zero genes {smaller}`P Angerer`

--- a/docs/release-notes/3994.fix.md
+++ b/docs/release-notes/3994.fix.md
@@ -1,1 +1,0 @@
-{func}`scanpy.pp.combat` now raises a {class}`ValueError` when a batch contains fewer than 2 cells, instead of silently producing NaN values in the corrected data {smaller}`L Zhang`

--- a/docs/release-notes/4011.feat.md
+++ b/docs/release-notes/4011.feat.md
@@ -1,1 +1,0 @@
-Use scverse S3 Cloudfront URLs for datasets {smaller}`zethson`

--- a/docs/release-notes/4015.fix.md
+++ b/docs/release-notes/4015.fix.md
@@ -1,1 +1,0 @@
-Fix crashes when running numba in dask by using the threadsafe {func}`fast_array_utils.numba.njit` {smaller}`P Angerer`

--- a/docs/release-notes/4031.fix.md
+++ b/docs/release-notes/4031.fix.md
@@ -1,1 +1,0 @@
-{func}`scanpy.tl.umap` no longer silently mutates `adata.obsp['connectivities']` via a shared sparse buffer {smaller}`N Justice`

--- a/docs/release-notes/4045.fix.md
+++ b/docs/release-notes/4045.fix.md
@@ -1,1 +1,0 @@
-Make {func}`scanpy.metrics.modularity` actually use edge weights {smaller}`P Angerer`


### PR DESCRIPTION
- [x] Release notes not necessary because: compiles release notes

@meeseeksdev backport to main