### PR TITLE
chore: bound asv-runner by 0.2.2

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,8 +47,7 @@ jobs:
 
       - name: Install dependencies
         # https://github.com/airspeed-velocity/asv/issues/1577
-        # https://github.com/airspeed-velocity/asv_runner/issues/52
-        run: pip install 'asv>=0.6.4' 'py-rattler<0.22' 'asv_runner<0.2.2'
+        run: pip install 'asv>=0.6.4' 'py-rattler<0.22'
 
       - name: Configure ASV
         working-directory: ${{ env.ASV_DIR }}

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -47,7 +47,8 @@ jobs:
 
       - name: Install dependencies
         # https://github.com/airspeed-velocity/asv/issues/1577
-        run: pip install 'asv>=0.6.4' 'py-rattler<0.22'
+        # https://github.com/airspeed-velocity/asv_runner/issues/52
+        run: pip install 'asv>=0.6.4' 'py-rattler<0.22' 'asv_runner<0.2.2'
 
       - name: Configure ASV
         working-directory: ${{ env.ASV_DIR }}

--- a/benchmarks/asv.conf.json
+++ b/benchmarks/asv.conf.json
@@ -71,6 +71,8 @@
     // followed by the pip installed packages).
     //
     "matrix": {
+        // https://github.com/airspeed-velocity/asv_runner/issues/52
+        "pip+asv_runner": ["0.2.1"],
         "numpy": [""],
         "scipy": [""],
         "h5py": [""],


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

See https://github.com/airspeed-velocity/asv_runner/issues/52

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: Dev change

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
