### PR TITLE
fix: use `get_igraph_from_adjacency` for graph construction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,6 @@
     "python.testing.pytestArgs": ["-vv", "--color=yes", "--internet-tests"],
     "python.testing.pytestEnabled": true,
     "python.terminal.activateEnvironment": true,
-    "python-envs.defaultEnvManager": "flying-sheep.hatch:hatch",
-    "python-envs.defaultPackageManager": "flying-sheep.hatch:hatch",
+    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
+    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
 }

--- a/docs/release-notes/4112.fix.md
+++ b/docs/release-notes/4112.fix.md
@@ -1,1 +1,5 @@
-Make {func}`scanpy.metrics.modularity` produce the exact same results as `igraph` itself {smaller}`P Angerer`
+Make {func}`scanpy.metrics.modularity` produce the exact same results as `igraph` itself,
+see `https://github.com/scverse/scanpy/blob/e4e43830ea3d5af0acd99648612612551fa7b83e/tests/test_metrics.py#L340 <here>`__.
+In Scanpy 2.0 (or with {attr}`scanpy.Preset.ScanpyV2Preview`),
+all graphs will be calculated slightly differently, using {meth}`igraph.Graph.Weighted_Adjacency`.
+{smaller}`P Angerer`

--- a/docs/release-notes/4112.fix.md
+++ b/docs/release-notes/4112.fix.md
@@ -1,0 +1,1 @@
+Make {func}`scanpy.metrics.modularity` produce the exact same results as `igraph` itself {smaller}`P Angerer`

--- a/src/scanpy/_settings/presets.py
+++ b/src/scanpy/_settings/presets.py
@@ -162,11 +162,19 @@ class Preset(enum.StrEnum):
         # lower-kebap-case
         return "-".join(part.lower() for part in re.split(r"(?=[A-Z])", name) if part)
 
+    # TODO: make the docstrings appear in the docs: https://github.com/sphinx-doc/sphinx/issues/857
+
     ScanpyV1 = enum.auto()
-    """: Scanpy 1.*’s default settings."""
+    """Scanpy 1.*’s default settings."""
 
     ScanpyV2Preview = enum.auto()
-    """: Scanpy 2.*’s feature default settings. (Preview: subject to change!)"""
+    """Scanpy 2.*’s feature default settings. (Preview: subject to change!)
+
+    Apart from changing the functions referenced below, this preset will also:
+
+    - change all functions using `igraph` to no longer create duplicate edges,
+      slightly changing community detection and modularity scores.
+    """
 
     @preset_property
     def highly_variable_genes() -> Mapping[Preset, HVGPreset]:

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -33,7 +33,7 @@ from anndata._core.sparse_dataset import BaseCompressedSparseDataset
 from packaging.version import Version
 
 from .. import logging as logg
-from .._compat import CSBase, DaskArray, _CSArray, pkg_version, warn
+from .._compat import CSBase, DaskArray, SpBase, _CSArray, pkg_version, warn
 from ._numba import _numba_thread_limit
 
 if TYPE_CHECKING:
@@ -277,13 +277,15 @@ def check_use_raw(
 def get_igraph_from_adjacency(adjacency: CSBase, *, directed: bool) -> Graph:
     """Get igraph graph from adjacency matrix."""
     import igraph as ig
+    import scipy.sparse as sps
 
     import scanpy as sc
 
     if sc.settings.preset is sc.Preset.ScanpyV2Preview:
         # TODO: replace all call sites with this line
         return ig.Graph.Weighted_Adjacency(
-            adjacency, mode=ig.ADJ_DIRECTED if directed else ig.ADJ_UNDIRECTED
+            sps.coo_matrix(adjacency) if isinstance(adjacency, SpBase) else adjacency,
+            mode=ig.ADJ_DIRECTED if directed else ig.ADJ_UNDIRECTED,
         )
 
     sources, targets = adjacency.nonzero()

--- a/src/scanpy/_utils/__init__.py
+++ b/src/scanpy/_utils/__init__.py
@@ -70,6 +70,7 @@ __all__ = [
     "compute_association_matrix_of_groups",
     "descend_classes_and_funcs",
     "ensure_igraph",
+    "get_igraph_from_adjacency",
     "get_literal_vals",
     "indent",
     "is_backed_type",
@@ -273,9 +274,17 @@ def check_use_raw(
 # --------------------------------------------------------------------------------
 
 
-def get_igraph_from_adjacency(adjacency: CSBase, *, directed: bool = False) -> Graph:
+def get_igraph_from_adjacency(adjacency: CSBase, *, directed: bool) -> Graph:
     """Get igraph graph from adjacency matrix."""
     import igraph as ig
+
+    import scanpy as sc
+
+    if sc.settings.preset is sc.Preset.ScanpyV2Preview:
+        # TODO: replace all call sites with this line
+        return ig.Graph.Weighted_Adjacency(
+            adjacency, mode=ig.ADJ_DIRECTED if directed else ig.ADJ_UNDIRECTED
+        )
 
     sources, targets = adjacency.nonzero()
     weights = dematrix(adjacency[sources, targets]).ravel() if len(sources) else []

--- a/src/scanpy/metrics/_metrics.py
+++ b/src/scanpy/metrics/_metrics.py
@@ -10,7 +10,7 @@ from anndata import AnnData
 from natsort import natsorted
 from pandas.api.types import CategoricalDtype
 
-from .._utils import NeighborsView
+from .._utils import NeighborsView, get_igraph_from_adjacency
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -203,15 +203,14 @@ def modularity_array(
     connectivities: AnyArrayLike | SpBase, /, *, labels: AnyArrayLike, is_directed: bool
 ) -> float:
     try:
-        import igraph as ig
+        import igraph  # noqa: F401
     except ImportError as e:  # pragma: no cover
         e.add_note(
             "`igraph` is required for computing modularity. "
             "Please install `igraph` and try again."
         )
         raise
-    igraph_mode: str = ig.ADJ_DIRECTED if is_directed else ig.ADJ_UNDIRECTED
-    graph: ig.Graph = ig.Graph.Weighted_Adjacency(connectivities, mode=igraph_mode)
+    graph = get_igraph_from_adjacency(connectivities, directed=is_directed)
     return graph.modularity(_codes(labels), "weight")
 
 

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -578,7 +578,7 @@ class Neighbors:
 
     def to_igraph(self) -> Graph:
         """Generate igraph from connectiviies."""
-        return _utils.get_igraph_from_adjacency(self.connectivities)
+        return _utils.get_igraph_from_adjacency(self.connectivities, directed=False)
 
     @_doc_params(n_pcs=doc_n_pcs, use_rep=doc_use_rep)
     @_accepts_legacy_random_state(0)

--- a/src/scanpy/plotting/_tools/paga.py
+++ b/src/scanpy/plotting/_tools/paga.py
@@ -243,7 +243,7 @@ def _compute_pos(  # noqa: PLR0912
             ctx = nullcontext()
         else:
             ctx = _set_igraph_rng(rng)
-        g = _sc_utils.get_igraph_from_adjacency(adjacency_solid)
+        g = _sc_utils.get_igraph_from_adjacency(adjacency_solid, directed=False)
         with ctx:
             if "rt" in layout:
                 g_tree = _sc_utils.get_igraph_from_adjacency(adj_tree)

--- a/src/scanpy/tools/_draw_graph.py
+++ b/src/scanpy/tools/_draw_graph.py
@@ -150,7 +150,7 @@ def draw_graph(  # noqa: PLR0913
     if layout == "fa":
         positions = np.array(fa2_positions(adjacency, init_coords, **kwds))
     else:
-        g = _utils.get_igraph_from_adjacency(adjacency)
+        g = _utils.get_igraph_from_adjacency(adjacency, directed=False)
         with _igraph_rng_compat(rng):
             if layout in {"fr", "drl", "kk", "grid_fr"}:
                 ig_layout = g.layout(layout, seed=init_coords.tolist(), **kwds)

--- a/src/scanpy/tools/_paga.py
+++ b/src/scanpy/tools/_paga.py
@@ -212,7 +212,7 @@ class PAGA:
 
         ones = self._neighbors.connectivities.copy()
         ones.data = np.ones(len(ones.data))
-        g = _utils.get_igraph_from_adjacency(ones)
+        g = _utils.get_igraph_from_adjacency(ones, directed=False)
         vc = igraph.VertexClustering(
             g, membership=self._adata.obs[self._groups_key].cat.codes.values
         )

--- a/src/scanpy/tools/_utils.py
+++ b/src/scanpy/tools/_utils.py
@@ -55,12 +55,13 @@ def _get_pca_or_small_x(adata: AnnData, n_pcs: int | None) -> np.ndarray | CSRBa
         logg.info("    using data matrix X directly")
         return adata.X
 
-    if "X_pca" in adata.obsm:
-        if n_pcs is not None and n_pcs > adata.obsm["X_pca"].shape[1]:
-            msg = "`X_pca` does not have enough PCs. Rerun `sc.pp.pca` with adjusted `n_comps`."
+    pca_key = next((k for k in ("pca", "X_pca") if k in adata.obsm), None)
+    if pca_key is not None:
+        if n_pcs is not None and n_pcs > adata.obsm[pca_key].shape[1]:
+            msg = f"`{pca_key}` does not have enough PCs. Rerun `sc.pp.pca` with adjusted `n_comps`."
             raise ValueError(msg)
-        x = adata.obsm["X_pca"][:, :n_pcs]
-        logg.info(f"    using 'X_pca' with n_pcs = {x.shape[1]}")
+        x = adata.obsm[pca_key][:, :n_pcs]
+        logg.info(f"    using {pca_key!r} with n_pcs = {x.shape[1]}")
         return x
 
     from ..preprocessing import pca
@@ -73,7 +74,7 @@ def _get_pca_or_small_x(adata: AnnData, n_pcs: int | None) -> np.ndarray | CSRBa
     warn(msg, UserWarning)
     n_pcs_pca = n_pcs if n_pcs is not None else settings.N_PCS
     pca(adata, n_comps=n_pcs_pca)
-    return adata.obsm["X_pca"]
+    return adata.obsm[settings.preset.pca.key_added or "X_pca"]
 
 
 def get_init_pos_from_paga(

--- a/src/testing/scanpy/_pytest/__init__.py
+++ b/src/testing/scanpy/_pytest/__init__.py
@@ -58,6 +58,7 @@ def original_settings(
         })
 
     setup()
+    sc.settings.preset = sc.Preset.ScanpyV1
     if pkg_version("anndata") >= Version("0.12"):
         ad.settings.zarr_write_format = 3  # default in anndata 0.13, warns otherwise
     sc.settings.logfile = sys.stderr

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -310,10 +310,13 @@ def test_modularity_adj_errors(labels: object, is_directed: object, pat: str) ->
 
 
 @needs.igraph
+@pytest.mark.parametrize("preset", [sc.Preset.ScanpyV1, sc.Preset.ScanpyV2Preview])
 def test_modularity_adata(
-    monkeypatch: pytest.MonkeyPatch, subtests: pytest.Subtests
+    monkeypatch: pytest.MonkeyPatch, subtests: pytest.Subtests, preset: sc.Preset
 ) -> None:
     """Test domain and API of modularity score."""
+    # get_igraph_from_adjacency works very slightly differently in scanpy 2
+    sc.settings.preset = preset
     adata = pbmc3k()
     sc.pp.pca(adata)
     sc.pp.neighbors(adata)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -334,7 +334,7 @@ def test_modularity_adata(
             assert 0 <= s <= 1
     for (n0, s0), (n1, s1) in combinations(scores.items(), 2):
         with subtests.test("equality", l=n0, r=n1):
-            assert pytest.approx(s0, rel=1e-6) == s1
+            assert s0 == s1
     with subtests.test("update"):
         assert adata.uns["leiden"]["modularity"] is scores["update"]
 


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] Closes #4099
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
