### PR TITLE
docs: add inline example plot to sc.pl.pca_variance_ratio

### DIFF
--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -202,6 +202,24 @@ def pca_variance_ratio(
         A string is appended to the default filename.
         Infer the filetype if ending on {`'.pdf'`, `'.png'`, `'.svg'`}.
 
+    Examples
+    --------
+    Plot the variance ratio for the first 30 PCs.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc3k_processed()
+        sc.pl.pca_variance_ratio(adata)
+
+    Plot on a logarithmic scale.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.pca_variance_ratio(adata, log=True)
+
     """
     ranking(
         adata,


### PR DESCRIPTION
Part of #1664. Adds rendered plot examples to `sc.pl.pca_variance_ratio` showing:
1. Default variance ratio plot on PBMC 3k
2. Log-scale variant

Follows the same pattern as #4032 (merged).