### PR TITLE
fix float32 precision loss in aggregate variance: cast to float64 before squaring

### DIFF
--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -139,7 +139,15 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         if isinstance(self.data, np.ndarray):
             mean_ = self.mean()
             # sparse matrices do not support ** for elementwise power.
-            mean_sq = self._sum(_power(self.data, 2)) / group_counts[:, None]
+            # Cast to float64 before squaring so float32 input doesn't
+            # lose precision at the squaring step (errors there feed
+            # directly into the `mean_sq - sq_mean` variance calculation).
+            data_f64 = (
+                self.data
+                if self.data.dtype == np.float64
+                else self.data.astype(np.float64)
+            )
+            mean_sq = self._sum(_power(data_f64, 2)) / group_counts[:, None]
             sq_mean = mean_**2
             var_ = mean_sq - sq_mean
         else:
@@ -372,7 +380,10 @@ def aggregate_dask_mean_var(
     dof: int = 1,
 ) -> MeanVarDict:
     mean = aggregate_dask(data, by, "mean", mask=mask, dof=dof)["mean"]
-    sq_mean = aggregate_dask(fau_power(data, 2), by, "mean", mask=mask, dof=dof)["mean"]
+    # Cast to float64 before squaring; float32 squaring at chunk level
+    # would lose precision before the variance calculation. Cast is lazy for dask.
+    data_f64 = data if data.dtype == np.float64 else data.astype(np.float64)
+    sq_mean = aggregate_dask(fau_power(data_f64, 2), by, "mean", mask=mask, dof=dof)["mean"]
     # TODO: If we don't compute here, the results are not deterministic under the process cluster for sparse.
     if isinstance(data._meta, CSRBase):
         sq_mean = sq_mean.compute()

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -383,7 +383,9 @@ def aggregate_dask_mean_var(
     # Cast to float64 before squaring; float32 squaring at chunk level
     # would lose precision before the variance calculation. Cast is lazy for dask.
     data_f64 = data if data.dtype == np.float64 else data.astype(np.float64)
-    sq_mean = aggregate_dask(fau_power(data_f64, 2), by, "mean", mask=mask, dof=dof)["mean"]
+    sq_mean = aggregate_dask(fau_power(data_f64, 2), by, "mean", mask=mask, dof=dof)[
+        "mean"
+    ]
     # TODO: If we don't compute here, the results are not deterministic under the process cluster for sparse.
     if isinstance(data._meta, CSRBase):
         sq_mean = sq_mean.compute()

--- a/src/scanpy/get/_kernels.py
+++ b/src/scanpy/get/_kernels.py
@@ -68,7 +68,6 @@ def mean_var_csr(
             for j in range(start_obs, end_obs):
                 col = data.indices[j]
                 value = np.float64(data.data[j])
-                value = data.data[j]
                 mean[cat_num, col] += value
                 var[cat_num, col] += value * value
 
@@ -102,7 +101,6 @@ def mean_var_csc(
 
             if cat != -1:
                 value = np.float64(data.data[j])
-                value = data.data[j]
                 mean[cat, col] += value
                 var[cat, col] += value * value
 


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

While working on the wilcoxon illico integration, I ran into numerical stability issues with the 'aggregate'  function.

Upon further inspection, the issues primarily stem from float32 squaring before the mean_of_sq - sq_of_mean variance calculation. It seems there was some code to cast to float64 e.g. in the csc and csr cases, but then the next line cast it right back to float32 ```value = data.data[j]```. And other cases like the Dask and dense paths were not using float64.

I'll add a writeup from AI in another message below about the error levels / empirical findings.

...

So this small fix solves a large part of the numerical stability problem. This is a sufficient-enough fix to enable the stats computation code in the wilcoxon illico work to be completed using 'aggregate', which speeds it up an OOM.

That said, 'aggregate' has further issues -- the variance calculation used here is known to have a 'catastrophic cancellation' scenario when the mean/var ratio is high, e.g. 10,000+. I will open another PR for this soon, but it's a much bigger change, probably requiring more testing and review.

**Note:** This uses float64 so it's a bit slower. I tested a few perturb-seq datasets and it was about 30% slower on the Dask path. But only about 5% slower on the CSR path, and ~10% on CSC. However, I am fairly sure once we add the welford's online approach (or similar) this will speed up.

@ilan-gold tagging you here since this resolves the issue in wilcoxon-illico work / unblocks completion of my PR on stats computation speedup