### PR TITLE
perf: memory usage for dask pca

### DIFF
--- a/docs/release-notes/4126.perf.md
+++ b/docs/release-notes/4126.perf.md
@@ -1,0 +1,1 @@
+Improve memory usage of {func}`scanpy.pp.pca` when run on sparse {class}`dask.array.Array` {smaller}`I Gold`

--- a/src/scanpy/preprocessing/_pca/_dask.py
+++ b/src/scanpy/preprocessing/_pca/_dask.py
@@ -10,7 +10,7 @@ from fast_array_utils import stats
 from scanpy._utils import raise_if_dask_feature_axis_chunked
 from scanpy._utils._doctests import doctest_needs
 
-from ..._compat import CSBase
+from ..._compat import CSBase, CSRBase
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -182,10 +182,13 @@ def _cov_sparse_dask(
     else:
         dtype = np.dtype(dtype)
 
-    def gram_block(x_part: CSBase | NDArray):
-        gram_matrix = x_part.T @ x_part
-        if isinstance(gram_matrix, CSBase):
-            gram_matrix = gram_matrix.toarray()
+    def gram_block(x_part: CSRBase | NDArray):
+        if isinstance(x_part, CSRBase):
+            from ._kernels import csr_gram_dense
+
+            gram_matrix = csr_gram_dense(x_part)
+        else:
+            gram_matrix = x_part.T @ x_part
         return gram_matrix[None, ...]  # need new axis for summing
 
     gram_matrix_dask: DaskArray = da.map_blocks(

--- a/src/scanpy/preprocessing/_pca/_kernels.py
+++ b/src/scanpy/preprocessing/_pca/_kernels.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from fast_array_utils.numba import njit
+from numba import njit # noqa: TID251
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from scanpy._compat import CSRBase
 
 
-@njit
+@njit(nogil=True)
 def _csr_gram_upper_triangular(
     mat: CSRBase,
     out: NDArray,
@@ -31,7 +31,7 @@ def _csr_gram_upper_triangular(
             out[i, j] = out[j, i]
 
 
-@njit
+@njit(nogil=True)
 def _csr_gram_full(
     mat: CSRBase,
     out: NDArray,

--- a/src/scanpy/preprocessing/_pca/_kernels.py
+++ b/src/scanpy/preprocessing/_pca/_kernels.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import numpy as np
-from numba import njit # noqa: TID251
+from numba import njit  # noqa: TID251
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray

--- a/src/scanpy/preprocessing/_pca/_kernels.py
+++ b/src/scanpy/preprocessing/_pca/_kernels.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+from fast_array_utils.numba import njit
+
+from scanpy._compat import CSRBase
+
+if TYPE_CHECKING:
+    from numpy.typing import DTypeLike, NDArray
+
+
+@njit
+def _csr_gram_upper_triangular(
+    mat: CSRBase,
+    out: NDArray,
+) -> None:
+    """Accumulate upper triangle of ``X.T @ X`` into ``out``, then write over the lower."""
+    n_rows = mat.indptr.shape[0] - 1
+    for i in range(n_rows):
+        row_start = mat.indptr[i]
+        row_end = mat.indptr[i + 1]
+        for k in range(row_start, row_end):
+            jk = mat.indices[k]
+            vk = mat.data[k]
+            for l in range(k, row_end):
+                out[jk, mat.indices[l]] += vk * mat.data[l]
+    for i in range(out.shape[0]):
+        for j in range(i):
+            out[i, j] = out[j, i]
+
+@njit
+def _csr_gram_full(
+    mat: CSRBase,
+    out: NDArray,
+) -> None:
+    """Accumulate ``X.T @ X`` into ``out``."""
+    n_rows = mat.indptr.shape[0] - 1
+    for i in range(n_rows):
+        row_start = mat.indptr[i]
+        row_end = mat.indptr[i + 1]
+        for k in range(row_start, row_end):
+            jk = mat.indices[k]
+            vk = mat.data[k]
+            for l in range(row_start, row_end):
+                out[jk, mat.indices[l]] += vk * mat.data[l]
+
+
+def csr_gram_dense(mat: CSRBase) -> NDArray:
+    """Compute the full dense gram matrix ``X.T @ X`` for a CSR ``X``."""
+    out = np.zeros((mat.shape[1], mat.shape[1]), dtype=mat.dtype)
+    if mat.has_sorted_indices:
+        _csr_gram_upper_triangular(mat, out)
+    else:
+        _csr_gram_full(mat, out)
+    return out

--- a/src/scanpy/preprocessing/_pca/_kernels.py
+++ b/src/scanpy/preprocessing/_pca/_kernels.py
@@ -5,10 +5,11 @@ from typing import TYPE_CHECKING
 import numpy as np
 from fast_array_utils.numba import njit
 
-
 if TYPE_CHECKING:
-    from numpy.typing import DTypeLike, NDArray
+    from numpy.typing import NDArray
+
     from scanpy._compat import CSRBase
+
 
 @njit
 def _csr_gram_upper_triangular(
@@ -28,6 +29,7 @@ def _csr_gram_upper_triangular(
     for i in range(out.shape[0]):
         for j in range(i):
             out[i, j] = out[j, i]
+
 
 @njit
 def _csr_gram_full(

--- a/src/scanpy/preprocessing/_pca/_kernels.py
+++ b/src/scanpy/preprocessing/_pca/_kernels.py
@@ -5,11 +5,10 @@ from typing import TYPE_CHECKING
 import numpy as np
 from fast_array_utils.numba import njit
 
-from scanpy._compat import CSRBase
 
 if TYPE_CHECKING:
     from numpy.typing import DTypeLike, NDArray
-
+    from scanpy._compat import CSRBase
 
 @njit
 def _csr_gram_upper_triangular(


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

This should give a very nice memory performance by not having the intermediate product of `x.T @ x` in memory.  I am not sure whether the upper-triangular performance benefit is real or not - It seems to appear real on the tahoe dataset but I'm not 100% sure given how large the dataset is and how reliant this pipeline is on i/o.

The failing test here is a warning because the kernel is not parallel so I see two options there:

1. silence in `fau`
2. Use `@njit(nogil=True, nopython=True)` manually (since this is only ever run from dask anyway)

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
