### PR TITLE
perf: illico + numba threads

### DIFF
--- a/docs/release-notes/4205.perf.md
+++ b/docs/release-notes/4205.perf.md
@@ -1,0 +1,3 @@
+Run the [`illico`][] `wilcoxon` backend of {func}`scanpy.tl.rank_genes_groups` multithreaded according to {attr}`scanpy.settings.n_jobs` {smaller}`Z Boldyga`
+
+[`illico`]: https://github.com/remydubois/illico

--- a/docs/release-notes/4205.perf.md
+++ b/docs/release-notes/4205.perf.md
@@ -1,3 +1,1 @@
 Parallelize the [`illico`][] `wilcoxon` backend of {func}`scanpy.tl.rank_genes_groups` via {attr}`scanpy.settings.n_jobs`, where ``-1`` now uses all cores for the `wilcoxon` methods {smaller}`Z Boldyga`
-
-[`illico`]: https://github.com/remydubois/illico

--- a/docs/release-notes/4205.perf.md
+++ b/docs/release-notes/4205.perf.md
@@ -1,3 +1,3 @@
-Run the [`illico`][] `wilcoxon` backend of {func}`scanpy.tl.rank_genes_groups` multithreaded according to {attr}`scanpy.settings.n_jobs` {smaller}`Z Boldyga`
+Parallelize the [`illico`][] `wilcoxon` backend of {func}`scanpy.tl.rank_genes_groups` via {attr}`scanpy.settings.n_jobs`, where ``-1`` now uses all cores for the `wilcoxon` methods {smaller}`Z Boldyga`
 
 [`illico`]: https://github.com/remydubois/illico

--- a/src/scanpy/_utils/_numba.py
+++ b/src/scanpy/_utils/_numba.py
@@ -5,21 +5,37 @@ from typing import TYPE_CHECKING
 
 import numba
 
+from .._compat import warn
+
 if TYPE_CHECKING:
     from collections.abc import Generator
 
 
+def _resolve_n_threads(n_threads: int) -> int:
+    n_max = numba.config.NUMBA_NUM_THREADS
+    if n_threads < -1:
+        msg = f"n_threads < -1 is not supported for this operation; treating {n_threads} as -1 ({n_max} threads, as per numba.config.NUMBA_NUM_THREADS)."
+        warn(msg, UserWarning)
+    if n_threads < 0:
+        return n_max
+    return max(1, min(n_threads, n_max))
+
+
 @contextmanager
-def _numba_thread_limit(n_threads: int | None) -> Generator[None]:
-    """Temporarily set Numba's thread count and restore it on exit."""
+def _numba_thread_limit(n_threads: int | None) -> Generator[int | None]:
+    """Temporarily set Numba's thread count and restore it on exit.
+
+    Resolves ``n_threads`` (``-1`` selects ``numba.config.NUMBA_NUM_THREADS``)
+    and yields the resolved count. ``None`` leaves Numba unchanged and yields ``None``.
+    """
     if n_threads is None:
-        yield
+        yield None
         return
 
+    resolved = _resolve_n_threads(n_threads)
     previous = numba.get_num_threads()
-    n_threads = max(1, min(n_threads, numba.config.NUMBA_NUM_THREADS))
-    numba.set_num_threads(n_threads)
+    numba.set_num_threads(resolved)
     try:
-        yield
+        yield resolved
     finally:
         numba.set_num_threads(previous)

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from typing import TYPE_CHECKING
 
 import numba
@@ -460,29 +459,29 @@ class _RankGenes:
     ) -> Generator[tuple[int, NDArray[np.floating], NDArray[np.floating]], None, None]:
         from illico import asymptotic_wilcoxon
 
-        n_threads = settings.n_jobs if settings.n_jobs > 0 else (os.cpu_count() or 1)
-        illico_df = asymptotic_wilcoxon(
-            AnnData(
-                X=self.X,
-                var=pd.DataFrame(index=self.var_names),
-                obs=pd.DataFrame(
-                    index=pd.RangeIndex(self.X.shape[0]).astype("str"),
-                    data={"group": self.group_col},
+        with _numba_thread_limit(settings.n_jobs) as n_threads:
+            illico_df = asymptotic_wilcoxon(
+                AnnData(
+                    X=self.X,
+                    var=pd.DataFrame(index=self.var_names),
+                    obs=pd.DataFrame(
+                        index=pd.RangeIndex(self.X.shape[0]).astype("str"),
+                        data={"group": self.group_col},
+                    ),
                 ),
-            ),
-            reference=self.groups_order[self.ireference]
-            if self.ireference is not None
-            else None,
-            group_keys="group",
-            return_as_scanpy=False,
-            is_log1p=True,
-            tie_correct=tie_correct,
-            use_continuity=False,
-            alternative="two-sided",
-            use_rust=False,
-            n_threads=n_threads,
-            groups=self.groups_order,
-        )
+                reference=self.groups_order[self.ireference]
+                if self.ireference is not None
+                else None,
+                group_keys="group",
+                return_as_scanpy=False,
+                is_log1p=True,
+                tie_correct=tie_correct,
+                use_continuity=False,
+                alternative="two-sided",
+                use_rust=False,
+                n_threads=n_threads,
+                groups=self.groups_order,
+            )
         return _illico_results_to_iter(
             illico_df,
             self.groups_order,
@@ -689,7 +688,7 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
     `adata.uns['rank_genes_groups' | key_added]['logfoldchanges']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
-        scores. Provided for every method except `'logreg'`.
+        scores. Only provided if method is 't-test' like.
         Note: if `mean_in_log_space=True`, this is an approximation calculated from mean-log values.
     `adata.uns['rank_genes_groups' | key_added]['pvals']` : structured :class:`numpy.ndarray` (dtype `float`)
         p-values.
@@ -859,7 +858,7 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
                 "    'logfoldchanges', sorted np.recarray to be indexed by group ids\n"
                 "    'pvals', sorted np.recarray to be indexed by group ids\n"
                 "    'pvals_adj', sorted np.recarray to be indexed by group ids"
-                if method != "logreg"
+                if method in {"t-test", "t-test_overestim_var", "wilcoxon"}
                 else ""
             )
         ),

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING
 
 import numba
@@ -461,6 +462,7 @@ class _RankGenes:
 
         from scanpy import settings
 
+        n_threads = settings.n_jobs if settings.n_jobs > 0 else (os.cpu_count() or 1)
         illico_df = asymptotic_wilcoxon(
             AnnData(
                 X=self.X,
@@ -480,7 +482,7 @@ class _RankGenes:
             use_continuity=False,
             alternative="two-sided",
             use_rust=False,
-            n_threads=settings.n_jobs,
+            n_threads=n_threads,
             groups=self.groups_order,
         )
         return _illico_results_to_iter(

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -16,7 +16,7 @@ from scipy import sparse
 from .. import _utils
 from .. import logging as logg
 from .._compat import CSBase, warn
-from .._settings import Default, Preset
+from .._settings import Default, Preset, settings
 from .._settings.presets import DETest
 from .._utils import (
     _numba_thread_limit,
@@ -460,8 +460,6 @@ class _RankGenes:
     ) -> Generator[tuple[int, NDArray[np.floating], NDArray[np.floating]], None, None]:
         from illico import asymptotic_wilcoxon
 
-        from scanpy import settings
-
         n_threads = settings.n_jobs if settings.n_jobs > 0 else (os.cpu_count() or 1)
         illico_df = asymptotic_wilcoxon(
             AnnData(
@@ -718,8 +716,6 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
     >>> sc.pl.rank_genes_groups(adata)
 
     """
-    from scanpy import settings
-
     if isinstance(mask_var, Default):
         mask_var = settings.preset.rank_genes_groups.mask_var
     if isinstance(mean_in_log_space, Default):

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -459,6 +459,8 @@ class _RankGenes:
     ) -> Generator[tuple[int, NDArray[np.floating], NDArray[np.floating]], None, None]:
         from illico import asymptotic_wilcoxon
 
+        from scanpy import settings
+
         illico_df = asymptotic_wilcoxon(
             AnnData(
                 X=self.X,
@@ -478,6 +480,7 @@ class _RankGenes:
             use_continuity=False,
             alternative="two-sided",
             use_rust=False,
+            n_threads=settings.n_jobs,
             groups=self.groups_order,
         )
         return _illico_results_to_iter(
@@ -638,16 +641,19 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
         The default method is `'t-test'`,
         `'t-test_overestim_var'` overestimates variance of each group,
         `'wilcoxon'` uses Wilcoxon rank-sum,
+        `'wilcoxon_illico'` uses the `illico <https://github.com/remydubois/illico>`__
+        implementation of the Wilcoxon rank-sum test (equivalent results, faster
+        with many groups; preferred via the ``ScanpyV2Preview`` preset),
         `'logreg'` uses logistic regression. See :cite:t:`Ntranos2019`,
         `here <https://github.com/scverse/scanpy/issues/95>`__ and `here
         <https://www.nxn.se/valent/2018/3/5/actionable-scrna-seq-clusters>`__,
         for why this is meaningful.
     corr_method
         p-value correction method.
-        Used only for `'t-test'`, `'t-test_overestim_var'`, and `'wilcoxon'`.
+        Used only for the `'t-test'`, `'t-test_overestim_var'`, `'wilcoxon'`, and `'wilcoxon_illico'` methods.
     tie_correct
         Use tie correction for `'wilcoxon'` scores.
-        Used only for `'wilcoxon'`.
+        Used only for the `'wilcoxon'` and `'wilcoxon_illico'` methods.
     rankby_abs
         Rank genes by the absolute value of the score, not by the
         score. The returned scores are never the absolute values.
@@ -683,7 +689,7 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
     `adata.uns['rank_genes_groups' | key_added]['logfoldchanges']` : structured :class:`numpy.ndarray` (dtype `object`)
         Structured array to be indexed by group id storing the log2
         fold change for each gene for each group. Ordered according to
-        scores. Only provided if method is 't-test' like.
+        scores. Provided for every method except `'logreg'`.
         Note: if `mean_in_log_space=True`, this is an approximation calculated from mean-log values.
     `adata.uns['rank_genes_groups' | key_added]['pvals']` : structured :class:`numpy.ndarray` (dtype `float`)
         p-values.
@@ -855,7 +861,7 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
                 "    'logfoldchanges', sorted np.recarray to be indexed by group ids\n"
                 "    'pvals', sorted np.recarray to be indexed by group ids\n"
                 "    'pvals_adj', sorted np.recarray to be indexed by group ids"
-                if method in {"t-test", "t-test_overestim_var", "wilcoxon"}
+                if method != "logreg"
                 else ""
             )
         ),

--- a/src/scanpy/tools/_rank_genes_groups.py
+++ b/src/scanpy/tools/_rank_genes_groups.py
@@ -640,19 +640,16 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
         The default method is `'t-test'`,
         `'t-test_overestim_var'` overestimates variance of each group,
         `'wilcoxon'` uses Wilcoxon rank-sum,
-        `'wilcoxon_illico'` uses the `illico <https://github.com/remydubois/illico>`__
-        implementation of the Wilcoxon rank-sum test (equivalent results, faster
-        with many groups; preferred via the ``ScanpyV2Preview`` preset),
         `'logreg'` uses logistic regression. See :cite:t:`Ntranos2019`,
         `here <https://github.com/scverse/scanpy/issues/95>`__ and `here
         <https://www.nxn.se/valent/2018/3/5/actionable-scrna-seq-clusters>`__,
         for why this is meaningful.
     corr_method
         p-value correction method.
-        Used only for the `'t-test'`, `'t-test_overestim_var'`, `'wilcoxon'`, and `'wilcoxon_illico'` methods.
+        Used only for `'t-test'`, `'t-test_overestim_var'`, and `'wilcoxon'`.
     tie_correct
         Use tie correction for `'wilcoxon'` scores.
-        Used only for the `'wilcoxon'` and `'wilcoxon_illico'` methods.
+        Used only for `'wilcoxon'`.
     rankby_abs
         Rank genes by the absolute value of the score, not by the
         score. The returned scores are never the absolute values.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -250,30 +250,39 @@ def test_random_str() -> None:
     assert len(unique) == len(strings)
 
 
-@pytest.mark.parametrize("success", [True, False], ids=["success", "exception"])
-def test_numba_thread_limit_restores_previous_value(
-    *, monkeypatch: pytest.MonkeyPatch, success: bool
-) -> None:
-    was_set_to = []
-    monkeypatch.setattr(numba, "get_num_threads", lambda: 8)
-    monkeypatch.setattr(numba, "set_num_threads", was_set_to.append)
+NUMBA_MAX = numba.config.NUMBA_NUM_THREADS
 
-    with suppress(RuntimeError), _numba_thread_limit(2):
-        if not success:
+
+@pytest.mark.parametrize(
+    ("n_threads", "expected"),
+    [(-1, NUMBA_MAX), (1, 1), (NUMBA_MAX + 5, NUMBA_MAX), (0, 1)],
+)
+def test_numba_thread_limit_resolves(n_threads: int, expected: int) -> None:
+    with _numba_thread_limit(n_threads) as resolved:
+        assert resolved == expected
+        assert numba.get_num_threads() == expected
+
+
+def test_numba_thread_limit_warns_below_minus_one() -> None:
+    with (
+        pytest.warns(UserWarning, match="n_threads < -1 is not supported"),
+        _numba_thread_limit(-2) as resolved,
+    ):
+        assert resolved == NUMBA_MAX
+
+
+@pytest.mark.parametrize("fail", [False, True], ids=["success", "exception"])
+def test_numba_thread_limit_restores(*, fail: bool) -> None:
+    outer = numba.get_num_threads()
+    with suppress(RuntimeError), _numba_thread_limit(1):
+        assert numba.get_num_threads() == 1
+        if fail:
             raise RuntimeError
+    assert numba.get_num_threads() == outer
 
-    assert was_set_to == [2, 8]
 
-
-def test_numba_thread_limit_clamps_to_configured_maximum(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    was_set_to = []
-    monkeypatch.setattr(numba, "get_num_threads", lambda: 3)
-    monkeypatch.setattr(numba, "set_num_threads", was_set_to.append)
-    monkeypatch.setattr(numba.config, "NUMBA_NUM_THREADS", 4)
-
-    with _numba_thread_limit(99):
-        pass
-
-    assert was_set_to == [4, 3]
+def test_numba_thread_limit_none_is_noop() -> None:
+    outer = numba.get_num_threads()
+    with _numba_thread_limit(None) as resolved:
+        assert resolved is None
+        assert numba.get_num_threads() == outer


### PR DESCRIPTION
<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [x] [Tests][] included or not required because: 
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

@ilan-gold this is a small PR that does a few things:

- illico previously wasn't getting a thread value passed down (e.g. n_jobs), it was defaulting to 1. that is fixed
- there was a preexisting bug with the _numba utility for resolving thread count, it resolved -1 to 1 thread. the only place it was used was in rank_genes_groups, which passed n_jobs, so this conflicted with scanpy docs. This now properly sets to the numba thread count
- we also wrap the illico call with the _numba utility so numba thread count restores upon completion (I think illico modifies numba thread count, this helps prevent side effects). 
