### PR TITLE
docs: add inline example for pca_scatter

### DIFF
--- a/src/scanpy/plotting/__init__.py
+++ b/src/scanpy/plotting/__init__.py
@@ -29,7 +29,6 @@ from ._tools import (
     embedding_density,
     pca_loadings,
     pca_overview,
-    pca_scatter,
     pca_variance_ratio,
     rank_genes_groups,
     rank_genes_groups_dotplot,
@@ -84,7 +83,6 @@ __all__ = [
     "pca",
     "pca_loadings",
     "pca_overview",
-    "pca_scatter",
     "pca_variance_ratio",
     "rank_genes_groups",
     "rank_genes_groups_dotplot",
@@ -127,3 +125,8 @@ def timeseries_subplot(*args, **kwargs):
     from ._utils import timeseries_subplot
 
     return timeseries_subplot(*args, **kwargs)
+
+
+@deprecated(Deprecation("1.13.0", "Use :func:`scanpy.pl.pca` instead."))
+def pca_scatter(*args, **params):
+    return pca(*args, **params)

--- a/src/scanpy/plotting/__init__.py
+++ b/src/scanpy/plotting/__init__.py
@@ -127,6 +127,6 @@ def timeseries_subplot(*args, **kwargs):
     return timeseries_subplot(*args, **kwargs)
 
 
-@deprecated(Deprecation("1.13.0", "Use :func:`scanpy.pl.pca` instead."))
+@deprecated(Deprecation("1.12.2", "Use :func:`scanpy.pl.pca` instead."))
 def pca_scatter(*args, **params):
     return pca(*args, **params)

--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -102,7 +102,34 @@ def pca_overview(adata: AnnData, **params):
 
 
 # backwards compat
-pca_scatter = pca
+@_doc_params(scatter_bulk=doc_scatter_embedding, show_save_ax=doc_show_save_ax)
+def pca_scatter(adata: AnnData, **params):
+    """Scatter plot in PCA coordinates.
+
+    This is a backwards-compatible alias for :func:`~scanpy.pl.pca`.
+
+    Parameters
+    ----------
+    adata
+        Annotated data matrix.
+    {scatter_bulk}
+    {show_save_ax}
+
+    Returns
+    -------
+    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
+
+    Examples
+    --------
+    .. plot::
+        :context: close-figs
+
+        import scanpy as sc
+
+        adata = sc.datasets.pbmc3k_processed()
+        sc.pl.pca_scatter(adata, color="louvain")
+    """
+    return pca(adata, **params)
 
 
 def pca_loadings(

--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -118,17 +118,6 @@ def pca_scatter(adata: AnnData, **params):
     Returns
     -------
     If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
-
-    Examples
-    --------
-    .. plot::
-        :context: close-figs
-
-        import scanpy as sc
-
-        adata = sc.datasets.pbmc3k_processed()
-        sc.pl.pca_scatter(adata, color="louvain")
-    """
     return pca(adata, **params)
 
 

--- a/src/scanpy/plotting/_tools/__init__.py
+++ b/src/scanpy/plotting/_tools/__init__.py
@@ -101,26 +101,6 @@ def pca_overview(adata: AnnData, **params):
     pca_variance_ratio(adata, show=show)
 
 
-# backwards compat
-@_doc_params(scatter_bulk=doc_scatter_embedding, show_save_ax=doc_show_save_ax)
-def pca_scatter(adata: AnnData, **params):
-    """Scatter plot in PCA coordinates.
-
-    This is a backwards-compatible alias for :func:`~scanpy.pl.pca`.
-
-    Parameters
-    ----------
-    adata
-        Annotated data matrix.
-    {scatter_bulk}
-    {show_save_ax}
-
-    Returns
-    -------
-    If `show==False` a :class:`~matplotlib.axes.Axes` or a list of it.
-    return pca(adata, **params)
-
-
 def pca_loadings(
     adata: AnnData,
     components: str | Sequence[int] | None = None,


### PR DESCRIPTION
Adds an inline rendered example for `sc.pl.pca_scatter`, addressing part of #1664.

`pca_scatter` is a backwards-compatible alias for `pca`, so this PR replaces the plain alias with a small wrapper that keeps behavior unchanged while giving the alias its own docstring and plot example.

- [x] Addresses part of #1664 
- [x] [Tests][] included or not required because: this is a documentation-only change adding an inline example for `sc.pl.pca_scatter`.
- [x] [Release notes][] not necessary because: this only adds a documentation example and does not change user-facing behavior.
