### PR TITLE
Fix #4008: Opinionated defaults for 2.0

### DIFF
--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -169,7 +169,7 @@ class Preset(enum.StrEnum):
         return {
             Preset.ScanpyV1: RankGenesGroupsPreset(method="t-test", mask_var=None),
             Preset.ScanpyV2Preview: RankGenesGroupsPreset(
-                method="wilcoxon", mask_var=None
+                method="wilcoxon", mask_var="highly_variable"
             ),
         }
 

--- a/tests/test_rank_genes_groups.py
+++ b/tests/test_rank_genes_groups.py
@@ -311,3 +311,11 @@ def test_mask_not_equal():
     with_mask = pbmc.uns["rank_genes_groups"]["names"]
 
     assert not np.array_equal(no_mask, with_mask)
+
+
+def test_v2preview_preset_mask_var() -> None:
+    """Test that ScanpyV2Preview preset sets mask_var='highly_variable'."""
+    from scanpy import Preset
+
+    assert Preset.ScanpyV2Preview.rank_genes_groups.mask_var == "highly_variable"
+    assert Preset.ScanpyV1.rank_genes_groups.mask_var is None


### PR DESCRIPTION
Closes #4008

- [x] Closes #4008
- [x] [Tests][] included or not required because: added `test_v2preview_preset_mask_var` in `tests/test_rank_genes_groups.py`
- [ ] [Release notes][] not necessary because:

Sets `mask_var="highly_variable"` as the default for `RankGenesGroupsPreset` under the `ScanpyV2Preview` preset in `src/scanpy/_settings/presets.py`. Previously both `ScanpyV1` and `ScanpyV2Preview` used `mask_var=None`; now `ScanpyV2Preview` automatically restricts differential expression to highly variable genes by default, aligning with the opinionated v2.0 conventions described in #4008.

The new unit test `test_v2preview_preset_mask_var` directly asserts:
- `Preset.ScanpyV2Preview.rank_genes_groups.mask_var == "highly_variable"`
- `Preset.ScanpyV1.rank_genes_groups.mask_var is None`

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*