### PR TITLE
fix: anchor sc.pl.scatter colorbar to user-supplied ax

### DIFF
--- a/docs/release-notes/4137.fix.md
+++ b/docs/release-notes/4137.fix.md
@@ -1,0 +1,1 @@
+Anchor the {func}`scanpy.pl.scatter` colorbar to a caller-supplied `ax` instead of placing it in figure coordinates computed from scanpy's internal panel layout, which previously dropped the colorbar over a sibling axes.

--- a/src/scanpy/plotting/legacy/_utils.py
+++ b/src/scanpy/plotting/legacy/_utils.py
@@ -791,6 +791,10 @@ def scatter_base(  # noqa: PLR0912, PLR0913, PLR0915
         sizes = [sizes[0] for _ in range(len(colors))]
     if len(markers) != len(colors) and len(markers) == 1:
         markers = [markers[0] for _ in range(len(colors))]
+    # When the caller provides an ax, panel_pos is computed for scanpy's own
+    # layout and does not reflect the user's figure, so the rectangle-based
+    # colorbar placement below would fall outside the user's ax (see #3963).
+    ax_was_user_supplied = ax is not None
     axs, panel_pos, draw_region_width, _figure_width = setup_axes(
         ax,
         panels=colors,
@@ -831,17 +835,30 @@ def scatter_base(  # noqa: PLR0912, PLR0913, PLR0915
                 rasterized=mpl_settings.VECTOR_FRIENDLY,
             )
         if colorbars[icolor]:
-            width = 0.006 * draw_region_width / len(colors)
-            left = (
-                panel_pos[2][2 * icolor + 1]
-                + (1.2 if projection == "3d" else 0.2) * width
-            )
-            rectangle = [left, bottom, width, height]
-            fig = plt.gcf()
-            ax_cb = fig.add_axes(rectangle)
-            _ = plt.colorbar(
-                sct, format=ticker.FuncFormatter(ticks_formatter), cax=ax_cb
-            )
+            if ax_was_user_supplied:
+                # Attach the colorbar to the caller's ax instead of using the
+                # internal panel_pos rectangle (which is in figure coords for
+                # scanpy's own layout). Mirrors sc.pl.embedding. See #3963.
+                _ = plt.colorbar(
+                    sct,
+                    ax=ax,
+                    format=ticker.FuncFormatter(ticks_formatter),
+                    pad=0.01,
+                    fraction=0.08,
+                    aspect=30,
+                )
+            else:
+                width = 0.006 * draw_region_width / len(colors)
+                left = (
+                    panel_pos[2][2 * icolor + 1]
+                    + (1.2 if projection == "3d" else 0.2) * width
+                )
+                rectangle = [left, bottom, width, height]
+                fig = plt.gcf()
+                ax_cb = fig.add_axes(rectangle)
+                _ = plt.colorbar(
+                    sct, format=ticker.FuncFormatter(ticks_formatter), cax=ax_cb
+                )
         # set the title
         if title is not None:
             ax.set_title(title[icolor])

--- a/tests/plotting/legacy/test_plotting.py
+++ b/tests/plotting/legacy/test_plotting.py
@@ -1472,6 +1472,41 @@ def test_dpt_plots(
     save_and_compare_images(func.__name__)
 
 
+def test_scatter_colorbar_uses_user_ax():
+    """Regression test for #3963.
+
+    When ``sc.pl.scatter`` receives a user-supplied ``ax``, the colorbar must
+    be attached to that ax. Previously the colorbar was placed via
+    ``fig.add_axes(rectangle)`` with rectangle in figure coords for scanpy's
+    own panel layout, landing the colorbar over an unrelated user axes.
+    """
+    rng = np.random.default_rng(0)
+    adata = AnnData(
+        rng.random((50, 3), dtype=np.float32),
+        obs=dict(score=rng.random(50, dtype=np.float32)),
+    )
+    adata.obsm["X_umap"] = rng.random((50, 2), dtype=np.float32)
+
+    fig, axs = plt.subplots(1, 2, figsize=(10, 4))
+    sc.pl.scatter(adata, color="score", basis="umap", ax=axs[0], show=False)
+
+    extra = [a for a in fig.axes if a not in axs]
+    assert extra, "sc.pl.scatter should add a colorbar for a continuous color"
+    cb = extra[0]
+    user_ax_pos = axs[0].get_position()
+    cb_pos = cb.get_position()
+    # The colorbar should sit just to the right of the user's ax, not float
+    # away from it across the figure.
+    assert cb_pos.x0 >= user_ax_pos.x0, (
+        f"Colorbar x0={cb_pos.x0:.3f} is left of user ax x0={user_ax_pos.x0:.3f}"
+    )
+    assert cb_pos.x0 < user_ax_pos.x1 + 0.05, (
+        f"Colorbar x0={cb_pos.x0:.3f} is far past user ax x1={user_ax_pos.x1:.3f}; "
+        "this would overlap a sibling axes."
+    )
+    plt.close(fig)
+
+
 def test_scatter_raw(tmp_path):
     pbmc = pbmc68k_reduced()[:100].copy()
     raw_pth = tmp_path / "raw.png"


### PR DESCRIPTION
## Summary

Fixes #3963.

When `sc.pl.scatter` is called with a user-supplied `ax`, `scatter_base` placed the colorbar by `fig.add_axes(rectangle)` with the rectangle coordinates computed from `panel_pos` -- positions scanpy uses for its own internal panel layout. Those positions have no relationship to the caller's figure, so the colorbar lands somewhere in the figure interior, typically overlapping a sibling axes.

`sc.pl.embedding` already handles this correctly by routing through `plt.colorbar(sct, ax=ax, ...)`. This PR detects the user-supplied-ax case in `scatter_base` and uses the same `ax=` form. The original rectangle-based path is kept for the scanpy-managed-figure case, so multi-panel scatter outputs that scanpy lays out itself are visually unchanged.

## Before / after

The OP's repro pattern (left panel is `sc.pl.scatter`, right panel is anything else):

**Before:** colorbar floats between the two panels, partly over the right panel's y-axis labels.
**After:** colorbar sits directly to the right of the left ax, like every other matplotlib colorbar attached via `ax=`.

Locally on `pbmc3k_processed` with `fig, axs = plt.subplots(1, 2, figsize=(10, 4))`:
- user ax: `x0=0.125 x1=0.446`
- colorbar: `x0=0.449 x1=0.477` (just past the user ax right edge)

## Test plan

Adds `tests/test_plotting.py::test_scatter_colorbar_uses_user_ax` -- structural assertion that the colorbar's x position sits just past the user's ax right edge, rather than overlapping a sibling panel. Uses a tiny synthetic AnnData to keep the test self-contained.

Unable to run the full `pytest tests/test_plotting.py` locally because every test in that file currently fails for me with `Cannot shard v2 format data. Please set anndata.settings.zarr_write_format to 3` from the `anndata_settings` autouse fixture (`tests/conftest.py:162`) interacting with `anndata 0.12.10` on Apple Silicon. The added test passes when run standalone with explicit `ad.settings.zarr_write_format = 3; ad.settings.auto_shard_zarr_v3 = False`, and the underlying fix is verified against the OP's two-panel repro. CI on a clean runner should be the authoritative check.

## Notes

- Doc string left as-is; no doc changes needed.
- Release notes not yet added (will follow up once I know the PR number, unless the maintainer would prefer me to add `<PR>.fix.md` in a follow-up commit here).

AI-assisted by Claude Code.