### PR TITLE
fix: download data atomically to avoid corrupt cache (#4097)

### DIFF
--- a/docs/release-notes/4142.fix.md
+++ b/docs/release-notes/4142.fix.md
@@ -1,1 +1,1 @@
-Download cached dataset files atomically so that parallel processes sharing a dataset directory (e.g. {mod}`pytest-xdist` workers) can no longer read a partially-written file {smaller}`gaoflow`
+Download cached dataset files atomically so that parallel processes sharing a dataset directory (e.g. `pytest-xdist` workers) can no longer read a partially-written file {smaller}`gaoflow`

--- a/docs/release-notes/4142.fix.md
+++ b/docs/release-notes/4142.fix.md
@@ -1,0 +1,1 @@
+Download cached dataset files atomically so that parallel processes sharing a dataset directory (e.g. {mod}`pytest-xdist` workers) can no longer read a partially-written file {smaller}`gaoflow`

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -1093,10 +1093,7 @@ def _download(url: str, path: Path):
     blocksize = 1024 * 8
     blocknum = 0
 
-    # Download to a temporary file in the same directory and atomically move it
-    # into place once it is complete. This way concurrent readers (e.g. parallel
-    # pytest workers sharing a dataset cache) never observe ``path`` in a
-    # partially-written state. See #4097.
+    # Write to a temp file and rename so readers never see a partial file (#4097).
     tmp_path: Path | None = None
     try:
         req = Request(url, headers={"User-agent": "scanpy-user"})
@@ -1130,9 +1127,7 @@ def _download(url: str, path: Path):
         tmp_path = None
 
     except (KeyboardInterrupt, Exception):
-        # Make sure no half-downloaded temporary file is left behind. ``path``
-        # itself is only ever created by the atomic rename above, so it is left
-        # untouched (it may belong to another process that finished first).
+        # Only remove our own temp file; leave path, which may be another process's.
         if tmp_path is not None:
             tmp_path.unlink(missing_ok=True)
         raise

--- a/src/scanpy/readwrite.py
+++ b/src/scanpy/readwrite.py
@@ -1084,6 +1084,7 @@ def _get_filename_from_key(key, ext=None) -> Path:
 
 def _download(url: str, path: Path):
     from ssl import create_default_context
+    from tempfile import NamedTemporaryFile
     from urllib.request import Request, urlopen
 
     from certifi import contents
@@ -1092,6 +1093,11 @@ def _download(url: str, path: Path):
     blocksize = 1024 * 8
     blocknum = 0
 
+    # Download to a temporary file in the same directory and atomically move it
+    # into place once it is complete. This way concurrent readers (e.g. parallel
+    # pytest workers sharing a dataset cache) never observe ``path`` in a
+    # partially-written state. See #4097.
+    tmp_path: Path | None = None
     try:
         req = Request(url, headers={"User-agent": "scanpy-user"})
 
@@ -1105,8 +1111,14 @@ def _download(url: str, path: Path):
                     unit_divisor=1024,
                     total=total if total is None else int(total),
                 ) as t,
-                path.open("wb") as f,
+                NamedTemporaryFile(
+                    dir=path.parent,
+                    prefix=f"{path.name}.",
+                    suffix=".part",
+                    delete=False,
+                ) as f,
             ):
+                tmp_path = Path(f.name)
                 block = resp.read(blocksize)
                 while block:
                     f.write(block)
@@ -1114,10 +1126,15 @@ def _download(url: str, path: Path):
                     t.update(len(block))
                     block = resp.read(blocksize)
 
+        tmp_path.replace(path)
+        tmp_path = None
+
     except (KeyboardInterrupt, Exception):
-        # Make sure file doesn’t exist half-downloaded
-        if path.is_file():
-            path.unlink()
+        # Make sure no half-downloaded temporary file is left behind. ``path``
+        # itself is only ever created by the atomic rename above, so it is left
+        # untouched (it may belong to another process that finished first).
+        if tmp_path is not None:
+            tmp_path.unlink(missing_ok=True)
         raise
 
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -228,7 +228,6 @@ def test_download_failure_keeps_existing_file(
     parallel-cache race could wipe a file another process had finished
     downloading. The atomic version only cleans up its own temporary file.
     """
-    import io
     import urllib.request
 
     from scanpy.readwrite import _download

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -219,6 +219,48 @@ def test_download_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     assert list(dest.parent.iterdir()) == [dest]
 
 
+def test_download_failure_keeps_existing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A failed download must not delete an already-present destination (#4097).
+
+    The old code unconditionally removed ``path`` on error, which under the
+    parallel-cache race could wipe a file another process had finished
+    downloading. The atomic version only cleans up its own temporary file.
+    """
+    import io
+    import urllib.request
+
+    from scanpy.readwrite import _download
+
+    dest = tmp_path / "cache" / "data.bin"
+    dest.parent.mkdir()
+    # A sibling process already finished this download.
+    dest.write_bytes(b"complete")
+
+    class FailingResponse:
+        def info(self) -> dict[str, str]:
+            return {"content-length": "100"}
+
+        def read(self, size: int) -> bytes:
+            raise OSError("connection reset")
+
+        def __enter__(self) -> Self:
+            return self
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: FailingResponse())
+
+    with pytest.raises(OSError, match="connection reset"):
+        _download("http://example.invalid/data.bin", dest)
+
+    # The pre-existing file is untouched and no temporary file is left behind.
+    assert dest.read_bytes() == b"complete"
+    assert list(dest.parent.iterdir()) == [dest]
+
+
 # These are tested via doctest
 DS_INCLUDED = frozenset({"krumsiek11", "toggleswitch", "pbmc68k_reduced"})
 # These have parameters that affect shape and so on

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -170,12 +170,7 @@ def test_download_failure() -> None:
 
 
 def test_download_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """A download must be atomic (#4097).
-
-    The destination path must not appear until the download has completed, so
-    that concurrent readers (e.g. parallel pytest workers sharing a cache) never
-    observe a partially-written file.
-    """
+    """The destination must not appear until the download finished (#4097)."""
     import io
     import urllib.request
 
@@ -210,31 +205,21 @@ def test_download_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
     _download("http://example.invalid/data.bin", dest)
 
     assert dest.read_bytes() == content
-    # sanity check that the download was actually streamed in several chunks
     assert len(dest_present_during_download) > 1
-    assert not any(dest_present_during_download), (
-        "destination appeared before the download finished"
-    )
-    # the temporary file must have been renamed, leaving only the final file
+    assert not any(dest_present_during_download)
     assert list(dest.parent.iterdir()) == [dest]
 
 
 def test_download_failure_keeps_existing_file(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """A failed download must not delete an already-present destination (#4097).
-
-    The old code unconditionally removed ``path`` on error, which under the
-    parallel-cache race could wipe a file another process had finished
-    downloading. The atomic version only cleans up its own temporary file.
-    """
+    """A failed download must not delete an already-present destination (#4097)."""
     import urllib.request
 
     from scanpy.readwrite import _download
 
     dest = tmp_path / "cache" / "data.bin"
     dest.parent.mkdir()
-    # A sibling process already finished this download.
     dest.write_bytes(b"complete")
 
     class FailingResponse:
@@ -256,7 +241,6 @@ def test_download_failure_keeps_existing_file(
     with pytest.raises(OSError, match="connection reset"):
         _download("http://example.invalid/data.bin", dest)
 
-    # The pre-existing file is untouched and no temporary file is left behind.
     assert dest.read_bytes() == b"complete"
     assert list(dest.parent.iterdir()) == [dest]
 

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -242,7 +242,8 @@ def test_download_failure_keeps_existing_file(
             return {"content-length": "100"}
 
         def read(self, size: int) -> bytes:
-            raise OSError("connection reset")
+            msg = "connection reset"
+            raise OSError(msg)
 
         def __enter__(self) -> Self:
             return self

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -168,6 +168,56 @@ def test_download_failure() -> None:
     excinfo.value.close()
 
 
+def test_download_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A download must be atomic (#4097).
+
+    The destination path must not appear until the download has completed, so
+    that concurrent readers (e.g. parallel pytest workers sharing a cache) never
+    observe a partially-written file.
+    """
+    import io
+    import urllib.request
+
+    from scanpy.readwrite import _download
+
+    content = b"0123456789" * 5_000
+    dest = tmp_path / "cache" / "data.bin"
+    dest.parent.mkdir()
+    dest_present_during_download: list[bool] = []
+
+    class FakeResponse:
+        def __init__(self) -> None:
+            self._buf = io.BytesIO(content)
+
+        def info(self) -> dict[str, str]:
+            return {"content-length": str(len(content))}
+
+        def read(self, size: int) -> bytes:
+            chunk = self._buf.read(size)
+            if chunk:
+                dest_present_during_download.append(dest.exists())
+            return chunk
+
+        def __enter__(self) -> FakeResponse:
+            return self
+
+        def __exit__(self, *exc: object) -> bool:
+            return False
+
+    monkeypatch.setattr(urllib.request, "urlopen", lambda *a, **k: FakeResponse())
+
+    _download("http://example.invalid/data.bin", dest)
+
+    assert dest.read_bytes() == content
+    # sanity check that the download was actually streamed in several chunks
+    assert len(dest_present_during_download) > 1
+    assert not any(dest_present_during_download), (
+        "destination appeared before the download finished"
+    )
+    # the temporary file must have been renamed, leaving only the final file
+    assert list(dest.parent.iterdir()) == [dest]
+
+
 # These are tested via doctest
 DS_INCLUDED = frozenset({"krumsiek11", "toggleswitch", "pbmc68k_reduced"})
 # These have parameters that affect shape and so on

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -21,6 +21,7 @@ from testing.scanpy._pytest.marks import needs
 
 if TYPE_CHECKING:
     from collections.abc import Callable
+    from typing import Self
 
     from anndata import AnnData
 
@@ -198,7 +199,7 @@ def test_download_atomic(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Non
                 dest_present_during_download.append(dest.exists())
             return chunk
 
-        def __enter__(self) -> FakeResponse:
+        def __enter__(self) -> Self:
             return self
 
         def __exit__(self, *exc: object) -> bool:


### PR DESCRIPTION
Fixes #4097.

## Problem

`_download` (used by `_check_datafile_present_and_download` for every cached dataset) writes directly to the destination cache path:

```python
with path.open("wb") as f:
    ...
```

As @flying-sheep diagnosed in #4097, this races under parallel execution (e.g. `pytest-xdist` workers sharing `settings.datasetdir`):

1. worker 1 doesn't see the cache file and starts downloading, creating `path` and writing into it;
2. worker 2 checks `path.is_file()`, sees the **partially-written** file, and reads it → corrupted file / error.

## Fix

Download to a `NamedTemporaryFile` in the **same directory** and atomically `Path.replace()` it into place once the download is complete (the second option suggested in the issue). A rename on the same filesystem is atomic, so `path` only ever becomes visible fully written; concurrent downloads still work, the loser's temp file just replaces in turn.

On failure the temporary file is removed, and `path` itself is **left untouched** — previously the error path unconditionally `unlink`-ed `path`, which under the race could delete a sibling process's already-completed download.

## Verification

Added `test_download_atomic` in `tests/test_datasets.py`: it mocks `urlopen` and asserts that the destination path does **not** exist while bytes are still being streamed, that the final content is correct, and that no temporary file is left behind. The test fails on the current code (`destination appeared before the download finished`) and passes with this change. I also verified that both an immediate failure (e.g. `HTTPError`) and a mid-stream failure propagate the exception and leave neither a destination nor a leftover temporary file.