### PR TITLE
fix: aggregate dask multifunc

### DIFF
--- a/docs/release-notes/4192.fix.md
+++ b/docs/release-notes/4192.fix.md
@@ -1,0 +1,1 @@
+Fix {func}`scanpy.get.aggregate` on `dask` arrays when `func` is a list containing `count_nonzero` or `sum` {smaller}`Z Boldyga`

--- a/src/scanpy/get/_aggregated.py
+++ b/src/scanpy/get/_aggregated.py
@@ -566,13 +566,13 @@ def aggregate_dask(
     )
     aggregated = {
         f: data.map_blocks(
-            partial(aggregate_chunk_sum_or_count_nonzero, func=func),
+            partial(aggregate_chunk_sum_or_count_nonzero, func=f),
             new_axis=(1,) if unchunked_axis == 1 else None,
             chunks=chunks,
             meta=np.array(
                 [],
                 dtype=np.float64
-                if func not in get_args(ConstantDtypeAgg)
+                if f not in get_args(ConstantDtypeAgg)
                 else data.dtype,  # TODO: figure out best dtype for aggs like sum where dtype can change from original
             ),
         )

--- a/tests/test_aggregated.py
+++ b/tests/test_aggregated.py
@@ -244,6 +244,23 @@ def test_aggregate_bad_dask_array(
         sc.get.aggregate(adata, ["louvain"], "sum")
 
 
+@needs.dask
+@pytest.mark.parametrize("func", [["count_nonzero"], ["sum", "mean", "count_nonzero"]])
+def test_aggregate_dask_multiple_funcs(func: list[AggType]) -> None:
+    """A multi-func list incl. count_nonzero/sum must survive `.compute()` on dask."""
+    import dask.array as da
+
+    adata = sc.datasets.blobs()
+    dask_adata = adata.copy()
+    dask_adata.X = da.from_array(adata.X, chunks=(adata.shape[0] // 2, -1))
+    expected = sc.get.aggregate(adata, "blobs", func=func)
+    result = sc.get.aggregate(dask_adata, "blobs", func=func)
+    for f in func:
+        np.testing.assert_allclose(
+            np.asarray(expected.layers[f]), np.asarray(result.layers[f])
+        )
+
+
 @pytest.mark.parametrize("axis_name", ["obs", "var"])
 def test_aggregate_axis_specification(axis_name: Literal["obs", "var"]) -> None:
     axis, axis_name = _resolve_axis(axis_name)


### PR DESCRIPTION
@ilan-gold there was a pre-existing bug in aggregate's dask code that causes a failure when calling with multiple function types. it works for just mean and var, but if adding anything else it failed. simple fix. this is a blocker for the stats PR

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
