### PR TITLE
fix: masked cells were accidentally added to group 0 + mask ignored in aggregate computations in `get.aggregate`

### DIFF
--- a/docs/release-notes/4178.fix.md
+++ b/docs/release-notes/4178.fix.md
@@ -1,0 +1,1 @@
+Fix usage of {func}`scanpy.get.aggregate` with `mask` argument mis-assigning values that are masked out to category 0 + correct group size calculation when `mask` {smaller}`Z Boldyga`

--- a/docs/release-notes/4178.fix.md
+++ b/docs/release-notes/4178.fix.md
@@ -1,1 +1,1 @@
-Fix usage of {func}`scanpy.get.aggregate` with `mask` argument mis-assigning values that are masked out to category 0 + correct group size calculation when `mask` {smaller}`Z Boldyga`
+Fix usage of {func}`scanpy.get.aggregate` with `mask` argument mis-assigning values that are masked out to category 0 + correct group size calculation with `mask` {smaller}`Z Boldyga`

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -160,10 +160,10 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         """
         medians = []
         for group in range(len(self.groupby.categories)):
-            mask = self.groupby.codes == group
+            group_mask = self.groupby.codes == group
             if self.mask is not None:
-                mask = mask & self.mask
-            group_data = self.data[mask]
+                group_mask = group_mask & self.mask
+            group_data = self.data[group_mask]
             if isinstance(group_data, CSBase):
                 if group_data.format != "csc":
                     group_data = group_data.tocsc()

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -158,10 +158,9 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         Array of median.
 
         """
-        keep = _kept_observations(self.groupby, self.mask)
         medians = []
         for group in range(len(self.groupby.categories)):
-            group_data = self.data[keep & (self.groupby.codes == group)]
+            group_data = self.data[self.mask & (self.groupby.codes == group)]
             if isinstance(group_data, CSBase):
                 if group_data.format != "csc":
                     group_data = group_data.tocsc()

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -67,6 +67,7 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         self.groupby = groupby
         if (missing := groupby.isna()).any():
             mask = mask & ~missing if mask is not None else ~missing
+        self.mask = mask
         self.indicator_matrix = sparse_indicator(groupby, mask=mask)
         if isinstance(data, CSBase):
             # TODO: Look into if this can be CSR and fast for dense
@@ -75,6 +76,7 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
 
     groupby: pd.Categorical
     indicator_matrix: CSRBase | sparse.coo_array
+    mask: NDArray[np.bool] | None
     data: ArrayT
 
     def count_nonzero(self) -> NDArray[np.integer]:
@@ -118,7 +120,7 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         Array of mean.
 
         """
-        return self.sum() / np.bincount(self.groupby.codes)[:, None]
+        return self.sum() / _group_counts(self.groupby, self.mask)[:, None]
 
     def mean_var(self, dof: int = 1) -> tuple[np.ndarray, np.ndarray]:
         """Compute the count, as well as mean and variance per feature, per group of observations.
@@ -139,7 +141,7 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         """
         assert dof >= 0
 
-        group_counts = np.bincount(self.groupby.codes)
+        group_counts = _group_counts(self.groupby, self.mask)
         if isinstance(self.data, np.ndarray):
             mean_, var_ = mean_var_dense(self.indicator_matrix.tocsr(), self.data)
         else:
@@ -158,10 +160,10 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         Array of median.
 
         """
+        keep = _kept_observations(self.groupby, self.mask)
         medians = []
-        for group in np.unique(self.groupby.codes):
-            group_mask = self.groupby.codes == group
-            group_data = self.data[group_mask]
+        for group in range(len(self.groupby.categories)):
+            group_data = self.data[keep & (self.groupby.codes == group)]
             if isinstance(group_data, CSBase):
                 if group_data.format != "csc":
                     group_data = group_data.tocsc()
@@ -307,10 +309,10 @@ def aggregate(  # noqa: PLR0912
     dim_df = getattr(adata, axis_name)
     categorical, new_label_df = _combine_categories(dim_df, by)
 
-    # Add number of obs aggregated into each group
-    new_label_df["n_obs_aggregated"] = (
-        pd.Series(categorical).value_counts().reindex(new_label_df.index)
-    )
+    # Add number of obs aggregated into each group (respecting the mask)
+    new_label_df["n_obs_aggregated"] = pd.Series(
+        _group_counts(categorical, mask), index=categorical.categories
+    ).reindex(new_label_df.index)
     # Actual computation
     layers = _aggregate(
         data,
@@ -372,7 +374,7 @@ def aggregate_dask_mean_var(
         sq_mean = sq_mean.compute()
     var = sq_mean - fau_power(mean, 2)
     if dof != 0:
-        group_counts = np.bincount(by.codes)
+        group_counts = _group_counts(by, mask)
         var *= (group_counts / (group_counts - dof))[:, np.newaxis]
     return MeanVarDict(mean=mean, var=var)
 
@@ -454,7 +456,7 @@ def aggregate_dask(
     # division must come after, not before, the summation for numerical precision
     # i.e., we can't just call map blocks over the mean function.
     elif has_mean:
-        group_counts = np.bincount(by.codes)
+        group_counts = _group_counts(by, mask)
         aggregated["mean"] = (
             aggregate_dask(data, by, "sum", mask=mask, dof=dof)["sum"]
             / group_counts[:, None]
@@ -555,19 +557,30 @@ def _combine_categories(
     return result_categorical, new_label_df
 
 
+def _group_counts(
+    categorical: pd.Categorical, mask: NDArray[np.bool] | None
+) -> NDArray[np.int64]:
+    """Count observations per category, ignoring unassigned (NaN) and masked-out ones."""
+    keep = _kept_observations(categorical, mask)
+    return np.bincount(categorical.codes[keep], minlength=len(categorical.categories))
+
+
+def _kept_observations(
+    categorical: pd.Categorical, mask: NDArray[np.bool] | None
+) -> NDArray[np.bool]:
+    """Boolean selector of observations that are assigned to a category and unmasked."""
+    keep = categorical.codes >= 0
+    return keep if mask is None else keep & mask
+
+
 def sparse_indicator(
     categorical: pd.Categorical,
     *,
     mask: NDArray[np.bool] | None = None,
 ) -> sparse.coo_array:
-    # TODO: why is this float64.  This is a scanpy 2.0 problem maybe?
-    mask = (
-        np.broadcast_to(1.0, len(categorical)) if mask is None else mask.astype("uint8")
-    )
-    # can’t have -1s in the codes, but (as long as it’s valid), the value is ignored, so set to 0 where masked
-    codes = np.where(mask, categorical.codes, 0)
-    a = sparse.coo_array(
-        (mask, (codes, np.arange(len(categorical)))),
+    keep = _kept_observations(categorical, mask)
+    obs = np.flatnonzero(keep)
+    return sparse.coo_array(
+        (np.ones(obs.shape[0]), (categorical.codes[keep], obs)),
         shape=(len(categorical.categories), len(categorical)),
     )
-    return a

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -65,8 +65,6 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         mask: NDArray[np.bool] | None = None,
     ) -> None:
         self.groupby = groupby
-        if (missing := groupby.isna()).any():
-            mask = mask & ~missing if mask is not None else ~missing
         self.mask = mask
         self.indicator_matrix = sparse_indicator(groupby, mask=mask)
         if isinstance(data, CSBase):

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -160,7 +160,10 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
         """
         medians = []
         for group in range(len(self.groupby.categories)):
-            group_data = self.data[self.mask & (self.groupby.codes == group)]
+            mask = self.groupby.codes == group
+            if self.mask is not None:
+                mask = mask & self.mask
+            group_data = self.data[mask]
             if isinstance(group_data, CSBase):
                 if group_data.format != "csc":
                     group_data = group_data.tocsc()

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -68,87 +68,39 @@ def test_mask(axis: Literal[0, 1]) -> None:
 
 
 @pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
-@pytest.mark.parametrize("func", ["sum", "count_nonzero", "mean", "var", "median"])
-def test_aggregate_mask_matches_subset(
-    array_type, func: AggType, request: pytest.FixtureRequest
-) -> None:
-    rng = np.random.default_rng(0)
-    n_per, n_features = 4, 2
-    groups = np.repeat(["a", "b", "c"], n_per)
-    x = rng.standard_normal((len(groups), n_features))
-    keep = np.ones(len(groups), dtype=bool)
-    for start in range(0, len(groups), n_per):
-        keep[start] = False
-        x[start] = 1e6
-    index = [f"cell{i}" for i in range(len(groups))]
-    adata = ad.AnnData(
-        X=x, obs=pd.DataFrame({"grp": pd.Categorical(groups)}, index=index)
-    )
-
-    expected = sc.get.aggregate(adata[keep].copy(), "grp", func)
-
-    adata.X = array_type(adata.X)
-    xfail_dask_median(adata, func, request)
-    result = sc.get.aggregate(adata, "grp", func, mask=keep)
-
-    assert list(result.obs_names) == list(expected.obs_names)
-    assert (
-        result.obs["n_obs_aggregated"].tolist()
-        == expected.obs["n_obs_aggregated"].tolist()
-    )
-    actual = result.layers[func]
-    if isinstance(actual, DaskArray):
-        actual = actual.compute()
-    np.testing.assert_allclose(
-        np.asarray(actual), np.asarray(expected.layers[func]), rtol=1e-6, atol=1e-8
-    )
-
-
-@pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
-@pytest.mark.parametrize("func", ["mean", "var", "median"])
-def test_aggregate_nan_group_matches_dropna(
-    array_type, func: AggType, request: pytest.FixtureRequest
-) -> None:
-    rng = np.random.default_rng(0)
-    n_per, n_features = 4, 2
-    labels = np.repeat(["a", "b", "c"], n_per).astype(object)
-    labels[1] = None
-    x = rng.standard_normal((len(labels), n_features))
-    index = [f"cell{i}" for i in range(len(labels))]
-    adata = ad.AnnData(
-        X=x, obs=pd.DataFrame({"grp": pd.Categorical(labels)}, index=index)
-    )
-    notna = ~pd.isna(labels)
-
-    expected = sc.get.aggregate(adata[notna].copy(), "grp", func)
-
-    adata.X = array_type(adata.X)
-    xfail_dask_median(adata, func, request)
-    result = sc.get.aggregate(adata, "grp", func)
-
-    assert list(result.obs_names) == list(expected.obs_names)
-    actual = result.layers[func]
-    if isinstance(actual, DaskArray):
-        actual = actual.compute()
-    np.testing.assert_allclose(
-        np.asarray(actual), np.asarray(expected.layers[func]), rtol=1e-6, atol=1e-8
-    )
-
-
-@pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
+@pytest.mark.parametrize("use_mask", [True, False], ids=["masked", "unmasked"])
+@pytest.mark.parametrize("with_na", [True, False], ids=["na", "no_na"])
 def test_aggregate_vs_pandas(
-    metric: AggType, array_type, request: pytest.FixtureRequest
+    metric: AggType,
+    array_type,
+    request: pytest.FixtureRequest,
+    *,
+    use_mask: bool,
+    with_na: bool,
 ) -> None:
     adata = pbmc3k_processed().raw.to_adata()
     adata = adata[
         adata.obs["louvain"].isin(adata.obs["louvain"].cat.categories[:5]), :1_000
     ].copy()
     adata.X = array_type(adata.X)
+    if with_na:
+        nas = list(range(0, adata.shape[0], 5))
+        adata.obs.iloc[nas, adata.obs.columns.get_loc("louvain")] = pd.NA
+    kwargs = {}
+    if use_mask:
+        mask = np.ones(adata.shape[0], dtype=bool)
+        for excluded in range(0, adata.shape[0], 4):
+            mask[excluded] = False
+        kwargs["mask"] = mask
     xfail_dask_median(adata, metric, request)
     adata.obs["percent_mito_binned"] = pd.cut(adata.obs["percent_mito"], bins=5)
-    result = sc.get.aggregate(adata, ["louvain", "percent_mito_binned"], metric)
+    result = sc.get.aggregate(
+        adata, ["louvain", "percent_mito_binned"], metric, **kwargs
+    )
     if isinstance(adata.X, DaskArray):
         adata.X = adata.X.compute()
+    if use_mask:
+        adata = adata[mask]
     if metric == "count_nonzero":
         expected = (
             (adata.to_df() != 0)
@@ -174,7 +126,10 @@ def test_aggregate_vs_pandas(
     result_df = result.to_df(layer=metric)
     result_df.index.name = None
     result_df.columns.name = None
-
+    expected_counts = adata.obs.groupby(
+        ["louvain", "percent_mito_binned"], observed=True
+    ).size()
+    assert result.obs["n_obs_aggregated"].tolist() == expected_counts.tolist()
     pd.testing.assert_frame_equal(result_df, expected, check_dtype=False, atol=1e-5)
 
 

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -70,6 +70,9 @@ def test_mask(axis: Literal[0, 1]) -> None:
 @pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
 @pytest.mark.parametrize("use_mask", [True, False], ids=["masked", "unmasked"])
 @pytest.mark.parametrize("with_na", [True, False], ids=["na", "no_na"])
+@pytest.mark.parametrize(
+    "remove_unused_categories", [True, False], ids=["removed_unused", "all_categories"]
+)
 def test_aggregate_vs_pandas(
     metric: AggType,
     array_type,
@@ -77,11 +80,13 @@ def test_aggregate_vs_pandas(
     *,
     use_mask: bool,
     with_na: bool,
+    remove_unused_categories: bool,
 ) -> None:
     adata = pbmc3k_processed().raw.to_adata()
-    adata = adata[
-        adata.obs["louvain"].isin(adata.obs["louvain"].cat.categories[:5]), :1_000
-    ].copy()
+    with ad.settings.override(remove_unused_categories=remove_unused_categories):
+        adata = adata[
+            adata.obs["louvain"].isin(adata.obs["louvain"].cat.categories[:5]), :1_000
+        ].copy()
     adata.X = array_type(adata.X)
     if with_na:
         nas = list(range(0, adata.shape[0], 5))

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -68,6 +68,74 @@ def test_mask(axis: Literal[0, 1]) -> None:
 
 
 @pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
+@pytest.mark.parametrize("func", ["sum", "count_nonzero", "mean", "var", "median"])
+def test_aggregate_mask_matches_subset(
+    array_type, func: AggType, request: pytest.FixtureRequest
+) -> None:
+    rng = np.random.default_rng(0)
+    n_per, n_features = 4, 2
+    groups = np.repeat(["a", "b", "c"], n_per)
+    x = rng.standard_normal((len(groups), n_features))
+    keep = np.ones(len(groups), dtype=bool)
+    for start in range(0, len(groups), n_per):
+        keep[start] = False
+        x[start] = 1e6
+    index = [f"cell{i}" for i in range(len(groups))]
+    adata = ad.AnnData(
+        X=x, obs=pd.DataFrame({"grp": pd.Categorical(groups)}, index=index)
+    )
+
+    expected = sc.get.aggregate(adata[keep].copy(), "grp", func)
+
+    adata.X = array_type(adata.X)
+    xfail_dask_median(adata, func, request)
+    result = sc.get.aggregate(adata, "grp", func, mask=keep)
+
+    assert list(result.obs_names) == list(expected.obs_names)
+    assert (
+        result.obs["n_obs_aggregated"].tolist()
+        == expected.obs["n_obs_aggregated"].tolist()
+    )
+    actual = result.layers[func]
+    if isinstance(actual, DaskArray):
+        actual = actual.compute()
+    np.testing.assert_allclose(
+        np.asarray(actual), np.asarray(expected.layers[func]), rtol=1e-6, atol=1e-8
+    )
+
+
+@pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
+@pytest.mark.parametrize("func", ["mean", "var", "median"])
+def test_aggregate_nan_group_matches_dropna(
+    array_type, func: AggType, request: pytest.FixtureRequest
+) -> None:
+    rng = np.random.default_rng(0)
+    n_per, n_features = 4, 2
+    labels = np.repeat(["a", "b", "c"], n_per).astype(object)
+    labels[1] = None
+    x = rng.standard_normal((len(labels), n_features))
+    index = [f"cell{i}" for i in range(len(labels))]
+    adata = ad.AnnData(
+        X=x, obs=pd.DataFrame({"grp": pd.Categorical(labels)}, index=index)
+    )
+    notna = ~pd.isna(labels)
+
+    expected = sc.get.aggregate(adata[notna].copy(), "grp", func)
+
+    adata.X = array_type(adata.X)
+    xfail_dask_median(adata, func, request)
+    result = sc.get.aggregate(adata, "grp", func)
+
+    assert list(result.obs_names) == list(expected.obs_names)
+    actual = result.layers[func]
+    if isinstance(actual, DaskArray):
+        actual = actual.compute()
+    np.testing.assert_allclose(
+        np.asarray(actual), np.asarray(expected.layers[func]), rtol=1e-6, atol=1e-8
+    )
+
+
+@pytest.mark.parametrize("array_type", VALID_ARRAY_TYPES)
 def test_aggregate_vs_pandas(
     metric: AggType, array_type, request: pytest.FixtureRequest
 ) -> None:

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -6,10 +6,11 @@ import anndata as ad
 import numpy as np
 import pandas as pd
 import pytest
+from packaging.version import Version
 from scipy import sparse
 
 import scanpy as sc
-from scanpy._compat import DaskArray
+from scanpy._compat import DaskArray, pkg_version
 from scanpy._utils import _resolve_axis, get_literal_vals
 from scanpy.get._aggregated import AggType
 from testing.scanpy._helpers import assert_equal
@@ -83,10 +84,19 @@ def test_aggregate_vs_pandas(
     remove_unused_categories: bool,
 ) -> None:
     adata = pbmc3k_processed().raw.to_adata()
-    with ad.settings.override(remove_unused_categories=remove_unused_categories):
-        adata = adata[
-            adata.obs["louvain"].isin(adata.obs["louvain"].cat.categories[:5]), :1_000
-        ].copy()
+    anndata_has_settings = pkg_version("anndata") >= Version("0.11")
+    cat_col = adata.obs["louvain"]
+    categories = cat_col.cat.categories
+    if anndata_has_settings:
+        with ad.settings.override(remove_unused_categories=remove_unused_categories):
+            adata = adata[cat_col.isin(categories[:5]), :1_000].copy()
+    else:
+        del adata.obs["louvain"]
+        mask = cat_col.isin(categories[:5])
+        adata = adata[mask, :1_000].copy()
+        adata.obs["louvain"] = cat_col[mask]
+        if remove_unused_categories:
+            adata.obs["louvain"] = adata.obs["louvain"].cat.remove_unused_categories()
     adata.X = array_type(adata.X)
     if with_na:
         nas = list(range(0, adata.shape[0], 5))


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
