### PR TITLE
docs: add inline example plot to sc.pl.scatter

### DIFF
--- a/docs/release-notes/4078.docs.md
+++ b/docs/release-notes/4078.docs.md
@@ -1,0 +1,1 @@
+Add a rendered example plot to {func}`~scanpy.pl.scatter` showing a QC scatter using `pbmc68k_reduced` {smaller}`C Gao`

--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -157,6 +157,17 @@ def scatter(  # noqa: PLR0913
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
 
+    Examples
+    --------
+    Plot per-cell total counts versus detected genes, colored by mitochondrial fraction.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.pl.scatter(adata, x="n_counts", y="n_genes", color="percent_mito")
+
     """
     # color can be a obs column name or a matplotlib color specification (or a collection thereof)
     if color is not None:


### PR DESCRIPTION
Part of the inline-example effort in #1664. Adds a rendered `.. plot::` to `sc.pl.scatter`'s docstring: a QC scatter (total counts vs detected genes, colored by mitochondrial fraction) on `pbmc68k_reduced`, which already carries the three required `.obs` columns so no preprocessing is needed.

### Local verification
- `pre-commit run --files src/scanpy/plotting/_anndata.py` — all hooks pass
- `pytest tests/test_plotting.py -k scatter` — 35/35 passed
- Manually ran the example with `show=False` against current main; no errors

Refs #1664
