### PR TITLE
Backport PR #4202: docs: Remove duplicated 'layer' parameter from PCA documentation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,6 @@
     "python.testing.pytestArgs": ["-vv", "--color=yes", "--internet-tests"],
     "python.testing.pytestEnabled": true,
     "python.terminal.activateEnvironment": true,
-    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
-    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
+    "python-envs.defaultEnvManager": "ms-python.python:venv",
+    "python-envs.defaultPackageManager": "ms-python.python:pip",
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -19,6 +19,6 @@
     "python.testing.pytestArgs": ["-vv", "--color=yes", "--internet-tests"],
     "python.testing.pytestEnabled": true,
     "python.terminal.activateEnvironment": true,
-    "python-envs.defaultEnvManager": "ms-python.python:venv",
-    "python-envs.defaultPackageManager": "ms-python.python:pip",
+    "python-envs.defaultEnvManager": "pypa.hatch:hatch",
+    "python-envs.defaultPackageManager": "pypa.hatch:hatch",
 }

--- a/src/scanpy/preprocessing/_pca/__init__.py
+++ b/src/scanpy/preprocessing/_pca/__init__.py
@@ -163,8 +163,6 @@ def pca(  # noqa: PLR0912, PLR0913, PLR0915
         Only relevant when not passing an :class:`~anndata.AnnData`:
         see “Returns”.
     {mask_var_hvg}
-    layer
-        Layer of `adata` to use as expression values.
     dtype
         Numpy data type string to which to convert the result.
     key_added


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes #
- [ ] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
