### PR TITLE
chore: stale AnnData.concatenate references

### DIFF
--- a/docs/release-notes/0.3.0.md
+++ b/docs/release-notes/0.3.0.md
@@ -1,7 +1,7 @@
 (v0.3.0)=
 ### 0.3.0 {small}`2017-11-16`
 
-- {class}`~anndata.AnnData` gains method {meth}`~anndata.AnnData.concatenate` {smaller}`A Wolf`
+- {class}`~anndata.AnnData` gains method `AnnData.concatenate` {smaller}`A Wolf`
 - {class}`~anndata.AnnData` is available as the separate [anndata] package {smaller}`P Angerer, A Wolf`
 - results of [PAGA](https://github.com/theislab/paga) simplified {smaller}`A Wolf`
 

--- a/src/scanpy/external/pp/_mnn_correct.py
+++ b/src/scanpy/external/pp/_mnn_correct.py
@@ -68,13 +68,13 @@ def mnn_correct(  # noqa: PLR0913
         correction. Typically, a list of highly variable genes (HVGs).
         When set to `None`, uses all vars.
     batch_key
-        The `batch_key` for :meth:`~anndata.AnnData.concatenate`.
+        The `batch_key` for ``anndata.AnnData.concatenate``.
         Only valid when `do_concatenate` and supplying `AnnData` objects.
     index_unique
-        The `index_unique` for :meth:`~anndata.AnnData.concatenate`.
+        The `index_unique` for ``anndata.AnnData.concatenate``.
         Only valid when `do_concatenate` and supplying `AnnData` objects.
     batch_categories
-        The `batch_categories` for :meth:`~anndata.AnnData.concatenate`.
+        The `batch_categories` for ``anndata.AnnData.concatenate``.
         Only valid when `do_concatenate` and supplying AnnData objects.
     k
         Number of mutual nearest neighbors.

--- a/src/scanpy/external/tl/_harmony_timeseries.py
+++ b/src/scanpy/external/tl/_harmony_timeseries.py
@@ -83,7 +83,7 @@ def harmony_timeseries(
 
     >>> from itertools import product
     >>> import pandas as pd
-    >>> from anndata import AnnData
+    >>> from anndata import AnnData, concat
     >>> import scanpy as sc
     >>> import scanpy.external as sce
 
@@ -97,11 +97,12 @@ def harmony_timeseries(
 
     >>> adata_ref = sc.datasets.pbmc3k()
     >>> start = [596, 615, 1682, 1663, 1409, 1432]
-    >>> adata = AnnData.concatenate(
-    ...     *(adata_ref[i : i + 1000] for i in start),
+    >>> adata = concat(
+    ...     [adata_ref[i : i + 1000] for i in start],
     ...     join="outer",
-    ...     batch_key="sample",
-    ...     batch_categories=[f"sa{i}_Rep{j}" for i, j in product((1, 2, 3), (1, 2))],
+    ...     label="sample",
+    ...     keys=[f"sa{i}_Rep{j}" for i, j in product((1, 2, 3), (1, 2))],
+    ...     index_unique="-",
     ... )
     >>> time_points = adata.obs["sample"].str.split("_", expand=True)[0]
     >>> adata.obs["time_points"] = pd.Categorical(

--- a/tests/external/test_harmony_timeseries.py
+++ b/tests/external/test_harmony_timeseries.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from itertools import product
 
-from anndata import AnnData
+from anndata import concat
 
 import scanpy as sc
 import scanpy.external as sce
@@ -15,11 +15,12 @@ pytestmark = [needs.harmony]
 def test_load_timepoints_from_anndata_list():
     adata_ref = pbmc3k()
     start = [596, 615, 1682, 1663, 1409, 1432]
-    adata = AnnData.concatenate(
-        *(adata_ref[i : i + 1000] for i in start),
+    adata = concat(
+        [adata_ref[i : i + 1000] for i in start],
         join="outer",
-        batch_key="sample",
-        batch_categories=[f"sa{i}_Rep{j}" for i, j in product((1, 2, 3), (1, 2))],
+        label="sample",
+        keys=[f"sa{i}_Rep{j}" for i, j in product((1, 2, 3), (1, 2))],
+        index_unique="-",
     )
     adata.obs["time_points"] = adata.obs["sample"].str.split("_", expand=True)[0]
     adata.obs["time_points"] = adata.obs["time_points"].astype("category")


### PR DESCRIPTION
This PR fixes stale references to `AnnData.concatenate`, which was removed from `anndata` (scverse/anndata#2370) and is no longer available in the hosted intersphinx inventory. These stale references were causing the Read the Docs build to fail.

Changes:

- Replace broken Sphinx `AnnData.concatenate` method links with plain literal text.
- Update the Harmony time-series example and test to use `anndata.concat`.
- Preserve the previous unique-index behavior with `index_unique="-"`.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: this is just a fix for stale historical references caused by an upstream `anndata` API removal.

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs