### PR TITLE
docs: add inline example plot to sc.pl.rank_genes_groups_violin

### DIFF
--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -1196,6 +1196,18 @@ def rank_genes_groups_violin(  # noqa: PLR0913
         Size of the jitter points.
     {show_save_ax}
 
+    Examples
+    --------
+    Plot violin distributions of top-ranked genes per group.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.tl.rank_genes_groups(adata, "bulk_labels")
+        sc.pl.rank_genes_groups_violin(adata, groups=["CD34+"], n_genes=5)
+
     """
     if key is None:
         key = "rank_genes_groups"


### PR DESCRIPTION
Part of #1664. Shows violin distribution of top-ranked genes on PBMC 68k reduced.