### PR TITLE
docs: add inline example plot to sc.pl.rank_genes_groups_stacked_violin

### DIFF
--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -985,13 +985,15 @@ def rank_genes_groups_stacked_violin(  # noqa: PLR0913
 
     Examples
     --------
-    >>> import scanpy as sc
-    >>> adata = sc.datasets.pbmc68k_reduced()
-    >>> sc.tl.rank_genes_groups(adata, "bulk_labels")
+    Plot top marker genes per group as a stacked violin.
 
-    >>> sc.pl.rank_genes_groups_stacked_violin(
-    ...     adata, n_genes=4, min_logfoldchange=4, figsize=(8, 6)
-    ... )
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.tl.rank_genes_groups(adata, "bulk_labels")
+        sc.pl.rank_genes_groups_stacked_violin(adata, n_genes=4, min_logfoldchange=4, figsize=(8, 6))
 
     """
     return _rank_genes_groups_plot(


### PR DESCRIPTION
Part of #1664. Converts existing doctest to rendered plot showing top marker genes per group on PBMC 68k reduced.