### PR TITLE
docs: clarify method vs transformer in sc.pp.neighbors

### DIFF
--- a/docs/release-notes/4079.docs.md
+++ b/docs/release-notes/4079.docs.md
@@ -1,0 +1,1 @@
+Clarify that `method` selects the connectivity kernel and `transformer` selects the kNN search backend in {func}`~scanpy.pp.neighbors` {smaller}`C Gao`

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -102,12 +102,12 @@ def neighbors(  # noqa: PLR0913
 ) -> AnnData | None:
     """Compute the nearest neighbors distance matrix and a neighborhood graph of observations :cite:p:`McInnes2018`.
 
-    The computation proceeds in two independent stages. First, a k-nearest
-    neighbor (kNN) search produces the distance matrix via the estimator
-    passed as ``transformer``. Second, connectivities are derived from the
-    kNN search output by the kernel selected via ``method``. The two stages
-    are controlled by independent parameters: ``transformer`` selects the
-    kNN search backend, ``method`` selects the connectivity kernel.
+    The computation proceeds in two independent stages.
+    First, a k-nearest neighbor (kNN) search produces the distance matrix via the estimator passed as ``transformer``.
+    Second, connectivities are derived from the kNN search output by the kernel selected via ``method``.
+    The two stages are controlled by independent parameters:
+    ``transformer`` selects the kNN search backend,
+    ``method`` selects the connectivity kernel.
 
     .. array-support:: pp.neighbors
 
@@ -134,8 +134,9 @@ def neighbors(  # noqa: PLR0913
         `n_neighbors` nearest neighbor.
     method
         Kernel that derives connectivities from the kNN search output.
-        The choice is independent of the kNN search backend, which is
-        controlled by ``transformer``. Use 'umap' :cite:p:`McInnes2018`,
+        The choice is independent of the kNN search backend,
+        which is controlled by ``transformer``.
+        Use 'umap' :cite:p:`McInnes2018`,
         'gauss' (Gauss kernel following :cite:t:`Coifman2005` with adaptive width :cite:t:`Haghverdi2016`),
         or 'jaccard' (Jaccard kernel as in PhenoGraph, :cite:t:`Levine2015`).
     transformer

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -102,12 +102,12 @@ def neighbors(  # noqa: PLR0913
 ) -> AnnData | None:
     """Compute the nearest neighbors distance matrix and a neighborhood graph of observations :cite:p:`McInnes2018`.
 
-    The neighbor search efficiency of this heavily relies on UMAP :cite:p:`McInnes2018`,
-    which also provides a method for estimating connectivities of data points -
-    the connectivity of the manifold (`method=='umap'`).
-    If `method=='gauss'`, connectivities are computed according to :cite:t:`Coifman2005`,
-    in the adaption of :cite:t:`Haghverdi2016`.
-    If `method=='jaccard'`, connectivities are computed as in PhenoGraph :cite:p:`Levine2015`.
+    The computation proceeds in two independent stages. First, a k-nearest
+    neighbor (kNN) search produces the distance matrix via the estimator
+    passed as ``transformer``. Second, connectivities are derived from the
+    kNN search output by the kernel selected via ``method``. The two stages
+    are controlled by independent parameters: ``transformer`` selects the
+    kNN search backend, ``method`` selects the connectivity kernel.
 
     .. array-support:: pp.neighbors
 
@@ -133,12 +133,13 @@ def neighbors(  # noqa: PLR0913
         Kernel to assign low weights to neighbors more distant than the
         `n_neighbors` nearest neighbor.
     method
-        Use 'umap' :cite:p:`McInnes2018`,
+        Kernel that derives connectivities from the kNN search output.
+        The choice is independent of the kNN search backend, which is
+        controlled by ``transformer``. Use 'umap' :cite:p:`McInnes2018`,
         'gauss' (Gauss kernel following :cite:t:`Coifman2005` with adaptive width :cite:t:`Haghverdi2016`),
-        or 'jaccard' (Jaccard kernel as in PhenoGraph, :cite:t:`Levine2015`)
-        for computing connectivities.
+        or 'jaccard' (Jaccard kernel as in PhenoGraph, :cite:t:`Levine2015`).
     transformer
-        Approximate kNN search implementation following the API of
+        kNN search backend following the API of
         :class:`~sklearn.neighbors.KNeighborsTransformer`.
         See :doc:`/how-to/knn-transformers` for more details.
         Also accepts the following known options:


### PR DESCRIPTION
## Problem

The `sc.pp.neighbors` docstring bundles the kNN search and the
connectivity kernel into a single lead sentence attributing both to
UMAP. The parameters controlling the two stages are independent:
`transformer` selects the kNN search backend, `method` selects the
connectivity kernel. The lead paragraph and the `method` /
`transformer` parameter descriptions obscure this.

## Change

- Rewrite the lead paragraph to describe the two stages separately.
- Add a sentence to the `method` parameter description stating that
  the choice is independent of the kNN search backend.
- Replace "Approximate kNN search implementation" with "kNN search
  backend" in the `transformer` description. The original wording
  contradicted the same block, which already stated that exact kNN
  is used for small data.

No signature, default, or behavior change.

## Verification

- `sphinx-build -W --keep-going` produces 0 new warnings; all four
  citations (McInnes2018, Coifman2005, Haghverdi2016, Levine2015)
  resolve; both `:class:` cross-references resolve.
- `pre-commit run --all-files`: 15/15 hooks pass.
- `pytest tests/test_neighbors.py tests/test_neighbors_common.py
  tests/test_neighbors_key_added.py`: 36 passed.

Closes #277.
