### PR TITLE
fix: guard bw conversion in pl.spatial against missing image

### DIFF
--- a/docs/release-notes/4207.fix.md
+++ b/docs/release-notes/4207.fix.md
@@ -1,0 +1,1 @@
+Fix {func}`scanpy.pl.spatial` raising `TypeError` when `bw=True` is passed without an image {smaller}`M German`

--- a/src/scanpy/plotting/_tools/scatterplots.py
+++ b/src/scanpy/plotting/_tools/scatterplots.py
@@ -1382,7 +1382,7 @@ def _check_img(
         )  # Throws StopIteration Error if keys not present
     if img is None and spatial_data is not None and img_key is not None:
         img = spatial_data["images"][img_key]
-    if bw:
+    if bw and img is not None:
         img = np.dot(img[..., :3], [0.2989, 0.5870, 0.1140])
     return img, img_key
 

--- a/tests/test_plotting_embedded/test_spatial.py
+++ b/tests/test_plotting_embedded/test_spatial.py
@@ -70,6 +70,16 @@ def test_visium_empty_img_key(image_comparer):  # visium coordinates but image e
     save_and_compare_images("spatial_visium_embedding")
 
 
+def test_spatial_bw_no_img():  # bw=True with no image should not raise
+    adata = sc.read_visium(DATA_DIR / "visium_data" / "1.0.0")
+    adata.obs = adata.obs.astype({"array_row": "str"})
+    adata.uns.pop("spatial")  # no image available anywhere
+    spot_size = 1.0
+
+    sc.pl.spatial(adata, color="array_row", bw=True, spot_size=spot_size, show=False)
+    plt.close()
+
+
 def test_spatial_general(image_comparer):  # general coordinates
     save_and_compare_images = partial(image_comparer, ROOT, tol=15)
 


### PR DESCRIPTION
## Summary

`sc.pl.spatial(..., bw=True)` raises `TypeError: 'NoneType' object is not subscriptable` when called without an image (no `img` passed and no image available in `.uns['spatial']`, e.g. general spatial coordinates without a background image).

`_check_img` runs the grayscale conversion unconditionally whenever `bw=True`:

```python
if bw:
    img = np.dot(img[..., :3], [0.2989, 0.5870, 0.1140])
```

If `img` is still `None` at that point, indexing it crashes. The existing test suite already documents this gap: `test_manual_equivalency_no_img` skips the `bw` case with the comment "Has no meaning when there is no image" instead of asserting it works.

## Fix

Guard the conversion on `img is not None`, matching how the rest of `_check_img` and `_check_na_color` treat a possibly-missing image.

## Test plan

- [x] Added `test_spatial_bw_no_img`, exercising `sc.pl.spatial(..., bw=True)` on data with no image anywhere, confirming it no longer raises.
- [x] Full `tests/test_plotting_embedded/` suite passes locally (117 passed, 5 skipped, no change to skip count).
- [x] `ruff check` clean on changed files.
- [x] Added a towncrier fragment at `docs/release-notes/4207.fix.md` (will rename if the PR number differs).