### PR TITLE
feat: create `scanpy2` extra for dependencies

### DIFF
--- a/docs/release-notes/4055.feat.md
+++ b/docs/release-notes/4055.feat.md
@@ -1,0 +1,1 @@
+New `scanpy2` option-dependency extra to make it easier to transition to the new scanpy 2 defaults {smaller}`I Gold`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ scanorama = [ "scanorama" ]
 scrublet = [ "scikit-image>=0.23.1" ]
 # highly_variable_genes method 'seurat_v3'
 skmisc = [ "scikit-misc>=0.5.1" ]
+scanpy2 = [ "igraph>=0.10.8", "leidenalg>=0.10.1", "scikit-misc>=0.5.1" ]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,7 @@ scanorama = [ "scanorama" ]
 scrublet = [ "scikit-image>=0.23.1" ]
 # highly_variable_genes method 'seurat_v3'
 skmisc = [ "scikit-misc>=0.5.1" ]
-scanpy2 = [ "igraph>=0.10.8", "leidenalg>=0.10.1", "scikit-misc>=0.5.1" ]
+scanpy2 = [ "igraph>=0.10.8", "scikit-misc>=0.5.1" ]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -202,7 +202,7 @@ lint.per-file-ignores."src/scanpy/tools/_sim.py" = [ "N" ]
 # D*: No need for docstrings for all test modules and test functions
 # PLR0913: Test may use many fixtures
 lint.per-file-ignores."tests/**/*.py" = [ "D100", "D101", "D103", "PLR0913" ]
-lint.allowed-confusables = [ "×", "–", "’", "α" ]
+lint.allowed-confusables = [ "×", "–", "‘", "’", "α" ]
 lint.external = [ "PLR0917" ]
 lint.flake8-bugbear.extend-immutable-calls = [ "scanpy._settings.Default" ]
 lint.flake8-type-checking.exempt-modules = []

--- a/src/scanpy/_settings/__init__.py
+++ b/src/scanpy/_settings/__init__.py
@@ -105,7 +105,6 @@ class SettingsMeta(SingletonMeta, type):
 
     @preset.setter
     def preset(cls, preset: Preset | str) -> None:
-
         new_preset = Preset(preset)
         new_preset.check_deps()
         cls._preset = new_preset

--- a/src/scanpy/_settings/__init__.py
+++ b/src/scanpy/_settings/__init__.py
@@ -105,11 +105,9 @@ class SettingsMeta(SingletonMeta, type):
 
     @preset.setter
     def preset(cls, preset: Preset | str) -> None:
-        from .presets import _check_scanpy_v2_deps
 
         new_preset = Preset(preset)
-        if new_preset is Preset.ScanpyV2Preview:
-            _check_scanpy_v2_deps()
+        new_preset.check_deps()
         cls._preset = new_preset
 
     @property

--- a/src/scanpy/_settings/__init__.py
+++ b/src/scanpy/_settings/__init__.py
@@ -105,7 +105,12 @@ class SettingsMeta(SingletonMeta, type):
 
     @preset.setter
     def preset(cls, preset: Preset | str) -> None:
-        cls._preset = Preset(preset)
+        from .presets import _check_scanpy_v2_deps
+
+        new_preset = Preset(preset)
+        if new_preset is Preset.ScanpyV2Preview:
+            _check_scanpy_v2_deps()
+        cls._preset = new_preset
 
     @property
     def verbosity(cls) -> Verbosity:

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -209,7 +209,9 @@ class Preset(enum.StrEnum):
 
         >>> import scanpy as sc
         >>> sc.settings.preset = sc.Preset.ScanpyV1
-        >>> with sc.settings.preset.override(sc.Preset.ScanpyV2Preview):
+        >>> with sc.settings.preset.override(
+        ...     sc.Preset.ScanpyV2Preview
+        ... ):  # doctest: +ELLIPSIS
         ...     sc.settings.preset
         <Preset.ScanpyV2Preview: 'scanpy-v2-preview'>
         >>> sc.settings.preset

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -6,7 +6,10 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property, partial, wraps
+from importlib.metadata import packages_distributions, requires
 from typing import TYPE_CHECKING, Literal, NamedTuple
+
+from packaging.requirements import Requirement
 
 from .._utils._doctests import doctest_needs
 
@@ -130,29 +133,6 @@ def preset_property[NT: NamedTuple](
     return prop
 
 
-def _check_scanpy_v2_deps() -> None:
-    from importlib.metadata import packages_distributions, requires
-
-    from packaging.requirements import Requirement
-
-    dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
-    missing = [
-        r.name
-        for r in map(Requirement, requires("scanpy"))
-        if r.marker
-        and r.marker.evaluate({"extra": "scanpy2"})
-        and r.name in dist_to_module
-    ]
-    if missing:
-        missing_str = ", ".join(f"’{m}’" for m in missing)
-        msg = (
-            f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
-            f"dependencies that are not installed: {missing_str}. "
-            "Install them with: pip install `scanpy[scanpy2]`"
-        )
-        raise ImportError(msg)
-
-
 class Preset(enum.StrEnum):
     """Presets for :attr:`scanpy.settings.preset`.
 
@@ -242,6 +222,31 @@ class Preset(enum.StrEnum):
             yield self
         finally:
             settings.preset = self
+
+    def check_deps(self) -> None:
+
+        match self:
+            case self.ScanpyV1:
+                return
+            case self.ScanpyV2Preview:
+                dist_to_module = {
+                    d: m for m, ds in packages_distributions().items() for d in ds
+                }
+                missing = [
+                    r.name
+                    for r in map(Requirement, requires("scanpy"))
+                    if r.marker
+                    and r.marker.evaluate({"extra": "scanpy2"})
+                    and r.name in dist_to_module
+                ]
+                if missing:
+                    missing_str = ", ".join(f"’{m}’" for m in missing)
+                    msg = (
+                        f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
+                        f"dependencies that are not installed: {missing_str}. "
+                        "Install them with: pip install `scanpy[scanpy2]`"
+                    )
+                    raise ImportError(msg)
 
 
 for postprocess in preset_postprocessors:

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -229,9 +229,7 @@ class Preset(enum.StrEnum):
             case self.ScanpyV1:
                 return
             case self.ScanpyV2Preview:
-                dists = {
-                    d for m, ds in packages_distributions().items() for d in ds
-                }
+                dists = {d for m, ds in packages_distributions().items() for d in ds}
                 missing = [
                     r.name
                     for r in map(Requirement, requires("scanpy"))

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from functools import cached_property, partial, wraps
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
+from .._utils._doctests import doctest_needs
+
 if TYPE_CHECKING:
     from collections.abc import Callable, Generator, Mapping
 
@@ -222,6 +224,7 @@ class Preset(enum.StrEnum):
         }
 
     @contextmanager
+    @doctest_needs("igraph")
     def override(self, preset: Preset) -> Generator[Preset, None, None]:
         """Temporarily override :attr:`scanpy.settings.preset`.
 

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -229,18 +229,18 @@ class Preset(enum.StrEnum):
             case self.ScanpyV1:
                 return
             case self.ScanpyV2Preview:
-                dist_to_module = {
-                    d: m for m, ds in packages_distributions().items() for d in ds
+                dists = {
+                    d for m, ds in packages_distributions().items() for d in ds
                 }
                 missing = [
                     r.name
                     for r in map(Requirement, requires("scanpy"))
                     if r.marker
                     and r.marker.evaluate({"extra": "scanpy2"})
-                    and r.name in dist_to_module
+                    and r.name in dists
                 ]
                 if missing:
-                    missing_str = ", ".join(f"’{m}’" for m in missing)
+                    missing_str = ", ".join(f"‘{m}’" for m in missing)
                     msg = (
                         f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
                         f"dependencies that are not installed: {missing_str}. "

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -204,14 +204,13 @@ class Preset(enum.StrEnum):
 
     @contextmanager
     @doctest_needs("igraph")
+    @doctest_needs("scikit-misc")
     def override(self, preset: Preset) -> Generator[Preset, None, None]:
         """Temporarily override :attr:`scanpy.settings.preset`.
 
         >>> import scanpy as sc
         >>> sc.settings.preset = sc.Preset.ScanpyV1
-        >>> with sc.settings.preset.override(
-        ...     sc.Preset.ScanpyV2Preview
-        ... ):  # doctest: +ELLIPSIS
+        >>> with sc.settings.preset.override(sc.Preset.ScanpyV2Preview):
         ...     sc.settings.preset
         <Preset.ScanpyV2Preview: 'scanpy-v2-preview'>
         >>> sc.settings.preset

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -132,7 +132,6 @@ def preset_property[NT: NamedTuple](
 
 def _check_scanpy_v2_deps() -> None:
     from importlib.metadata import packages_distributions, requires
-    from importlib.util import find_spec
 
     from packaging.requirements import Requirement
 

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -142,7 +142,7 @@ def _check_scanpy_v2_deps() -> None:
         for r in map(Requirement, requires("scanpy"))
         if r.marker
         and r.marker.evaluate({"extra": "scanpy2"})
-        and find_spec(dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
+        and r.name in dist_to_module
     ]
     if missing:
         missing_str = ", ".join(f"’{m}’" for m in missing)

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -7,6 +7,7 @@ from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property, partial, wraps
 from importlib.metadata import packages_distributions, requires
+from importlib.util import find_spec
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from packaging.requirements import Requirement
@@ -230,13 +231,13 @@ class Preset(enum.StrEnum):
             case self.ScanpyV1:
                 return
             case self.ScanpyV2Preview:
-                dists = {d for m, ds in packages_distributions().items() for d in ds}
+                dists = {d: m for m, ds in packages_distributions().items() for d in ds}
                 missing = [
                     r.name
                     for r in map(Requirement, requires("scanpy"))
                     if r.marker
                     and r.marker.evaluate({"extra": "scanpy2"})
-                    and r.name in dists
+                    and find_spec(dists.get(r.name, r.name.replace("-", "_"))) is None
                 ]
                 if missing:
                     missing_str = ", ".join(f"‘{m}’" for m in missing)

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -128,6 +128,30 @@ def preset_property[NT: NamedTuple](
     return prop
 
 
+def _check_scanpy_v2_deps() -> None:
+    from importlib.metadata import packages_distributions, requires
+    from importlib.util import find_spec
+
+    from packaging.requirements import Requirement
+
+    dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
+    missing = [
+        r.name
+        for r in map(Requirement, requires("scanpy"))
+        if r.marker
+        and r.marker.evaluate({"extra": "scanpy2"})
+        and find_spec(dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
+    ]
+    if missing:
+        missing_str = ", ".join(f"’{m}’" for m in missing)
+        msg = (
+            f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
+            f"dependencies that are not installed: {missing_str}. "
+            "Install them with: pip install `scanpy[scanpy2]`"
+        )
+        raise ImportError(msg)
+
+
 class Preset(enum.StrEnum):
     """Presets for :attr:`scanpy.settings.preset`.
 

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -34,7 +34,6 @@ from packaging.version import Version
 
 from .. import logging as logg
 from .._compat import CSBase, DaskArray, _CSArray, pkg_version, warn
-from .._settings import settings
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, KeysView, Mapping
@@ -340,6 +339,8 @@ def compute_association_matrix_of_groups(
         reference labels, entries are proportional to degree of association.
 
     """
+    from .._settings import settings
+
     if normalization not in {"prediction", "reference"}:
         msg = '`normalization` needs to be either "prediction" or "reference".'
         raise ValueError(msg)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+from importlib.metadata import packages_distributions, requires
+from importlib.util import find_spec
+
 import pytest
+from packaging.requirements import Requirement
 
 import scanpy as sc
 
@@ -17,3 +21,21 @@ def test_resets(_attempt: int) -> None:
 def test_set_figure_params_warns() -> None:
     with pytest.warns(FutureWarning, match=r"scanpy\.set_figure_params"):
         sc.settings.set_figure_params()
+
+
+def test_preset_scanpy_v2_preview_checks_deps() -> None:
+    _dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
+    _scanpy2_deps_missing = any(
+        find_spec(_dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
+        for r in map(Requirement, requires("scanpy"))
+        if r.marker and r.marker.evaluate({"extra": "scanpy2"})
+    )
+
+    if _scanpy2_deps_missing:
+        with pytest.raises(ImportError, match=r"scanpy\[scanpy2\]"):
+            sc.settings.preset = sc.Preset.ScanpyV2Preview
+    else:
+        sc.settings.preset = sc.Preset.ScanpyV2Preview
+        assert sc.settings.preset is sc.Preset.ScanpyV2Preview
+        sc.settings.preset = sc.Preset.ScanpyV1
+    assert sc.settings.preset == sc.Preset.ScanpyV1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,9 +24,9 @@ def test_set_figure_params_warns() -> None:
 
 
 def test_preset_scanpy_v2_preview_checks_deps() -> None:
-    dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
+    dists = {d for m, ds in packages_distributions().items() for d in ds}
     _scanpy2_deps_missing = any(
-        find_spec(dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
+        r.name in dists
         for r in map(Requirement, requires("scanpy"))
         if r.marker and r.marker.evaluate({"extra": "scanpy2"})
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,13 +24,13 @@ def test_set_figure_params_warns() -> None:
 
 def test_preset_scanpy_v2_preview_checks_deps() -> None:
     dists = {d for m, ds in packages_distributions().items() for d in ds}
-    _scanpy2_deps_missing = any(
+    scanpy2_deps_missing = any(
         r.name in dists
         for r in map(Requirement, requires("scanpy"))
         if r.marker and r.marker.evaluate({"extra": "scanpy2"})
     )
 
-    if _scanpy2_deps_missing:
+    if scanpy2_deps_missing:
         with pytest.raises(ImportError, match=r"scanpy\[scanpy2\]"):
             sc.settings.preset = sc.Preset.ScanpyV2Preview
     else:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -24,9 +24,9 @@ def test_set_figure_params_warns() -> None:
 
 
 def test_preset_scanpy_v2_preview_checks_deps() -> None:
-    _dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
+    dist_to_module = {d: m for m, ds in packages_distributions().items() for d in ds}
     _scanpy2_deps_missing = any(
-        find_spec(_dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
+        find_spec(dist_to_module.get(r.name, r.name.replace("-", "_"))) is None
         for r in map(Requirement, requires("scanpy"))
         if r.marker and r.marker.evaluate({"extra": "scanpy2"})
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from importlib.metadata import packages_distributions, requires
+from importlib.util import find_spec
 
 import pytest
 from packaging.requirements import Requirement
@@ -23,11 +24,13 @@ def test_set_figure_params_warns() -> None:
 
 
 def test_preset_scanpy_v2_preview_checks_deps() -> None:
-    dists = {d for m, ds in packages_distributions().items() for d in ds}
+    dists = {d: m for m, ds in packages_distributions().items() for d in ds}
     scanpy2_deps_missing = any(
-        r.name in dists
+        r.name
         for r in map(Requirement, requires("scanpy"))
-        if r.marker and r.marker.evaluate({"extra": "scanpy2"})
+        if r.marker
+        and r.marker.evaluate({"extra": "scanpy2"})
+        and find_spec(dists.get(r.name, r.name.replace("-", "_"))) is None
     )
 
     if scanpy2_deps_missing:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from importlib.metadata import packages_distributions, requires
-from importlib.util import find_spec
 
 import pytest
 from packaging.requirements import Requirement


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

I noticed that the scanpy 2 settings are not tested in general - this seems like an oversight maybe? Or? Marking this as a draft because I'm not sure this is the best way to check this behavior.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #4051
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
