### PR TITLE
style: add NPY lints to prevent use of legacy `np.random`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,7 @@ lint.select = [
     "ICN",    # Follow import conventions
     "ISC",    # Implicit string concatenation
     "N",      # Naming conventions
+    "NPY",    # Numpy-specific rules
     "PD",     # Pandas
     "PERF",   # Performance
     "PIE",    # Syntax simplifications

--- a/src/scanpy/_utils/random.py
+++ b/src/scanpy/_utils/random.py
@@ -103,6 +103,9 @@ class _LegacyRng(np.random.Generator):
         self.arg = arg
         self.state = check_random_state(arg) if state is None else state
 
+    def __str__(self) -> str:
+        return f"LegacyRng({self.arg!r})"
+
     @property
     def bit_generator(self) -> BitGenerator:
         msg = "A _LegacyRng instance has no `bit_generator` attribute."
@@ -117,9 +120,9 @@ class _LegacyRng(np.random.Generator):
         """Create a generator that wraps the global `RandomState` backing the legacy `np.random` functions."""
         if arg is not None:
             if isinstance(arg, np.random.RandomState):
-                np.random.set_state(arg.get_state(legacy=False))
+                np.random.set_state(arg.get_state(legacy=False))  # noqa: NPY002
                 return _LegacyRng(arg, state)
-            np.random.seed(arg)
+            np.random.seed(arg)  # noqa: NPY002
         return _LegacyRng(arg, np.random.RandomState(np.random.get_bit_generator()))
 
     def spawn(self, n_children: int) -> list[Self]:

--- a/src/scanpy/_utils/random.py
+++ b/src/scanpy/_utils/random.py
@@ -148,7 +148,7 @@ class _LegacyRng(np.random.Generator):
 
                 return wrapper
 
-            setattr(cls, names.get(name, name), mk_wrapper(name, meth))
+            setattr(cls, name, mk_wrapper(names.get(name, name), meth))
 
 
 _LegacyRng._delegate()

--- a/src/scanpy/external/tl/_phenograph.py
+++ b/src/scanpy/external/tl/_phenograph.py
@@ -188,13 +188,13 @@ def phenograph(  # noqa: PLR0913
 
     Cluster and cluster centroids for input Numpy ndarray
 
-    >>> df = np.random.rand(1000, 40)
-    >>> dframe = pd.DataFrame(df)
-    >>> dframe.index, dframe.columns = (
-    ...     map(str, dframe.index),
-    ...     map(str, dframe.columns),
+    >>> data = np.random.default_rng().random((1000, 40))
+    >>> df = pd.DataFrame(data)
+    >>> df.index, df.columns = (
+    ...     map(str, df.index),
+    ...     map(str, df.columns),
     ... )
-    >>> adata = AnnData(dframe)
+    >>> adata = AnnData(df)
     >>> sc.pp.pca(adata, n_comps=20)
     >>> sce.tl.phenograph(adata, clustering_algo="leiden", k=50)
     >>> sc.tl.tsne(adata, random_state=1)

--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -11,12 +11,11 @@ import pandas as pd
 from matplotlib import colormaps, rcParams
 from matplotlib import pyplot as plt
 
-from scanpy.get import obs_df
-
 from ... import logging as logg
 from ..._settings import Default, settings
 from ..._utils import _doc_params, sanitize_anndata, with_cat_dtype
-from ...get import rank_genes_groups_df
+from ..._utils.random import _LegacyRng
+from ...get import obs_df, rank_genes_groups_df
 from .._anndata import ranking
 from .._docs import (
     doc_cm_palette,
@@ -47,6 +46,7 @@ if TYPE_CHECKING:
     from matplotlib.colors import Colormap, Normalize
     from matplotlib.figure import Figure
 
+    from ..._utils.random import RNGLike, SeedLike
     from .._baseplot_class import BasePlot
     from .._utils import DensityNorm
 
@@ -1312,6 +1312,7 @@ def sim(
     shuffle: bool = False,
     show: bool | None = None,
     marker: str | Sequence[str] = ".",
+    rng: SeedLike | RNGLike | None | Default = Default("0 (legacy)"),
     # deprecated
     save: bool | str | None = None,
 ) -> None:
@@ -1364,8 +1365,12 @@ def sim(
         )
         savefig_or_show("sim", save=save, show=show)
     else:  # shuffle data
-        np.random.seed(1)
-        rows = np.random.choice(adata.shape[0], size=adata.shape[0], replace=False)
+        rng = (
+            _LegacyRng.wrap_global(1)
+            if isinstance(rng, Default)
+            else np.random.default_rng(rng)
+        )
+        rows = rng.choice(adata.shape[0], size=adata.shape[0], replace=False)
         x = adata[rows].X
         timeseries(
             x,
@@ -1554,8 +1559,9 @@ def embedding_density(  # noqa: PLR0912, PLR0913, PLR0915
     color_map.set_under("lightgray")
     # a name to store the density values is needed. To avoid
     # overwriting a user name a new random name is created
+    rng = np.random.default_rng()
     while True:
-        col_id = np.random.randint(1000, 10000)
+        col_id = rng.integers(1000, 10000)
         density_col_name = f"_tmp_embedding_density_column_{col_id}_"
         if density_col_name not in adata.obs.columns:
             break

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -19,6 +19,7 @@ from packaging.version import Version
 from . import logging as logg
 from ._compat import deprecated, pkg_version, warn
 from ._settings import AnnDataFileFormat, Default, settings
+from ._utils.random import _LegacyRng
 
 if pkg_version("anndata") >= Version("0.11.0rc2"):
     from anndata.io import (
@@ -815,7 +816,11 @@ def write_params(path: PathLike[str] | str, *args, **maps):
             if header is not None:
                 f.write(f"[{header}]\n")
             for key, val in map.items():
-                f.write(f"{key} = {val}\n")
+                if key == "rng":
+                    if isinstance(val, _LegacyRng) and val.arg is not None:
+                        f.write(f"seed = {val.arg}\n")
+                else:
+                    f.write(f"{key} = {val}\n")
 
 
 # -------------------------------------------------------------------------------

--- a/src/scanpy/tools/_sim.py
+++ b/src/scanpy/tools/_sim.py
@@ -13,8 +13,6 @@ Beta Version. The code will be reorganized soon.
 from __future__ import annotations
 
 import itertools
-import shutil
-import sys
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING
@@ -24,7 +22,10 @@ import scipy as sp
 
 from .. import _utils, readwrite
 from .. import logging as logg
+from .._docs import doc_rng
 from .._settings import settings
+from .._utils import _doc_params
+from .._utils.random import _if_legacy_apply_global, _LegacyRng
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -32,8 +33,11 @@ if TYPE_CHECKING:
 
     from anndata import AnnData
 
+    from .._utils.random import RNGLike, SeedLike
 
-def sim(
+
+@_doc_params(rng=doc_rng)
+def sim(  # noqa: PLR0913
     model: Literal["krumsiek11", "toggleswitch"],
     *,
     params_file: bool = True,
@@ -43,10 +47,12 @@ def sim(
     noiseObs: float | None = None,
     noiseDyn: float | None = None,
     step: int | None = None,
-    seed: int | None = None,
+    rng: SeedLike | RNGLike | None = None,
     writedir: Path | str | None = None,
+    # deprecated
+    seed: int | None = None,
 ) -> AnnData:
-    """Simulate dynamic gene expression data :cite:p:`Wittmann2009` :cite:p:`Wolf2018`.
+    """Simulate dynamic gene expression data :cite:p:`Wittmann2009,Wolf2018`.
 
     Sample from a stochastic differential equation model built from
     literature-curated boolean gene regulatory networks, as suggested by
@@ -70,8 +76,7 @@ def sim(
         Dynamic noise.
     step
         Interval for saving state of system.
-    seed
-        Seed for generation of random numbers.
+    {rng}
     writedir
         Path to directory for writing output files.
 
@@ -85,6 +90,9 @@ def sim(
 
     """
     params = locals()
+    if seed is not None and rng is not None:
+        msg = "Cannot specify both `seed` and `rng`."
+        raise TypeError(msg)
     if params_file:
         model_key = Path(model).with_suffix("").name
         from .. import sim_models
@@ -92,6 +100,8 @@ def sim(
         pfile_sim = Path(sim_models.__file__).parent / f"{model_key}_params.txt"
         default_params = readwrite.read_params(pfile_sim)
         params = _utils.update_params(default_params, params)
+    params["rng"] = np.random.default_rng(rng) if rng is not None else _LegacyRng(seed)
+    del params["seed"]
     adata = sample_dynamic_data(**params)
     adata.uns["iroot"] = 0
     return adata
@@ -116,6 +126,7 @@ def add_args(p):
 
 
 def sample_dynamic_data(**params):  # noqa: PLR0912, PLR0915
+    rng: np.random.Generator = params["rng"]
     model_key = Path(params["model"]).with_suffix("").name
     writedir = params.get("writedir")
     if writedir is None:
@@ -152,7 +163,7 @@ def sample_dynamic_data(**params):  # noqa: PLR0912, PLR0915
                         for g in range(grnsim.dim):
                             # only consider off-diagonal edges
                             if g != gp:
-                                Coupl[gp, g] = 0.7 if np.random.rand() < 0.4 else 0
+                                Coupl[gp, g] = 0.7 if rng.random() < 0.4 else 0
                                 nrOffEdges += 1 if Coupl[gp, g] > 0 else 0
                             else:
                                 Coupl[gp, g] = 0.7
@@ -164,14 +175,14 @@ def sample_dynamic_data(**params):  # noqa: PLR0912, PLR0915
                 grnsim.set_coupl(Coupl)
             # init type
             real = 0
-            X0 = np.random.rand(grnsim.dim)
+            X0 = rng.random(grnsim.dim)
             Xsamples = []
             for restart in range(nrRealizations + maxRestarts):
                 # slightly break symmetry in initial conditions
                 if "toggleswitch" in model_key:
                     X0 = np.array([
                         0.8 for i in range(grnsim.dim)
-                    ]) + 0.01 * np.random.randn(grnsim.dim)
+                    ]) + 0.01 * rng.standard_normal(grnsim.dim)
                 X = grnsim.sim_model(tmax=tmax, X0=X0, noiseDyn=noiseDyn)
                 # check branching
                 check = True
@@ -190,7 +201,7 @@ def sample_dynamic_data(**params):  # noqa: PLR0912, PLR0915
                 # append some zeros
                 if "zeros" in writedir.name and real == 2:
                     grnsim.write_data(
-                        noiseDyn * np.random.randn(500, 3),
+                        noiseDyn * rng.standard_normal((500, 3)),
                         dir=writedir,
                         noiseObs=noiseObs,
                         append=restart != 0,
@@ -224,21 +235,21 @@ def sample_dynamic_data(**params):  # noqa: PLR0912, PLR0915
             for restart in range(nrRealizations + maxRestarts):
                 if initType == "branch":
                     # vary initial conditions around mean
-                    X0 = X0mean + (0.05 * np.random.rand(dim) - 0.025 * np.ones(dim))
+                    X0 = X0mean + (0.05 * rng.random(dim) - 0.025 * np.ones(dim))
                 else:
                     # generate random initial conditions within [0.3,0.7]
-                    X0 = 0.4 * np.random.rand(dim) + 0.3
+                    X0 = 0.4 * rng.random(dim) + 0.3
                 if model_key in [5, 6]:
                     X0 = np.array([0.3, 0.3, 0, 0, 0, 0])
                 if model_key in [7, 8, 9, 10]:
-                    X0 = 0.6 * np.random.rand(dim) + 0.2
+                    X0 = 0.6 * rng.random(dim) + 0.2
                     X0[2:] = np.zeros(4)
                 if "krumsiek11" in model_key:
                     X0 = np.zeros(dim)
                     X0[grnsim.varNames["Gata2"]] = 0.8
                     X0[grnsim.varNames["Pu.1"]] = 0.8
                     X0[grnsim.varNames["Cebpa"]] = 0.8
-                    X0 += 0.001 * np.random.randn(dim)
+                    X0 += 0.001 * rng.standard_normal(dim)
                     if False:
                         switch_gene = restart - (nrRealizations - dim)
                         if switch_gene >= dim:
@@ -423,7 +434,7 @@ class GRNsim:
         # set the coupling matrix, and with that the adjacency matrix
         self.set_coupl(Coupl=Coupl)
         # seed
-        np.random.seed(params["seed"])
+        _if_legacy_apply_global(params["rng"])
         # header
         self.header = f"model = {self.model.name} \n"
         # params
@@ -433,7 +444,7 @@ class GRNsim:
         """Simulate the model."""
         self.noiseDyn = noiseDyn
         X = np.zeros((tmax, self.dim))
-        X[0] = X0 + noiseDyn * np.random.randn(self.dim)
+        X[0] = X0 + noiseDyn * self.params["rng"].standard_normal(self.dim)
         # run simulation
         for t in range(1, tmax):
             if self.modelType == "hill":
@@ -445,7 +456,7 @@ class GRNsim:
                 raise ValueError(msg)
             X[t] = X[t - 1] + Xdiff
             # add dynamic noise
-            X[t] += noiseDyn * np.random.randn(self.dim)
+            X[t] += noiseDyn * self.params["rng"].standard_normal(self.dim)
         return X
 
     def Xdiff_hill(self, Xt):
@@ -604,25 +615,25 @@ class GRNsim:
         elif self.model in ["6", "7", "8", "9", "10"]:
             self.Adj_signed = np.zeros((self.dim, self.dim))
             n_sinknodes = 2
-            #             sinknodes = np.random.choice(self.dim, n_sinknodes, replace=False)
+            #             sinknodes = rng.choice(self.dim, n_sinknodes, replace=False)
             sinknodes = np.array([0, 1])
             # assume sinknodes have feeback
             self.Adj_signed[sinknodes, sinknodes] = np.ones(n_sinknodes)
             #             # allow negative feedback
             #             if self.model == 10:
-            #                 plus_minus = (np.random.randint(0,2,n_sinknodes) - 0.5)*2
-            #                 self.Adj_signed[sinknodes,sinknodes] = plus_minus
+            #                 plus_minus = (rng.integers(0, 2, n_sinknodes) - 0.5) * 2
+            #                 self.Adj_signed[sinknodes, sinknodes] = plus_minus
             leafnodes = np.array(sinknodes)
             availnodes = np.array([i for i in range(self.dim) if i not in sinknodes])
             #             settings.m(0,leafnodes,availnodes)
             while len(availnodes) != 0:
                 # parent
-                parent_idx = np.random.choice(
+                parent_idx = self.params["rng"].choice(
                     np.arange(0, len(leafnodes)), size=1, replace=False
                 )
                 parent = leafnodes[parent_idx]
                 # children
-                children_ids = np.random.choice(
+                children_ids = self.params["rng"].choice(
                     np.arange(0, len(availnodes)), size=2, replace=False
                 )
                 children = availnodes[children_ids]
@@ -645,13 +656,13 @@ class GRNsim:
         else:
             self.Adj = np.zeros((self.dim, self.dim))
             for i in range(self.dim):
-                indep = np.random.binomial(1, self.p_indep)
+                indep = self.params["rng"].binomial(1, self.p_indep)
                 if indep == 0:
                     # this number includes parents (other variables)
                     # and the variable itself, therefore its
                     # self.maxnpar+2 in the following line
-                    nr = np.random.randint(1, self.maxnpar + 2)
-                    j_par = np.random.choice(
+                    nr = self.params["rng"].integers(1, self.maxnpar + 2)
+                    j_par = self.params["rng"].choice(
                         np.arange(0, self.dim), size=nr, replace=False
                     )
                     self.Adj[i, j_par] = 1
@@ -671,11 +682,11 @@ class GRNsim:
                 # if there is a 1 in Adj, specify co and antiregulation
                 # and strength of regulation
                 if a != 0:
-                    co_anti = np.random.randint(2)
+                    co_anti = self.params["rng"].integers(2)
                     # set a lower bound for the coupling parameters
                     # they ought not to be smaller than 0.1
                     # and not be larger than 0.4
-                    self.Coupl[i, j] = 0.0 * np.random.rand() + 0.1
+                    self.Coupl[i, j] = 0.0 * self.params["rng"].random() + 0.1
                     # set sign for coupling
                     if co_anti == 1:
                         self.Coupl[i, j] *= -1
@@ -867,7 +878,7 @@ class GRNsim:
         header += f"noiseDyn = {self.noiseDyn}\n"
         header += f"seed = {seed}\n"
         # add observational noise
-        X += noiseObs * np.random.randn(tmax, self.dim)
+        X += noiseObs * self.params["rng"].standard_normal((tmax, self.dim))
         # call helper function
         write_data(
             X,
@@ -927,351 +938,3 @@ def _check_branching(
             Xsamples.append(X)
     logg.debug(f"realization {restart}: {'' if check else 'no'} new branch")
     return check, Xsamples
-
-
-def check_nocycles(Adj: np.ndarray, verbosity: int = 2) -> bool:
-    """Check that there are no cycles in graph described by adjacancy matrix.
-
-    Parameters
-    ----------
-    Adj
-        adjancancy matrix of dimension (dim, dim)
-
-    Returns
-    -------
-    True if there is no cycle, False otherwise.
-
-    """
-    dim = Adj.shape[0]
-    for g in range(dim):
-        v = np.zeros(dim)
-        v[g] = 1
-        for i in range(dim):
-            v = Adj.dot(v)
-            if v[g] > 1e-10:
-                if verbosity > 2:
-                    settings.m(0, Adj)
-                    settings.m(
-                        0,
-                        "contains a cycle of length",
-                        i + 1,
-                        "starting from node",
-                        g,
-                        "-> reject",
-                    )
-                return False
-    return True
-
-
-def sample_coupling_matrix(
-    dim: int = 3, connectivity: float = 0.5
-) -> tuple[np.ndarray, np.ndarray, np.ndarray, int]:
-    """Sample coupling matrix.
-
-    Checks that returned graphs contain no self-cycles.
-
-    Parameters
-    ----------
-    dim
-        dimension of coupling matrix.
-    connectivity
-        fraction of connectivity, fully connected means 1.,
-        not-connected means 0, in the case of fully connected, one has
-        dim*(dim-1)/2 edges in the graph.
-
-    Returns
-    -------
-    coupl
-        coupling matrix
-    adj
-        adjancancy matrix
-    adj_signed
-        signed adjacancy matrix
-    n_edges
-        Number of edges
-
-    """
-    for _attempt in range(max_attempt := 10):
-        # random topology for a given connectivity / edge density
-        Coupl = np.zeros((dim, dim))
-        n_edges = 0
-        for gp in range(dim):
-            for g in range(dim):
-                if gp == g:
-                    continue
-                # need to have the factor 0.5, otherwise
-                # connectivity=1 would lead to dim*(dim-1) edges
-                if np.random.rand() < 0.5 * connectivity:
-                    Coupl[gp, g] = 0.7
-                    n_edges += 1
-        # obtain adjacancy matrix
-        Adj_signed = np.zeros((dim, dim), dtype="int_")
-        Adj_signed = np.sign(Coupl)
-        Adj = np.abs(Adj_signed)
-        # check for cycles and whether there is at least one edge
-        if check_nocycles(Adj) and n_edges > 0:
-            break
-    else:
-        msg = f"did not find graph without cycles after {max_attempt} trials"
-        raise ValueError(msg)
-    return Coupl, Adj, Adj_signed, n_edges
-
-
-class StaticCauseEffect:
-    """Simulates static data to investigate structure learning."""
-
-    availModels: ClassVar = dict(
-        line="y = αx \n",
-        noise="y = noise \n",
-        absline="y = |x| \n",
-        parabola="y = αx² \n",
-        sawtooth="y = x - |x| \n",
-        tanh="y = tanh(x) \n",
-        combi="combinatorial regulation \n",
-    )
-
-    def __init__(self):
-        # define a set of available functions
-        self.funcs = dict(
-            line=lambda x: x,
-            noise=lambda x: 0,
-            absline=np.abs,
-            parabola=lambda x: x**2,
-            sawtooth=lambda x: 0.5 * x - np.floor(0.5 * x),
-            tanh=lambda x: np.tanh(2 * x),
-        )
-
-    def sim_givenAdj(self, Adj: np.ndarray, model="line"):
-        """Simulate data given only an adjacancy matrix and a model.
-
-        The model is a bivariate funtional dependence. The adjacancy matrix
-        needs to be acyclic.
-
-        Parameters
-        ----------
-        Adj
-            adjacancy matrix of shape (dim,dim).
-
-        Returns
-        -------
-        Data array of shape (n_samples,dim).
-
-        """
-        # nice examples
-        examples = [  # noqa: F841 TODO We are really unsure whether this is needed.
-            dict(
-                func="sawtooth",
-                gdist="uniform",
-                sigma_glob=1.8,
-                sigma_noise=0.1,
-            )
-        ]
-
-        # nr of samples
-        n_samples = 100
-
-        # noise
-        sigma_glob = 1.8
-        sigma_noise = 0.4
-
-        # coupling function / model
-        func = self.funcs[model]
-
-        # glob distribution
-        sourcedist = "uniform"
-
-        # loop over source nodes
-        dim = Adj.shape[0]
-        X = np.zeros((n_samples, dim))
-        # source nodes have no parents themselves
-        nrpar = 0
-        children = list(range(dim))
-        parents = []
-        for gp in range(dim):
-            if Adj[gp, :].sum() == nrpar:
-                if sourcedist == "gaussian":
-                    X[:, gp] = np.random.normal(0, sigma_glob, n_samples)
-                if sourcedist == "uniform":
-                    X[:, gp] = np.random.uniform(-sigma_glob, sigma_glob, n_samples)
-                parents.append(gp)
-                children.remove(gp)
-
-        # all of the following guarantees for 3 dim, that we generate the data
-        # in the correct sequence
-        # then compute all nodes that have 1 parent, then those with 2 parents
-        children_sorted = []
-        nrchildren_par = np.zeros(dim)
-        nrchildren_par[0] = len(parents)
-        for nrpar in range(1, dim):
-            # loop over child nodes
-            for gp in children:
-                if Adj[gp, :].sum() == nrpar:
-                    children_sorted.append(gp)
-                    nrchildren_par[nrpar] += 1
-        # if there is more than a child with a single parent
-        # order these children (there are two in three dim)
-        # by distance to the source/parent
-        if nrchildren_par[1] > 1 and Adj[children_sorted[0], parents[0]] == 0:
-            help = children_sorted[0]
-            children_sorted[0] = children_sorted[1]
-            children_sorted[1] = help
-
-        for gp in children_sorted:
-            for g in range(dim):
-                if Adj[gp, g] > 0:
-                    X[:, gp] += 1.0 / Adj[gp, :].sum() * func(X[:, g])
-            X[:, gp] += np.random.normal(0, sigma_noise, n_samples)
-
-        #         fig = pl.figure()
-        #         fig.add_subplot(311)
-        #         pl.plot(X[:,0],X[:,1],'.',mec='white')
-        #         fig.add_subplot(312)
-        #         pl.plot(X[:,1],X[:,2],'.',mec='white')
-        #         fig.add_subplot(313)
-        #         pl.plot(X[:,2],X[:,0],'.',mec='white')
-        #         pl.show()
-
-        return X
-
-    def sim_combi(self):
-        """Simulate data to model combi regulation."""
-        n_samples = 500
-        sigma_glob = 1.8
-
-        X = np.zeros((n_samples, 3))
-
-        X[:, 0] = np.random.uniform(-sigma_glob, sigma_glob, n_samples)
-        X[:, 1] = np.random.uniform(-sigma_glob, sigma_glob, n_samples)
-
-        func = self.funcs["tanh"]
-
-        # XOR type
-        #         X[:,2] = (func(X[:,0])*sp.stats.norm.pdf(X[:,1],0,0.2)
-        #                   + func(X[:,1])*sp.stats.norm.pdf(X[:,0],0,0.2))
-        # AND type / diagonal
-        #         X[:,2] = (func(X[:,0]+X[:,1])*sp.stats.norm.pdf(X[:,1]-X[:,0],0,0.2))
-        # AND type / horizontal
-        X[:, 2] = func(X[:, 0]) * sp.stats.norm.cdf(X[:, 1], 1, 0.2)
-
-        pl.scatter(  # noqa: F821  TODO Fix me
-            X[:, 0], X[:, 1], c=X[:, 2], edgecolor="face"
-        )
-        pl.show()  # noqa: F821  TODO Fix me
-
-        pl.plot(X[:, 1], X[:, 2], ".")  # noqa: F821  TODO Fix me
-        pl.show()  # noqa: F821  TODO Fix me
-
-        return X
-
-
-def sample_static_data(model, dir, verbosity=0):
-    # fraction of connectivity as compared to fully connected
-    # in one direction, which amounts to dim*(dim-1)/2 edges
-    connectivity = 0.8
-    dim = 3
-    n_Coupls = 50
-    model = model.replace("static-", "")
-    np.random.seed(0)
-
-    if model != "combi":
-        n_edges = np.zeros(n_Coupls)
-        for icoupl in range(n_Coupls):
-            _coupl, adj, _adj_signed, n_e = sample_coupling_matrix(dim, connectivity)
-            if verbosity > 1:
-                settings.m(0, icoupl)
-                settings.m(0, adj)
-            n_edges[icoupl] = n_e
-            # sample data
-            X = StaticCauseEffect().sim_givenAdj(adj, model)
-            write_data(X, dir, Adj=adj)
-        settings.m(0, "mean edge number:", n_edges.mean())
-
-    else:
-        X = StaticCauseEffect().sim_combi()
-        adj = np.zeros((3, 3))
-        adj[2, 0] = adj[2, 1] = 0
-        write_data(X, dir, Adj=adj)
-
-
-if __name__ == "__main__":
-    import argparse
-
-    #     epilog = (
-    #         "    1: 2dim, causal direction X_1 -> X_0, constraint signs\n"
-    #         "    2: 2dim, causal direction X_1 -> X_0, arbitrary signs\n"
-    #         "    3: 2dim, causal direction X_1 <-> X_0, arbitrary signs\n"
-    #         "    4: 2dim, mix of model 2 and 3\n"
-    #         "    5: 6dim double toggle switch\n"
-    #         "    6: two independent evolutions without repression, sync.\n"
-    #         "    7: two independent evolutions without repression, random init\n"
-    #         "    8: two independent evolutions directed repression, random init\n"
-    #         "    9: two independent evolutions mutual repression, random init\n"
-    #         "   10: two indep. evol., diff. self-loops possible, mut. repr., rand init\n"
-    #     )
-    epilog = ""
-    for k, v in StaticCauseEffect.availModels.items():
-        epilog += f"    static-{k}: {v}"
-    for k, v in GRNsim.availModels.items():
-        epilog += f"    {k}: {v}"
-    # command line options
-    p = argparse.ArgumentParser(
-        description=(
-            "Simulate stochastic discrete-time dynamical systems,\n"
-            "in particular gene regulatory networks."
-        ),
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        epilog=(
-            "  MODEL: specify one of the following models, or one of \n"
-            '    the filenames (without ".txt") in the directory "models" \n' + epilog
-        ),
-    )
-    aa = p.add_argument
-    dir_arg = aa(
-        "--dir",
-        required=True,
-        type=str,
-        default="",
-        help=(
-            "specify directory to store data, "
-            ' must start with "sim/MODEL_...", see possible values for MODEL below '
-        ),
-    )
-    aa("--show", action="store_true", help="show plots")
-    aa(
-        "--verbosity",
-        type=int,
-        default=0,
-        help="specify integer > 0 to get more output [default 0]",
-    )
-    args = p.parse_args()
-
-    # run checks on output directory
-    dir = Path(args.dir)
-    if not dir.resolve().parent.name == "sim":
-        raise argparse.ArgumentError(
-            dir_arg,
-            "The parent directory of the --dir argument needs to be named 'sim'",
-        )
-    else:
-        model = dir.name.split("_")[0]
-        settings.m(0, f"...model is: {model!r}")
-    if dir.is_dir() and "test" not in str(dir):
-        message = (
-            f"directory {dir} already exists, "
-            "remove it and continue? [y/n, press enter]"
-        )
-        if str(input(message)) != "y":
-            settings.m(0, "    ...quit program execution")
-            sys.exit()
-        else:
-            settings.m(0, "   ...removing directory and continuing...")
-            shutil.rmtree(dir)
-
-    settings.m(0, model)
-    settings.m(0, dir)
-
-    # sample data
-    if "static" in model:
-        sample_static_data(model=model, dir=dir, verbosity=args.verbosity)
-    else:
-        sample_dynamic_data(model=model, dir=dir)

--- a/src/testing/scanpy/_pytest/fixtures/data.py
+++ b/src/testing/scanpy/_pytest/fixtures/data.py
@@ -55,17 +55,24 @@ def pbmc3k_parametrized_small(pbmc3ks_parametrized_session) -> Callable[[], AnnD
     return pbmc3ks_parametrized_session[True].copy
 
 
-def random_csr(m: int, n: int) -> CSRBase:
-    return sparse.random(m, n, format="csr")
+def random_csr(rng: np.random.Generator, size: tuple[int, int]) -> CSRBase:
+    m, n = size
+    return sparse.random(m, n, format="csr", random_state=rng)
 
 
-@pytest.fixture(params=[np.random.randn, random_csr], ids=["sparse", "dense"])
+@pytest.fixture(
+    params=[np.random.Generator.standard_normal, random_csr], ids=["sparse", "dense"]
+)
 def backed_adata(request: pytest.FixtureRequest, tmp_path: Path) -> AnnData:
-    rand_func = cast("Callable[[int, int], np.ndarray | CSRBase]", request.param)
-    x = rand_func(200, 10).astype(np.float32)
-    cat = np.random.randint(0, 3, (x.shape[0],)).ravel()
+    rng = np.random.default_rng()
+    rand_func = cast(
+        "Callable[[np.random.Generator, tuple[int, int]], np.ndarray | CSRBase]",
+        request.param,
+    )
+    x = rand_func(rng, (200, 10)).astype(np.float32)
+    cat = rng.integers(0, 3, (x.shape[0],)).ravel()
     adata = AnnData(x, obs={"cat": cat})
-    adata.obs["percent_mito"] = np.random.rand(x.shape[0])
+    adata.obs["percent_mito"] = rng.random(x.shape[0])
     adata.obs["n_counts"] = x.sum(axis=1)
     adata.obs["cat"] = adata.obs["cat"].astype("category")
     adata.layers["X_copy"] = adata.X[...]
@@ -102,8 +109,8 @@ def _prepare_pbmc_testdata(
     if small:
         adata = adata[:1000, :500].copy()
         sc.pp.filter_cells(adata, min_genes=1)
-    np.random.seed(42)
-    adata.obs["batch"] = np.random.randint(0, 3, size=adata.shape[0])
+    rng = np.random.default_rng()
+    adata.obs["batch"] = rng.integers(0, 3, size=adata.shape[0])
     sc.pp.filter_genes(adata, min_cells=1)
     adata.X = sparsity_func(adata.X.astype(dtype))
     return adata

--- a/tests/external/test_hashsolo.py
+++ b/tests/external/test_hashsolo.py
@@ -10,14 +10,13 @@ import scanpy.external as sce
 
 
 def test_cell_demultiplexing():
-    import random
-
     from scipy import stats
 
-    random.seed(52)
-    signal = stats.poisson.rvs(1000, 1, 990)
-    doublet_signal = stats.poisson.rvs(1000, 1, 10)
-    x = np.reshape(stats.poisson.rvs(500, 1, 10000), (1000, 10))
+    rng = np.random.default_rng()
+
+    signal = stats.poisson.rvs(1000, 1, 990, random_state=rng)
+    doublet_signal = stats.poisson.rvs(1000, 1, 10, random_state=rng)
+    x = np.reshape(stats.poisson.rvs(500, 1, 10000, random_state=rng), (1000, 10))
     for idx, signal_count in enumerate(signal):
         col_pos = idx % 10
         x[idx, col_pos] = signal_count
@@ -28,9 +27,7 @@ def test_cell_demultiplexing():
 
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=ImplicitModificationWarning)
-        test_data = AnnData(
-            np.random.randint(0, 100, size=x.shape), obs=pd.DataFrame(x)
-        )
+        test_data = AnnData(rng.integers(0, 100, size=x.shape), obs=pd.DataFrame(x))
     sce.pp.hashsolo(test_data, test_data.obs.columns)
 
     doublets = ["Doublet"] * 10

--- a/tests/external/test_phenograph.py
+++ b/tests/external/test_phenograph.py
@@ -12,7 +12,8 @@ pytestmark = [needs.phenograph]
 
 
 def test_phenograph():
-    df = np.random.rand(1000, 40)
+    rng = np.random.default_rng()
+    df = rng.random((1000, 40))
     dframe = pd.DataFrame(df)
     dframe.index, dframe.columns = (map(str, dframe.index), map(str, dframe.columns))
     adata = AnnData(dframe)

--- a/tests/external/test_sam.py
+++ b/tests/external/test_sam.py
@@ -11,8 +11,9 @@ pytestmark = [needs.samalg]
 
 
 def test_sam():
+    rng = np.random.default_rng()
     adata_ref = pbmc3k()
-    ix = np.random.choice(adata_ref.shape[0], size=200, replace=False)
+    ix = rng.choice(adata_ref.shape[0], size=200, replace=False)
     adata = adata_ref[ix, :].copy()
     sc.pp.normalize_total(adata, target_sum=10000)
     sc.pp.log1p(adata)

--- a/tests/notebooks/test_pbmc3k.py
+++ b/tests/notebooks/test_pbmc3k.py
@@ -33,7 +33,8 @@ ROOT = HERE / "_images_pbmc3k"
 @pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")
 def test_pbmc3k(subtests: pytest.Subtests, image_comparer) -> None:  # noqa: PLR0915
     # ensure violin plots and other non-determinstic plots have deterministic behavior
-    np.random.seed(0)
+    # TODO: rework this test for scanpy 2.0 so this is no longer necessary
+    np.random.seed(0)  # noqa: NPY002
     save_and_compare_images = partial(image_comparer, ROOT, tol=20)
     adata = sc.datasets.pbmc3k()
 

--- a/tests/test_combat.py
+++ b/tests/test_combat.py
@@ -29,15 +29,15 @@ def test_norm():
 
 
 def test_covariates():
+    rng = np.random.default_rng()
     adata = sc.datasets.blobs()
     key = "blobs"
 
     x1 = sc.pp.combat(adata, key=key, inplace=False)
 
-    np.random.seed(0)
-    adata.obs["cat1"] = np.random.binomial(3, 0.5, size=(adata.n_obs))
-    adata.obs["cat2"] = np.random.binomial(2, 0.1, size=(adata.n_obs))
-    adata.obs["num1"] = np.random.normal(size=(adata.n_obs))
+    adata.obs["cat1"] = rng.binomial(3, 0.5, size=adata.n_obs)
+    adata.obs["cat2"] = rng.binomial(2, 0.1, size=adata.n_obs)
+    adata.obs["num1"] = rng.standard_normal(adata.n_obs)
 
     x2 = sc.pp.combat(
         adata, key=key, covariates=["cat1", "cat2", "num1"], inplace=False
@@ -54,10 +54,11 @@ def test_covariates():
 
 
 def test_combat_obs_names():
-    # Test for fix to #1170
-    x = np.random.random((200, 100))
+    """Regression test for <https://github.com/scverse/scanpy/issues/1170>."""
+    rng = np.random.default_rng()
+    x = rng.random((200, 100))
     obs = pd.DataFrame(
-        {"batch": pd.Categorical(np.random.randint(0, 2, 200))},
+        {"batch": pd.Categorical(rng.integers(0, 2, (200,)))},
         index=np.repeat(np.arange(100), 2).astype(str),  # Non-unique index
     )
     with pytest.warns(UserWarning, match="Observation names are not unique"):

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -93,8 +93,9 @@ def test_krumsiek11():
 
 
 def test_blobs():
-    n_obs = np.random.randint(15, 30)
-    n_var = np.random.randint(500, 600)
+    rng = np.random.default_rng()
+    n_obs = rng.integers(15, 30)
+    n_var = rng.integers(500, 600)
     adata = sc.datasets.blobs(n_variables=n_var, n_observations=n_obs)
     assert adata.shape == (n_obs, n_var)
 

--- a/tests/test_highly_variable_genes.py
+++ b/tests/test_highly_variable_genes.py
@@ -569,8 +569,9 @@ def test_batches() -> None:
 
 @pytest.mark.filterwarnings("ignore:invalid value encountered:RuntimeWarning")
 def test_degenerate_batches():
+    rng = np.random.default_rng()
     adata = AnnData(
-        X=np.random.randn(10, 100),
+        X=rng.standard_normal((10, 100)),
         obs=dict(batch=pd.Categorical([*([1] * 4), *([2] * 5), 3])),
     )
     sc.pp.highly_variable_genes(adata, batch_key="batch")
@@ -595,7 +596,8 @@ def test_seurat_v3_mean_var_output_with_batchkey():
 
 
 def test_cellranger_n_top_genes_warning():
-    x = np.random.poisson(2, (100, 30))
+    rng = np.random.default_rng()
+    x = rng.poisson(2, (100, 30))
     adata = AnnData(x)
     sc.pp.normalize_total(adata)
     sc.pp.log1p(adata)

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -249,7 +249,8 @@ def test_metrics_argument():
 
 
 def test_use_rep_argument():
-    adata = AnnData(np.random.randn(30, 300))
+    rng = np.random.default_rng()
+    adata = AnnData(rng.standard_normal((30, 300)))
     sc.pp.pca(adata)
     neigh_pca = Neighbors(adata)
     neigh_pca.compute_neighbors(n_pcs=5, use_rep="X_pca")

--- a/tests/test_neighbors_common.py
+++ b/tests/test_neighbors_common.py
@@ -29,8 +29,9 @@ def mk_knn_matrix(
     style: Literal["basic", "rapids", "sklearn"],
     duplicates: bool = False,
 ) -> CSRBase:
+    rng = np.random.default_rng()
     n_col = n_neighbors + (1 if style == "sklearn" else 0)
-    dists = np.abs(np.random.randn(n_obs, n_col)) + 1e-8
+    dists = np.abs(rng.standard_normal((n_obs, n_col))) + 1e-8
     idxs = np.arange(n_obs * n_col).reshape((n_col, n_obs)).T
     if style == "rapids":
         idxs[:, 0] += 1  # does not include cell itself
@@ -80,7 +81,9 @@ def test_ind_dist_shortcut_manual(
         pytest.param(
             lambda n_obs, n_neighbors: KNeighborsTransformer(
                 n_neighbors=n_neighbors
-            ).fit_transform(np.random.randn(n_obs, n_obs // 4)),
+            ).fit_transform(
+                np.random.default_rng().standard_normal((n_obs, n_obs // 4))
+            ),
             id="sklearn_auto",
         )
     ],

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -283,11 +283,13 @@ def test_pca_shapes():
 
     See <https://github.com/scverse/scanpy/issues/1051>
     """
-    adata = AnnData(np.random.randn(30, 20))
+    rng = np.random.default_rng()
+
+    adata = AnnData(rng.standard_normal((30, 20)))
     sc.pp.pca(adata)
     assert adata.obsm["X_pca"].shape == (30, 19)
 
-    adata = AnnData(np.random.randn(20, 30))
+    adata = AnnData(rng.standard_normal((20, 30)))
     sc.pp.pca(adata)
     assert adata.obsm["X_pca"].shape == (20, 19)
 
@@ -438,8 +440,9 @@ def test_obsm_mask_error(mask_type: Literal["highly_variable", "array"]) -> None
 
 def test_mask_var_argument_equivalence(float_dtype, array_type):
     """Test if pca result is equal when given mask as boolarray vs string."""
-    adata_base = AnnData(array_type(np.random.random((100, 10))).astype(float_dtype))
-    mask_var = _helpers.random_mask(adata_base.shape[1])
+    rng = np.random.default_rng()
+    adata_base = AnnData(array_type(rng.random((100, 10))).astype(float_dtype))
+    mask_var = _helpers.random_mask(adata_base.shape[1], rng=rng)
 
     adata = adata_base.copy()
     sc.pp.pca(adata, mask_var=mask_var, dtype=float_dtype)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1615,10 +1615,11 @@ def test_no_copy():
     # https://github.com/scverse/scanpy/issues/1000
     # Tests that plotting functions don't make a copy from a view unless they
     # actually have to
+    rng = np.random.default_rng()
     actual = pbmc68k_reduced()
     sc.pl.umap(actual, color=["bulk_labels", "louvain"], show=False)  # Set colors
 
-    view = actual[np.random.choice(actual.obs_names, size=actual.shape[0] // 5), :]
+    view = actual[rng.choice(actual.obs_names, size=actual.shape[0] // 5), :]
 
     sc.pl.umap(view, color=["bulk_labels", "louvain"], show=False)
     assert view.is_view
@@ -1676,18 +1677,18 @@ def test_groupby_index(image_comparer):
     save_and_compare_images("dotplot_groupby_index")
 
 
-# test category order when groupby is a list (#1735)
-def test_groupby_list(image_comparer):
+def test_groupby_list(image_comparer) -> None:
+    """Test category order when groupby is a list.
+
+    See <https://github.com/scverse/scanpy/issues/1735>
+    """
     save_and_compare_images = partial(image_comparer, ROOT, tol=30)
-
+    rng = np.random.default_rng()
     adata = krumsiek11()
-
-    np.random.seed(1)
-
     cat_val = adata.obs.cell_type.tolist()
-    np.random.shuffle(cat_val)
+    rng.shuffle(cat_val)
     cats = adata.obs.cell_type.cat.categories.tolist()
-    np.random.shuffle(cats)
+    rng.shuffle(cats)
     adata.obs["rand_cat"] = pd.Categorical(cat_val, categories=cats)
 
     with mpl.rc_context({"figure.subplot.bottom": 0.5}):
@@ -1698,7 +1699,8 @@ def test_groupby_list(image_comparer):
             swap_axes=True,
             show=False,
         )
-        save_and_compare_images("dotplot_groupby_list_catorder")
+
+    save_and_compare_images("dotplot_groupby_list_catorder")
 
 
 def test_color_cycler(caplog):
@@ -1721,12 +1723,14 @@ def test_color_cycler(caplog):
 
 def test_repeated_colors_w_missing_value():
     # https://github.com/scverse/scanpy/issues/2133
+    rng = np.random.default_rng()
+
     v = pd.Series(np.arange(10).astype(str))
     v[0] = np.nan
     v = v.astype("category")
 
     ad = sc.AnnData(obs=dict(value=v))
-    ad.obsm["X_umap"] = np.random.normal(size=(ad.n_obs, 2))
+    ad.obsm["X_umap"] = rng.standard_normal((ad.n_obs, 2))
 
     sc.pl.umap(ad, color="value", show=False)
 

--- a/tests/test_plotting_utils.py
+++ b/tests/test_plotting_utils.py
@@ -49,9 +49,10 @@ def test_validate_palette_no_mod(palette, typ):
 )
 def test_check_all_in_axis(
     *, axis_name: Literal["obs", "var"], args: dict[str, Any], expected: bool
-):
+) -> None:
+    rng = np.random.default_rng()
     raw = AnnData(
-        np.random.randn(10, 20),
+        rng.standard_normal((10, 20)),
         dict(obs_a=range(10), obs_names=list(ascii_lowercase[:10])),
         dict(var_a=range(20), var_names=list(ascii_uppercase[:20])),
     )

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -363,7 +363,9 @@ def test_recipe_plotting() -> None:
 
 def test_regress_out_ordinal():
     rng = np.random.default_rng()
-    adata = AnnData(sparse.random(1000, 100, density=0.6, format="csr", rng=rng))
+    adata = AnnData(
+        sparse.random(1000, 100, density=0.6, format="csr", random_state=rng)
+    )
     adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
 
@@ -404,7 +406,7 @@ def test_regress_out_layer(dtype):
     rng = np.random.default_rng()
     adata = AnnData(
         sparse.random(
-            1000, 100, density=0.6, format="csr", dtype=np.uint16, rng=rng
+            1000, 100, density=0.6, format="csr", dtype=np.uint16, random_state=rng
         ).astype(dtype)
     )
     adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
@@ -430,7 +432,9 @@ def test_regress_out_layer(dtype):
 
 def test_regress_out_view():
     rng = np.random.default_rng()
-    adata = AnnData(sparse.random(500, 1100, density=0.2, format="csr", rng=rng))
+    adata = AnnData(
+        sparse.random(500, 1100, density=0.2, format="csr", random_state=rng)
+    )
     adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
     subset_adata = adata[:, :1050]
@@ -446,7 +450,9 @@ def test_regress_out_view():
 
 def test_regress_out_categorical():
     rng = np.random.default_rng()
-    adata = AnnData(sparse.random(1000, 100, density=0.6, format="csr", rng=rng))
+    adata = AnnData(
+        sparse.random(1000, 100, density=0.6, format="csr", random_state=rng)
+    )
     # create a categorical column
     adata.obs["batch"] = pd.Categorical(rng.integers(1, 4, size=adata.X.shape[0]))
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -60,8 +60,9 @@ def zero_center(request: pytest.FixtureRequest) -> bool:
     return request.param
 
 
-def test_log1p(tmp_path):
-    a = np.random.rand(200, 10).astype(np.float32)
+def test_log1p(tmp_path: Path) -> None:
+    rng = np.random.default_rng()
+    a = rng.random((200, 10)).astype(np.float32)
     a_log = np.log1p(a)
     ad = AnnData(a.copy())
     ad2 = AnnData(a.copy())
@@ -95,7 +96,8 @@ def test_log1p_rep(count_matrix_format: _MatrixFormat, base, dtype: DTypeLike) -
 
 def _random_probs(n: int, frac_zero: float) -> NDArray[np.float64]:
     """Generate a random probability distribution of `n` values between 0 and 1."""
-    probs = np.random.randint(0, 10000, n).astype(np.float64)
+    rng = np.random.default_rng()
+    probs = rng.integers(0, 10000, n).astype(np.float64)
     probs[probs < np.quantile(probs, frac_zero)] = 0
     probs /= probs.sum()
     np.testing.assert_almost_equal(probs.sum(), 1)
@@ -230,7 +232,8 @@ def test_sample_backwards_compat():
 
 
 def test_sample_copy_backed(tmp_path):
-    adata_m = AnnData(np.random.rand(200, 10).astype(np.float32))
+    rng = np.random.default_rng()
+    adata_m = AnnData(rng.random((200, 10)).astype(np.float32))
     adata_d = adata_m.copy()
     adata_d.filename = tmp_path / "test.h5ad"
 
@@ -241,8 +244,9 @@ def test_sample_copy_backed(tmp_path):
     )
 
 
-def test_sample_copy_backed_error(tmp_path):
-    adata_d = AnnData(np.random.rand(200, 10).astype(np.float32))
+def test_sample_copy_backed_error(tmp_path: Path) -> None:
+    rng = np.random.default_rng()
+    adata_d = AnnData(rng.random((200, 10)).astype(np.float32))
     adata_d.filename = tmp_path / "test.h5ad"
     with pytest.raises(NotImplementedError):
         sc.pp.sample(adata_d, n=40, copy=False)
@@ -348,31 +352,31 @@ def test_scale_array(*, count_matrix_format: _MatrixFormat, zero_center: bool) -
 # https://github.com/pandas-dev/pandas/issues/61928
 @pytest.mark.filterwarnings("ignore:invalid value encountered in cast:RuntimeWarning")
 def test_recipe_plotting() -> None:
+    rng = np.random.default_rng()
     sc.settings.autoshow = False
-    adata = AnnData(np.random.randint(0, 1000, (1000, 1000)))
+    adata = AnnData(rng.integers(0, 1000, (1000, 1000)))
+
     # These shouldn't throw an error
     sc.pp.recipe_seurat(adata.copy(), plot=True)
     sc.pp.recipe_zheng17(adata.copy(), plot=True)
 
 
 def test_regress_out_ordinal():
-    from scipy.sparse import random
-
-    adata = AnnData(random(1000, 100, density=0.6, format="csr"))
-    adata.obs["percent_mito"] = np.random.rand(adata.X.shape[0])
+    rng = np.random.default_rng()
+    adata = AnnData(sparse.random(1000, 100, density=0.6, format="csr", rng=rng))
+    adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
 
     # results using only one processor
     single = sc.pp.regress_out(
         adata, keys=["n_counts", "percent_mito"], n_jobs=1, copy=True
     )
-    assert adata.X.shape == single.X.shape
-
     # results using 8 processors
     multi = sc.pp.regress_out(
         adata, keys=["n_counts", "percent_mito"], n_jobs=8, copy=True
     )
 
+    assert adata.X.shape == single.X.shape
     np.testing.assert_array_equal(single.X, multi.X)
 
 
@@ -397,12 +401,13 @@ def test_regress_out_int(dtype):
 
 @pytest.mark.parametrize("dtype", [np.int64, np.float64, np.int32])
 def test_regress_out_layer(dtype):
-    from scipy.sparse import random
-
+    rng = np.random.default_rng()
     adata = AnnData(
-        random(1000, 100, density=0.6, format="csr", dtype=np.uint16).astype(dtype)
+        sparse.random(
+            1000, 100, density=0.6, format="csr", dtype=np.uint16, rng=rng
+        ).astype(dtype)
     )
-    adata.obs["percent_mito"] = np.random.rand(adata.X.shape[0])
+    adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
     if dtype == np.float64:
         dtype_cast = dtype
@@ -415,49 +420,50 @@ def test_regress_out_layer(dtype):
     single = sc.pp.regress_out(
         adata, keys=["n_counts", "percent_mito"], n_jobs=1, copy=True
     )
-    assert adata.X.shape == single.X.shape
-
     layer = sc.pp.regress_out(
         adata, layer="counts", keys=["n_counts", "percent_mito"], n_jobs=1, copy=True
     )
 
+    assert adata.X.shape == single.X.shape
     np.testing.assert_allclose(single.X, layer.layers["counts"])
 
 
 def test_regress_out_view():
-    from scipy.sparse import random
-
-    adata = AnnData(random(500, 1100, density=0.2, format="csr"))
-    adata.obs["percent_mito"] = np.random.rand(adata.X.shape[0])
+    rng = np.random.default_rng()
+    adata = AnnData(sparse.random(500, 1100, density=0.2, format="csr", rng=rng))
+    adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
     subset_adata = adata[:, :1050]
     subset_adata_copy = subset_adata.copy()
+
     with pytest.warns(UserWarning, match=r"Received a view"):
         sc.pp.regress_out(subset_adata, keys=["n_counts", "percent_mito"])
     sc.pp.regress_out(subset_adata_copy, keys=["n_counts", "percent_mito"])
+
     assert_equal(subset_adata, subset_adata_copy)
     assert not subset_adata.is_view
 
 
 def test_regress_out_categorical():
-    import pandas as pd
-    from scipy.sparse import random
-
-    adata = AnnData(random(1000, 100, density=0.6, format="csr"))
+    rng = np.random.default_rng()
+    adata = AnnData(sparse.random(1000, 100, density=0.6, format="csr", rng=rng))
     # create a categorical column
-    adata.obs["batch"] = pd.Categorical(np.random.randint(1, 4, size=adata.X.shape[0]))
+    adata.obs["batch"] = pd.Categorical(rng.integers(1, 4, size=adata.X.shape[0]))
 
     multi = sc.pp.regress_out(adata, keys="batch", n_jobs=8, copy=True)
+
     assert adata.X.shape == multi.X.shape
 
 
 def test_regress_out_constants():
+    rng = np.random.default_rng()
     adata = AnnData(np.hstack((np.full((10, 1), 0.0), np.full((10, 1), 1.0))))
-    adata.obs["percent_mito"] = np.random.rand(adata.X.shape[0])
+    adata.obs["percent_mito"] = rng.random(adata.X.shape[0])
     adata.obs["n_counts"] = adata.X.sum(axis=1)
     adata_copy = adata.copy()
 
     sc.pp.regress_out(adata, keys=["n_counts", "percent_mito"])
+
     assert_equal(adata, adata_copy)
 
 
@@ -497,8 +503,9 @@ def test_regress_out_constants_equivalent():
 def test_downsample_counts_per_cell(
     *, count_matrix_format: _MatrixFormat, replace: bool, dtype: DTypeLike
 ) -> None:
+    rng = np.random.default_rng()
     target = 1000
-    x = np.random.randint(0, 100, (1000, 100)) * np.random.binomial(1, 0.3, (1000, 100))
+    x = rng.integers(0, 100, (1000, 100)) * rng.binomial(1, 0.3, (1000, 100))
     x = x.astype(dtype)
     adata = AnnData(X=count_matrix_format(x).astype(dtype))
     with pytest.raises(ValueError, match=r"Must specify exactly one"):
@@ -530,8 +537,9 @@ def test_downsample_counts_per_cell(
 def test_downsample_counts_per_cell_multiple_targets(
     *, count_matrix_format: _MatrixFormat, replace: bool, dtype: DTypeLike
 ) -> None:
-    targets = np.random.randint(500, 1500, 1000)
-    x = np.random.randint(0, 100, (1000, 100)) * np.random.binomial(1, 0.3, (1000, 100))
+    rng = np.random.default_rng()
+    targets = rng.integers(500, 1500, (1000,))
+    x = rng.integers(0, 100, (1000, 100)) * rng.binomial(1, 0.3, (1000, 100))
     x = x.astype(dtype)
     adata = AnnData(X=count_matrix_format(x).astype(dtype))
     initial_totals = np.ravel(adata.X.sum(axis=1))
@@ -560,7 +568,8 @@ def test_downsample_counts_per_cell_multiple_targets(
 def test_downsample_total_counts(
     *, count_matrix_format: _MatrixFormat, replace: bool, dtype: DTypeLike
 ) -> None:
-    x = np.random.randint(0, 100, (1000, 100)) * np.random.binomial(1, 0.3, (1000, 100))
+    rng = np.random.default_rng()
+    x = rng.integers(0, 100, (1000, 100)) * rng.binomial(1, 0.3, (1000, 100))
     x = x.astype(dtype)
     adata_orig = AnnData(X=count_matrix_format(x))
     total = x.sum()

--- a/tests/test_qc_metrics.py
+++ b/tests/test_qc_metrics.py
@@ -25,7 +25,8 @@ from testing.scanpy._pytest.params import ARRAY_TYPES, ARRAY_TYPES_MEM
 
 @pytest.fixture
 def adata() -> AnnData:
-    a = np.random.binomial(100, 0.005, (1000, 1000))
+    rng = np.random.default_rng()
+    a = rng.binomial(100, 0.005, (1000, 1000))
     adata = AnnData(
         sparse.csr_matrix(a),  # noqa: TID251
         obs=pd.DataFrame(index=[f"cell{i}" for i in range(a.shape[0])]),
@@ -245,8 +246,9 @@ def test_dask_against_in_memory(adata, log1p):
 
 @pytest.fixture
 def adata_mito() -> AnnData:
+    rng = np.random.default_rng()
     return AnnData(
-        X=np.random.binomial(100, 0.005, (1000, 1000)),
+        X=rng.binomial(100, 0.005, (1000, 1000)),
         var=dict(
             mito=np.concatenate((np.ones(100, dtype=bool), np.zeros(900, dtype=bool)))
         ),

--- a/tests/test_rank_genes_groups.py
+++ b/tests/test_rank_genes_groups.py
@@ -8,12 +8,12 @@ import numpy as np
 import pandas as pd
 import pytest
 from anndata import AnnData
-from numpy.random import binomial, negative_binomial, seed
 from scipy.stats import mannwhitneyu
 
 import scanpy as sc
 from scanpy._compat import CSBase
 from scanpy._utils import select_groups
+from scanpy._utils.random import _LegacyRng
 from scanpy.get import rank_genes_groups_df
 from scanpy.tools import rank_genes_groups
 from scanpy.tools._rank_genes_groups import _RankGenes
@@ -39,14 +39,17 @@ DATA_PATH = HERE / "_data"
 
 
 @pytest.mark.parametrize("array_type", ARRAY_TYPES)
-def get_example_data(array_type: Callable[[np.ndarray], Any]) -> AnnData:
+def get_example_data(
+    array_type: Callable[[np.ndarray], Any], *, rng: np.random.Generator | None = None
+) -> AnnData:
+    rng = np.random.default_rng(rng)
     # create test object
     adata = AnnData(
-        np.multiply(binomial(1, 0.15, (100, 20)), negative_binomial(2, 0.25, (100, 20)))
+        rng.binomial(1, 0.15, (100, 20)) * rng.negative_binomial(2, 0.25, (100, 20))
     )
     # adapt marker_genes for cluster (so as to have some form of reasonable input
-    adata.X[0:10, 0:5] = np.multiply(
-        binomial(1, 0.9, (10, 5)), negative_binomial(1, 0.5, (10, 5))
+    adata.X[0:10, 0:5] = rng.binomial(1, 0.9, (10, 5)) * rng.negative_binomial(
+        1, 0.5, (10, 5)
     )
 
     adata.X = array_type(adata.X)
@@ -80,8 +83,7 @@ def get_true_scores(method: Literal["t-test", "wilcoxon"]) -> Expected:
 def test_results(
     subtests: pytest.Subtests, array_type, method: Literal["t-test", "wilcoxon"]
 ) -> None:
-    seed(1234)
-    adata = get_example_data(array_type)
+    adata = get_example_data(array_type, rng=_LegacyRng(1234))
     assert adata.raw is None  # Assumption for later checks
     expected = get_true_scores(method)
     # no clue why we did this: https://github.com/scverse/scanpy/commit/7f10fa3138374bbc664776c6aae1c0e05cf2c5cf
@@ -92,8 +94,10 @@ def test_results(
 
     for g in range(expected["names"].shape[0]):
         with subtests.test(group=g):
-            assert np.allclose(expected["scores"][g, :n], results["scores"][str(g)][:n])
-            assert np.array_equal(
+            np.testing.assert_allclose(
+                expected["scores"][g, :n], results["scores"][str(g)][:n], rtol=1e-5
+            )
+            np.testing.assert_array_equal(
                 expected["names"][g, :n], results["names"][str(g)][:n]
             )
     assert results["params"]["use_raw"] is False
@@ -104,11 +108,10 @@ def test_results(
 def test_results_layers(
     subtests: pytest.Subtests, array_type, method: Literal["t-test", "wilcoxon"]
 ) -> None:
-    seed(1234)
-    adata = get_example_data(array_type)
+    adata = get_example_data(array_type, rng=_LegacyRng(1234))
     adata.layers["to_test"] = adata.X.copy()
     x = adata.X.tolil() if isinstance(adata.X, CSBase) else adata.X
-    mask = np.random.randint(0, 2, adata.shape, dtype=bool)
+    mask = np.random.default_rng().integers(0, 2, adata.shape, dtype=bool)
     x[mask] = 0
     adata.X = array_type(x)
     scores = get_true_scores(method)["scores"]

--- a/tests/test_score_genes.py
+++ b/tests/test_score_genes.py
@@ -33,13 +33,19 @@ _create_random_gene_names = partial(random_str, alphabet=string.ascii_uppercase)
 """Create a bunch of random gene names (just CAPS letters)."""
 
 
-def _create_sparse_nan_matrix(rows, cols, percent_zero, percent_nan) -> CSRBase:
+def _create_sparse_nan_matrix(
+    rows: int,
+    cols: int,
+    percent_zero: float,
+    percent_nan: float,
+    *,
+    rng: np.random.Generator | None = None,
+) -> CSRBase:
     """Create a sparse matrix with certain amounts of NaN and Zeros."""
-    arr = (
-        np.random.randint(0, 1000, rows * cols).reshape((rows, cols)).astype("float32")
-    )
-    maskzero = np.random.rand(rows, cols) < percent_zero
-    masknan = np.random.rand(rows, cols) < percent_nan
+    rng = np.random.default_rng(rng)
+    arr = rng.integers(0, 1000, rows * cols).reshape((rows, cols)).astype("float32")
+    maskzero = rng.random((rows, cols)) < percent_zero
+    masknan = rng.random((rows, cols)) < percent_nan
     if np.any(maskzero):
         arr[maskzero] = 0
     if np.any(masknan):
@@ -47,11 +53,18 @@ def _create_sparse_nan_matrix(rows, cols, percent_zero, percent_nan) -> CSRBase:
     return sparse.csr_matrix(arr)  # noqa: TID251
 
 
-def _create_adata(n_obs: int, n_var: int, p_zero: float, p_nan: float) -> AnnData:
+def _create_adata(
+    n_obs: int,
+    n_var: int,
+    p_zero: float,
+    p_nan: float,
+    *,
+    rng: np.random.Generator | None = None,
+) -> AnnData:
     """Create an AnnData with random data, sparseness and some NaN values."""
-    x = _create_sparse_nan_matrix(n_obs, n_var, p_zero, p_nan)
+    x = _create_sparse_nan_matrix(n_obs, n_var, p_zero, p_nan, rng=rng)
     adata = AnnData(x)
-    gene_names = _create_random_gene_names(n_var, length=6)
+    gene_names = _create_random_gene_names(n_var, length=6, rng=rng)
     adata.var_names = gene_names.reshape(n_var)  # can be unsized
     return adata
 
@@ -76,16 +89,17 @@ def test_score_with_reference():
 def test_add_score():
     """Check the dtype of the scores and that non-existing genes get ignored."""
     # TODO: write a test that costs less resources and is more meaningful
-    adata = _create_adata(100, 1000, p_zero=0, p_nan=0)
+    rng = np.random.default_rng()
+    adata = _create_adata(100, 1000, p_zero=0, p_nan=0, rng=rng)
 
     sc.pp.normalize_total(adata, target_sum=1e4)
     sc.pp.log1p(adata)
 
     # the actual genes names are all 6 letters
     # create some non-exstisting names with 7 letters:
-    non_existing_genes = _create_random_gene_names(3, length=7)
+    non_existing_genes = _create_random_gene_names(3, length=7, rng=rng)
     some_genes = np.r_[
-        np.unique(np.random.choice(adata.var_names, 10)), np.unique(non_existing_genes)
+        np.unique(rng.choice(adata.var_names, 10)), np.unique(non_existing_genes)
     ]
     sc.tl.score_genes(adata, some_genes, score_name="Test")
     assert adata.obs["Test"].dtype == "float64"
@@ -133,8 +147,10 @@ def test_sparse_nanmean_on_dense_matrix():
     """TypeError must be thrown when calling _sparse_nanmean with a dense matrix."""
     from scanpy.tools._score_genes import _sparse_nanmean
 
+    data = np.random.default_rng().random((4, 5))
+
     with pytest.raises(TypeError):
-        _sparse_nanmean(np.random.rand(4, 5), 0)
+        _sparse_nanmean(data, 0)
 
 
 def test_score_genes_sparse_vs_dense():
@@ -163,12 +179,13 @@ def test_score_genes_deplete(*, dense: bool) -> None:
 
     Check that for both sparse and dense matrices.
     """
-    adata = _create_adata(100, 1000, p_zero=0.3, p_nan=0.3)
+    rng = np.random.default_rng()
+    adata = _create_adata(100, 1000, p_zero=0.3, p_nan=0.3, rng=rng)
     if dense:
         adata.X = adata.X.toarray()
 
     # deplete these genes in 50 cells,
-    ix_obs = np.random.choice(adata.shape[0], 50)
+    ix_obs = rng.choice(adata.shape[0], 50)
     with warnings.catch_warnings():
         warnings.filterwarnings("ignore", category=sparse.SparseEfficiencyWarning)
         adata.X[ix_obs, :10] = 0
@@ -205,9 +222,10 @@ def test_npnanmean_vs_sparsemean(monkeypatch):
 
 
 def test_missing_genes():
-    adata = _create_adata(100, 1000, p_zero=0, p_nan=0)
+    rng = np.random.default_rng()
+    adata = _create_adata(100, 1000, p_zero=0, p_nan=0, rng=rng)
     # These genes have a different length of name
-    non_extant_genes = _create_random_gene_names(3, length=7)
+    non_extant_genes = _create_random_gene_names(3, length=7, rng=rng)
 
     with pytest.raises(ValueError, match=r"No valid genes were passed for scoring"):
         sc.tl.score_genes(adata, non_extant_genes)
@@ -255,7 +273,6 @@ def test_invalid_gene_pool(gene_pool):
 
 
 def test_no_control_gene():
-    np.random.seed(0)
     adata = _create_adata(100, 1, p_zero=0, p_nan=0)
 
     with pytest.raises(RuntimeError, match="No control genes found"):
@@ -266,7 +283,6 @@ def test_no_control_gene():
     "ctrl_as_ref", [True, False], ids=["ctrl_as_ref", "no_ctrl_as_ref"]
 )
 def test_gene_list_is_control(*, ctrl_as_ref: bool):
-    np.random.seed(0)
     adata = sc.datasets.blobs(n_variables=10, n_observations=100, n_centers=20)
     adata.var_names = "g" + adata.var_names
     with (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,24 +143,29 @@ def test_scale_rechunk(array_type, axis, op):
 
 @pytest.mark.parametrize("array_type", ARRAY_TYPES)
 @pytest.mark.parametrize(
-    ("array_value", "expected"),
+    ("mk_array", "expected"),
     [
         pytest.param(
-            np.random.poisson(size=(100, 100)).astype(np.float64),
+            lambda rng: rng.poisson(size=(100, 100)).astype(np.float64),
             True,
             id="poisson-float64",
         ),
         pytest.param(
-            np.random.poisson(size=(100, 100)).astype(np.uint32),
+            lambda rng: rng.poisson(size=(100, 100)).astype(np.uint32),
             True,
             id="poisson-uint32",
         ),
-        pytest.param(np.random.normal(size=(100, 100)), False, id="normal"),
-        pytest.param(np.array([[0, 0, 0], [0, -1, 0], [0, 0, 0]]), False, id="middle"),
+        pytest.param(lambda rng: rng.normal(size=(100, 100)), False, id="normal"),
+        pytest.param(
+            lambda _: np.array([[0, 0, 0], [0, -1, 0], [0, 0, 0]]), False, id="middle"
+        ),
     ],
 )
-def test_check_nonnegative_integers(array_type, array_value, expected):
-    x = array_type(array_value)
+def test_check_nonnegative_integers(
+    array_type, mk_array: Callable[[np.random.Generator], np.ndarray], expected
+):
+    rng = np.random.default_rng()
+    x = array_type(mk_array(rng))
 
     received = check_nonnegative_integers(x)
     if isinstance(x, DaskArray):
@@ -178,16 +183,18 @@ def test_check_nonnegative_integers(array_type, array_value, expected):
 @pytest.mark.parametrize("pass_seed", [True, False], ids=["pass_seed", "set_seed"])
 @pytest.mark.parametrize("func", ["choice"])
 def test_legacy_numpy_gen(*, seed: int, pass_seed: bool, func: str):
-    np.random.seed(seed)
-    state_before = np.random.get_state(legacy=False)
+    np.random.seed(seed)  # noqa: NPY002
+    state_before = np.random.get_state(legacy=False)  # noqa: NPY002
 
     arrs: dict[bool, np.ndarray] = {}
     states_after: dict[bool, dict[str, Any]] = {}
     for direct in [True, False]:
         if not pass_seed:
-            np.random.seed(seed)
-        arrs[direct] = _mk_random(func, direct=direct, seed=seed if pass_seed else None)
-        states_after[direct] = np.random.get_state(legacy=False)
+            np.random.seed(seed)  # noqa: NPY002
+        arrs[direct] = _mk_legacy_random(
+            func, direct=direct, seed=seed if pass_seed else None
+        )
+        states_after[direct] = np.random.get_state(legacy=False)  # noqa: NPY002
 
     np.testing.assert_array_equal(arrs[True], arrs[False])
     np.testing.assert_equal(
@@ -198,9 +205,9 @@ def test_legacy_numpy_gen(*, seed: int, pass_seed: bool, func: str):
         np.testing.assert_equal(states_after[True], state_before)
 
 
-def _mk_random(func: str, *, direct: bool, seed: int | None) -> np.ndarray:
+def _mk_legacy_random(func: str, *, direct: bool, seed: int | None) -> np.ndarray:
     if direct and seed is not None:
-        np.random.seed(seed)
+        np.random.seed(seed)  # noqa: NPY002
     gen = np.random if direct else _LegacyRng.wrap_global(seed)
     match func:
         case "choice":


### PR DESCRIPTION
One more for https://github.com/scverse/anndata/issues/1241

Basically to move to `np.random.Generator`:
- `rand` and `randn` are almost aliases for `random` and `standard_normal`, except that they have a worse API (`f(*shape)` instead of the more common `f(shape)` or `f(..., *, size=shape)`)
- `randint` is renamed to `integers`
- the rest has the same name

There were a few leftover `np.random.seed` calls:
- some in the tests could just be removed, they did nothing?
- one was left in the tests (`test_notebooks.py::test_pbmc`) where it basically tests that the backwards compat defaults work as expected
- I didn’t port some of the old `sim` code last time, now I did. I wonder if anyone uses it.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: linting only

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
