### PR TITLE
docs: Remove duplicated 'layer' parameter from PCA documentation

### DIFF
--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -159,8 +159,6 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         Only relevant when not passing an :class:`~anndata.AnnData`:
         see “Returns”.
     {mask_var}
-    layer
-        Layer of `adata` to use as expression values.
     dtype
         Numpy data type string to which to convert the result.
     key_added


### PR DESCRIPTION
Fix small documentation error: the 'layer' parameter is documented twice for the PCA preprocessing function.
