### PR TITLE
fix: inconsist variance output between in-memory and dask for groups of size 1

### DIFF
--- a/docs/release-notes/4184.fix.md
+++ b/docs/release-notes/4184.fix.md
@@ -1,0 +1,1 @@
+Fix single-observation (or `n_obs == dof`) aggregated variance in {func}`scanpy.get.aggregate` {smaller}`Z Boldyga`

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -11,7 +11,7 @@ from fast_array_utils.numba import njit
 from scipy import sparse
 from sklearn.utils.sparsefuncs import csc_median_axis_0
 
-from scanpy._compat import CSBase, CSRBase, DaskArray
+from scanpy._compat import CSBase, CSRBase, DaskArray, warn
 
 from .._utils import _resolve_axis, get_literal_vals
 from ._kernels import (
@@ -149,6 +149,10 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
             )(self.indicator_matrix, self.data)
         if dof != 0:
             denom = np.where(group_counts > dof, group_counts - dof, np.nan)
+            which_nan = np.isnan(denom)
+            if which_nan.any():
+                msg = f"Group counts matches dof, resulting var for groups {self.groupby.categories[which_nan].to_list()} will be nan"
+                warn(msg, RuntimeWarning)
             var_ *= (group_counts / denom)[:, np.newaxis]
         return mean_, var_
 

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -148,7 +148,8 @@ class Aggregate[ArrayT: np.ndarray | CSBase]:
                 mean_var_csr if isinstance(self.data, CSRBase) else mean_var_csc
             )(self.indicator_matrix, self.data)
         if dof != 0:
-            var_ *= (group_counts / np.maximum(group_counts - dof, 1))[:, np.newaxis]
+            denom = np.where(group_counts > dof, group_counts - dof, np.nan)
+            var_ *= (group_counts / denom)[:, np.newaxis]
         return mean_, var_
 
     def median(self) -> Array:
@@ -427,7 +428,7 @@ def aggregate_dask_mean_var(
     counts = combined[0]
     mean_ = combined[1]
     m2 = combined[2]
-    denom = counts - dof if dof > 0 else counts
+    denom = da.where(counts > dof, counts - dof, np.nan) if dof > 0 else counts
     return MeanVarDict(mean=mean_, var=m2 / denom)
 
 
@@ -452,9 +453,9 @@ def _block_moments(
         return out
 
     agg = Aggregate(groupby=by, data=data, mask=mask)
-    mean_, var_ = agg.mean_var()
-    # M2 is the variance times the counts directly minus correction.
-    m2 = var_ * (counts - 1)[:, np.newaxis]
+    mean_, var_ = agg.mean_var(dof=0)
+    # M2 (sum of squared deviations) is the population variance times the count.
+    m2 = var_ * counts[:, np.newaxis]
     out[1, :] = mean_
     out[2, :] = m2
     return out

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -670,7 +670,9 @@ def test_aggregate_var_group_matches_dof(dof: int) -> None:
     var = dict(zip(["a", "b"], in_memory[:, 0], strict=True))
     for cat in ["a", "b"]:
         with (
-            pytest.warns(RuntimeWarning, match="((Degrees of freedom.*))")
+            pytest.warns(
+                RuntimeWarning, match="((Degrees of freedom.*)|(.*invalid value.*))"
+            )
             if dof > 0 and cat == "b"
             else nullcontext()
         ):

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -633,30 +633,44 @@ def test_var_no_catastrophic_cancellation(array_type) -> None:
 
 
 @needs.dask
-def test_aggregate_var_singleton_group() -> None:
-    # Guards that a one-observation group's variance is nan (not 0), and that a
+@pytest.mark.parametrize("dof", [0, 1, 4])
+def test_aggregate_var_group_matches_dof(dof: int) -> None:
+    # Guards that a one-observation (or n_obs==dof) group's variance is nan (not 0), and that a
     # group split into single-observation chunks keeps its correct variance
     # rather than being corrupted to nan by the dask per-chunk combine.
     import dask.array as da
 
-    x = np.array([[1.0], [2.0], [3.0]])
+    run_size = max(1, dof)
+    x = np.array(([1.0] * run_size) + ([2.0] * run_size) + ([3.0] * run_size)).reshape(
+        3 * run_size, 1
+    )
     obs = pd.DataFrame(
-        {"group": pd.Categorical(["a", "b", "a"])},
-        index=[f"cell_{i}" for i in range(3)],
+        {
+            "group": pd.Categorical(
+                (["a"] * run_size) + (["b"] * run_size) + (["a"] * run_size)
+            )
+        },
+        index=[f"cell_{i}" for i in range(x.shape[0])],
     )
 
-    in_memory = sc.get.aggregate(ad.AnnData(X=x, obs=obs), "group", "var").layers["var"]
-    dask_x = da.from_array(x, chunks=(1, -1))  # tests chunks that contain one item
+    in_memory = sc.get.aggregate(
+        ad.AnnData(X=x, obs=obs), "group", "var", dof=dof
+    ).layers["var"]
+    # tests chunks that contain run_size item i.e., chunk matches dof
+    dask_x = da.from_array(x, chunks=(run_size, -1))
     dask = (
         sc.get
-        .aggregate(ad.AnnData(X=dask_x, obs=obs), "group", "var")
+        .aggregate(ad.AnnData(X=dask_x, obs=obs), "group", "var", dof=dof)
         .layers["var"]
         .compute()
     )
 
     np.testing.assert_allclose(in_memory, dask)  # equal_nan=True by default
     var = dict(zip(["a", "b"], in_memory[:, 0], strict=True))
-    assert (
-        var["a"] == 2.0
-    )  # two observations in two separate chunks -> finite, not corrupted
-    assert np.isnan(var["b"])  # one observation -> undefined sample variance
+    # two observations in two separate chunks -> finite, not corrupted
+    assert var["a"] == (2.0 if dof > 0 else 1.0)
+    # one observation and dof > 0 -> undefined sample variance, otherwise 0
+    if dof > 0:
+        assert np.isnan(var["b"])
+    else:
+        assert var["b"] == 0

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -653,10 +653,14 @@ def test_aggregate_var_group_matches_dof(dof: int) -> None:
         },
         index=[f"cell_{i}" for i in range(x.shape[0])],
     )
-
-    in_memory = sc.get.aggregate(
-        ad.AnnData(X=x, obs=obs), "group", "var", dof=dof
-    ).layers["var"]
+    with (
+        pytest.warns(RuntimeWarning, match=r".*groups \['b'\] will be nan.*")
+        if dof > 0
+        else nullcontext()
+    ):
+        in_memory = sc.get.aggregate(
+            ad.AnnData(X=x, obs=obs), "group", "var", dof=dof
+        ).layers["var"]
     # tests chunks that contain run_size item i.e., chunk matches dof
     dask_x = da.from_array(x, chunks=(run_size, -1))
     dask = (
@@ -671,7 +675,7 @@ def test_aggregate_var_group_matches_dof(dof: int) -> None:
     for cat in ["a", "b"]:
         with (
             pytest.warns(
-                RuntimeWarning, match="((Degrees of freedom.*)|(.*invalid value.*))"
+                RuntimeWarning, match=r"((Degrees of freedom.*)|(.*invalid value.*))"
             )
             if dof > 0 and cat == "b"
             else nullcontext()

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -630,3 +630,32 @@ def test_var_no_catastrophic_cancellation(array_type) -> None:
     if isinstance(result, DaskArray):
         result = result.compute()
     np.testing.assert_allclose(result, expected, rtol=1e-4)
+
+
+def test_aggregate_var_singleton_group() -> None:
+    # Guards that a one-observation group's variance is nan (not 0), and that a
+    # group split into single-observation chunks keeps its correct variance
+    # rather than being corrupted to nan by the dask per-chunk combine.
+    import dask.array as da
+
+    x = np.array([[1.0], [2.0], [3.0]])
+    obs = pd.DataFrame(
+        {"group": pd.Categorical(["a", "b", "a"])},
+        index=[f"cell_{i}" for i in range(3)],
+    )
+
+    in_memory = sc.get.aggregate(ad.AnnData(X=x, obs=obs), "group", "var").layers["var"]
+    dask_x = da.from_array(x, chunks=(1, -1))  # tests chunks that contain one item
+    dask = (
+        sc.get
+        .aggregate(ad.AnnData(X=dask_x, obs=obs), "group", "var")
+        .layers["var"]
+        .compute()
+    )
+
+    np.testing.assert_allclose(in_memory, dask)  # equal_nan=True by default
+    var = dict(zip(["a", "b"], in_memory[:, 0], strict=True))
+    assert (
+        var["a"] == 2.0
+    )  # two observations in two separate chunks -> finite, not corrupted
+    assert np.isnan(var["b"])  # one observation -> undefined sample variance

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
 import anndata as ad
@@ -664,13 +665,15 @@ def test_aggregate_var_group_matches_dof(dof: int) -> None:
         .layers["var"]
         .compute()
     )
-
-    np.testing.assert_allclose(in_memory, dask)  # equal_nan=True by default
+    # equal_nan=True by default
+    np.testing.assert_allclose(in_memory, dask)
     var = dict(zip(["a", "b"], in_memory[:, 0], strict=True))
-    # two observations in two separate chunks -> finite, not corrupted
-    assert var["a"] == (2.0 if dof > 0 else 1.0)
-    # one observation and dof > 0 -> undefined sample variance, otherwise 0
-    if dof > 0:
-        assert np.isnan(var["b"])
-    else:
-        assert var["b"] == 0
+    for cat in ["a", "b"]:
+        with (
+            pytest.warns(RuntimeWarning, match="((Degrees of freedom.*))")
+            if dof > 0 and cat == "b"
+            else nullcontext()
+        ):
+            np.testing.assert_equal(
+                var[cat], np.var(x[(obs["group"] == cat).to_numpy()], ddof=dof)
+            )

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -632,6 +632,7 @@ def test_var_no_catastrophic_cancellation(array_type) -> None:
     np.testing.assert_allclose(result, expected, rtol=1e-4)
 
 
+@needs.dask
 def test_aggregate_var_singleton_group() -> None:
     # Guards that a one-observation group's variance is nan (not 0), and that a
     # group split into single-observation chunks keeps its correct variance


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
