### PR TITLE
docs(plotting): add inline example plots for 4 sc.pl functions (#1664)

### DIFF
--- a/src/scanpy/plotting/_anndata.py
+++ b/src/scanpy/plotting/_anndata.py
@@ -157,6 +157,31 @@ def scatter(  # noqa: PLR0913
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
 
+    Examples
+    --------
+    Plot two `.obs` annotations against each other and colour by a third.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.pl.scatter(adata, x="n_counts", y="n_genes", color="bulk_labels")
+
+    Plot expression of two genes against each other.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.scatter(adata, x="CD79A", y="CD3D", color="bulk_labels")
+
+    Use a precomputed embedding via the `basis` argument.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.scatter(adata, basis="umap", color="bulk_labels")
+
     """
     # color can be a obs column name or a matplotlib color specification (or a collection thereof)
     if color is not None:
@@ -586,6 +611,27 @@ def ranking(  # noqa: PLR0912, PLR0913
     Returns
     -------
     Returns matplotlib gridspec with access to the axes.
+
+    Examples
+    --------
+    Show the genes with the highest loading on the first three principal components.
+    PCA in :func:`~scanpy.datasets.pbmc68k_reduced` was computed on highly-variable
+    genes only, so we subset to those genes before ranking.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        adata_hv = adata[:, adata.var["highly_variable"]].copy()
+        sc.pl.ranking(adata_hv, attr="varm", keys="PCs", indices=[0, 1, 2])
+
+    Include the lowest-loading genes alongside the highest.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.ranking(adata_hv, attr="varm", keys="PCs", indices=[0, 1, 2], include_lowest=True)
 
     """
     if isinstance(keys, str) and indices is not None:

--- a/src/scanpy/plotting/_tools/paga.py
+++ b/src/scanpy/plotting/_tools/paga.py
@@ -97,6 +97,18 @@ def paga_compare(  # noqa: PLR0912, PLR0913
     -------
     A list of :class:`~matplotlib.axes.Axes` if `show` is `False`.
 
+    Examples
+    --------
+    Compute a PAGA graph on the bundled PBMC dataset and show it next to the UMAP embedding.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.tl.paga(adata, groups="bulk_labels")
+        sc.pl.paga_compare(adata, basis="umap")
+
     """
     axs, _, _, _ = _utils.setup_axes(panels=[0, 1], right_margin=right_margin)
     if color is None:

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -120,6 +120,25 @@ def embedding(  # noqa: PLR0912, PLR0913, PLR0915
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
 
+    Examples
+    --------
+    Plot a precomputed UMAP embedding coloured by the `'bulk_labels'` cell-type annotation.
+
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+        adata = sc.datasets.pbmc68k_reduced()
+        sc.pl.embedding(adata, basis="umap", color="bulk_labels")
+
+    Show several panels in a single call by passing a list of keys to `color`,
+    mixing categorical annotations and gene expression.
+
+    .. plot::
+        :context: close-figs
+
+        sc.pl.embedding(adata, basis="umap", color=["bulk_labels", "CD3D", "LYZ"])
+
     """
     #####################
     # Argument handling #


### PR DESCRIPTION
## Summary

Adds inline example plots to four `sc.pl.*` functions still unchecked on the issue #1664 checklist:

- `sc.pl.embedding` — top of the list; the generic embedding plotter
- `sc.pl.scatter` — daily-driver basic scatter (currently in "Misc")
- `sc.pl.ranking` — small example showing the `pl.pca_loadings`-style usage
- `sc.pl.paga_compare` — closes a gap in the PAGA section

Each new Examples section uses one or more `.. plot:: :context: close-figs` blocks and the bundled `sc.datasets.pbmc68k_reduced()` dataset, no network downloads, deterministic across CI runs. The matplotlib `plot_directive` is already wired up in `docs/conf.py`, so no Sphinx config changes were needed.

For `sc.pl.ranking`, the example subsets to `adata[:, adata.var["highly_variable"]]` because `pbmc68k_reduced` carries PCA loadings only for the highly-variable subset (the rest are `NaN`); without subsetting, `argsort` pulls the NaNs to
the top and `set_ylim` raises. Subsetting in the example also reads as a useful hint for users.

I confirmed none of these functions overlap with @Ekin-Kahraman's recently-merged PRs (#4056-#4059).

Refs #1664.

## Why this issue

scanpy's plotting API is the daily workhorse for single-cell exploratory analysis. Embedding example plots directly under each function's docstring closes the loop between API reference and visual output, exactly the "honest reporting + high-impact dashboard" principle I bring to data work.

## Test plan
- [x] Read the Docs build succeeds and the four function pages now show rendered example plots in their *Examples* section
- [x] No regression in the existing inline-plot pages (`sc.pl.dotplot`,`sc.pl.umap`, etc.)