### PR TITLE
docs: improve prefix default rendering

### DIFF
--- a/hatch.toml
+++ b/hatch.toml
@@ -37,8 +37,9 @@ overrides.matrix.deps.python = [
 ]
 overrides.matrix.deps.extra-dependencies = [
     { if = [ "stable" ], value = "scipy>=1.17" },
+    { if = [ "stable" ], value = "pandas>=3" },
     { if = [ "pre" ], value = "anndata @ git+https://github.com/scverse/anndata.git" },
-    { if = [ "pre" ], value = "pandas>=3rc0" },
+    { if = [ "pre" ], value = "pandas>=3" },
 ]
 overrides.matrix.deps.dependency-groups = [
     { if = [ "stable", "pre", "low-vers" ], value = "test" },

--- a/hatch.toml
+++ b/hatch.toml
@@ -37,7 +37,6 @@ overrides.matrix.deps.python = [
 ]
 overrides.matrix.deps.extra-dependencies = [
     { if = [ "stable" ], value = "scipy>=1.17" },
-    { if = [ "stable" ], value = "pandas>=3" },
     { if = [ "pre" ], value = "anndata @ git+https://github.com/scverse/anndata.git" },
     { if = [ "pre" ], value = "pandas>=3" },
 ]

--- a/src/scanpy/_settings/__init__.py
+++ b/src/scanpy/_settings/__init__.py
@@ -106,7 +106,7 @@ class SettingsMeta(SingletonMeta, type):
     @preset.setter
     def preset(cls, preset: Preset | str) -> None:
         new_preset = Preset(preset)
-        new_preset.check_deps()
+        new_preset.check()
         cls._preset = new_preset
 
     @property

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -53,7 +53,7 @@ class Default:
         value = self._get_value(sc.settings.preset)
         suffix = (
             " – changes in 2.0"
-            if sc.settings.preset == Preset.ScanpyV1
+            if sc.settings.preset is Preset.ScanpyV1
             and value != self._get_value(Preset.ScanpyV2Preview)
             else ""
         )

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -6,8 +6,7 @@ import re
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import cached_property, partial, wraps
-from importlib.metadata import packages_distributions, requires
-from importlib.util import find_spec
+from importlib.metadata import distributions, requires
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from packaging.requirements import Requirement
@@ -51,10 +50,22 @@ class Default:
             return self.repr or "default"
         import scanpy as sc
 
+        value = self._get_value(sc.settings.preset)
+        suffix = (
+            " – changes in 2.0"
+            if sc.settings.preset == Preset.ScanpyV1
+            and value != self._get_value(Preset.ScanpyV2Preview)
+            else ""
+        )
+        return f"{value!r} (sc.settings.preset={str(sc.settings.preset)!r}{suffix})"
+
+    def _get_value(self, preset: Preset) -> object:
+        if not self.preset:
+            msg = "preset is not set"
+            raise AssertionError(msg)
         func, param = self.preset
-        params = getattr(sc.settings.preset, func)
-        value = getattr(params, param)
-        return f"{value!r} ({sc.settings.preset=} – changes in 2.0)"
+        params = getattr(preset, func)
+        return getattr(params, param)
 
 
 class HVGPreset(NamedTuple):
@@ -225,28 +236,32 @@ class Preset(enum.StrEnum):
         finally:
             settings.preset = self
 
-    def check_deps(self) -> None:
-
+    def check(self) -> None:
+        """Check if requirements for preset are met."""
         match self:
             case self.ScanpyV1:
                 return
             case self.ScanpyV2Preview:
-                dists = {d: m for m, ds in packages_distributions().items() for d in ds}
-                missing = [
-                    r.name
-                    for r in map(Requirement, requires("scanpy"))
-                    if r.marker
-                    and r.marker.evaluate({"extra": "scanpy2"})
-                    and find_spec(dists.get(r.name, r.name.replace("-", "_"))) is None
-                ]
-                if missing:
-                    missing_str = ", ".join(f"‘{m}’" for m in missing)
-                    msg = (
-                        f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
-                        f"dependencies that are not installed: {missing_str}. "
-                        "Install them with: pip install `scanpy[scanpy2]`"
-                    )
-                    raise ImportError(msg)
+                if not (missing := _missing_scanpy2_deps()):
+                    return
+                missing_str = ", ".join(f"‘{m.name}’" for m in missing)
+                msg = (
+                    f"Setting preset to {Preset.ScanpyV2Preview!r} requires optional "
+                    f"dependencies that are not installed: {missing_str}. "
+                    "Install them with: pip install `scanpy[scanpy2]`"
+                )
+                raise ImportError(msg)
+
+
+def _missing_scanpy2_deps() -> list[Requirement]:
+    dist_names = {d.name for d in distributions()}
+    return [
+        r
+        for r in map(Requirement, requires("scanpy") or ())
+        if r.marker
+        and r.marker.evaluate({"extra": "scanpy2"})
+        and r.name not in dist_names
+    ]
 
 
 for postprocess in preset_postprocessors:

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -10,6 +10,7 @@ from importlib.metadata import distributions, requires
 from typing import TYPE_CHECKING, Literal, NamedTuple
 
 from packaging.requirements import Requirement
+from packaging.utils import canonicalize_name
 
 from .._utils._doctests import doctest_needs
 
@@ -254,13 +255,13 @@ class Preset(enum.StrEnum):
 
 
 def _missing_scanpy2_deps() -> list[Requirement]:
-    dist_names = {d.name for d in distributions()}
+    dist_names = {canonicalize_name(d.name) for d in distributions()}
     return [
         r
         for r in map(Requirement, requires("scanpy") or ())
         if r.marker
-        and r.marker.evaluate({"extra": "scanpy2"})
-        and r.name not in dist_names
+        and r.marker.evaluate({"extra": "scanpy2"}, "requirement")
+        and canonicalize_name(r.name) not in dist_names
     ]
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -28,4 +28,4 @@ def test_preset_scanpy_v2_preview_checks_deps() -> None:
         sc.settings.preset = sc.Preset.ScanpyV2Preview
         assert sc.settings.preset is sc.Preset.ScanpyV2Preview
         sc.settings.preset = sc.Preset.ScanpyV1
-    assert sc.settings.preset == sc.Preset.ScanpyV1
+    assert sc.settings.preset is sc.Preset.ScanpyV1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-from importlib.metadata import packages_distributions, requires
-from importlib.util import find_spec
-
 import pytest
-from packaging.requirements import Requirement
 
 import scanpy as sc
+from scanpy._settings.presets import _missing_scanpy2_deps
 
 
 # TODO: reset everything
@@ -24,16 +21,7 @@ def test_set_figure_params_warns() -> None:
 
 
 def test_preset_scanpy_v2_preview_checks_deps() -> None:
-    dists = {d: m for m, ds in packages_distributions().items() for d in ds}
-    scanpy2_deps_missing = any(
-        r.name
-        for r in map(Requirement, requires("scanpy"))
-        if r.marker
-        and r.marker.evaluate({"extra": "scanpy2"})
-        and find_spec(dists.get(r.name, r.name.replace("-", "_"))) is None
-    )
-
-    if scanpy2_deps_missing:
+    if _missing_scanpy2_deps():
         with pytest.raises(ImportError, match=r"scanpy\[scanpy2\]"):
             sc.settings.preset = sc.Preset.ScanpyV2Preview
     else:


### PR DESCRIPTION
this improves how default strings look by
1. only displaying the string representation of the preset
2. not showing “changes in scanpy 2.0” if that’s not the case

it also re-introduces a change I requested in https://github.com/scverse/scanpy/pull/4055#discussion_r3092691504 that didn’t make it in