### PR TITLE
feat: add min_cells parameter to dotplot

### DIFF
--- a/docs/release-notes/4218.feat.md
+++ b/docs/release-notes/4218.feat.md
@@ -1,0 +1,1 @@
+Add `min_cells` parameter to {func}`~scanpy.pl.dotplot` to hide `groupby` combinations with fewer than `min_cells` cells

--- a/src/scanpy/plotting/_dotplot.py
+++ b/src/scanpy/plotting/_dotplot.py
@@ -66,6 +66,12 @@ class DotPlot(BasePlot):
     mean_only_expressed
         If True, gene expression is averaged only over the cells
         expressing the given genes.
+    min_cells
+        Minimum number of cells (observations) a ``groupby`` combination must
+        contain to be shown. Combinations with fewer than ``min_cells`` cells are
+        removed before computing the fraction and mean statistics. The default of
+        ``0`` disables filtering. Useful when ``groupby`` is a sequence and some
+        combinations contain too few cells for robust summary statistics.
     standard_scale
         Whether or not to standardize that dimension between 0 and 1,
         meaning for each variable or group,
@@ -131,6 +137,7 @@ class DotPlot(BasePlot):
         layer: str | None = None,
         expression_cutoff: float = 0.0,
         mean_only_expressed: bool = False,
+        min_cells: int = 0,
         standard_scale: Literal["var", "group"] | None = None,
         dot_color_df: pd.DataFrame | None = None,
         dot_size_df: pd.DataFrame | None = None,
@@ -165,6 +172,32 @@ class DotPlot(BasePlot):
             norm=norm,
             **kwds,
         )
+
+        # Drop groupby combinations with fewer than ``min_cells`` cells, keeping
+        # ``obs_tidy``, ``categories`` and ``categories_order`` mutually
+        # consistent before the dot statistics are computed.
+        self.min_cells = min_cells
+        self._min_cells_mask = None
+        if min_cells > 0:
+            counts = self.obs_tidy.groupby(level=0, observed=True).size()
+            keep = counts.index[counts >= min_cells]
+            if len(keep) == 0:
+                msg = (
+                    f"`min_cells={min_cells}` filtered out every group; "
+                    f"the largest group has only {int(counts.max())} cells."
+                )
+                raise ValueError(msg)
+            if len(keep) < len(counts):
+                keep_set = set(keep)
+                self._min_cells_mask = self.obs_tidy.index.isin(keep_set)
+                self.obs_tidy = self.obs_tidy[self._min_cells_mask]
+                # drop now-unused categories so grouping and ``.loc`` stay aligned
+                self.obs_tidy.index = self.obs_tidy.index.remove_unused_categories()
+                self.categories = self.obs_tidy.index.categories
+                if self.categories_order is not None:
+                    self.categories_order = [
+                        c for c in self.categories_order if c in keep_set
+                    ]
 
         # Set default style parameters
         self.cmap = self.DEFAULT_COLORMAP
@@ -308,6 +341,25 @@ class DotPlot(BasePlot):
         )
 
         return dot_color_df, dot_size_df
+
+    def _reorder_categories_after_dendrogram(self, dendrogram_key: str | None) -> None:
+        if self._min_cells_mask is not None:
+            # ``min_cells`` dropped some groups. Restrict ``adata`` to the
+            # surviving cells and drop any cached dendrogram so it is recomputed
+            # over the groups actually shown (a cache, if present, was built over
+            # all groups and would otherwise mismatch the filtered categories).
+            self.adata = self.adata[self._min_cells_mask].copy()
+            # explicitly drop the now-empty categories so the recomputed
+            # dendrogram is aligned with the surviving groups regardless of
+            # ``anndata.settings.remove_unused_categories``
+            for group in self.groupby:
+                col = self.adata.obs[group]
+                if hasattr(col, "cat"):
+                    self.adata.obs[group] = col.cat.remove_unused_categories()
+            key = dendrogram_key or f"dendrogram_{'_'.join(self.groupby)}"
+            self.adata.uns.pop(key, None)
+            self._min_cells_mask = None
+        super()._reorder_categories_after_dendrogram(dendrogram_key)
 
     def style(  # noqa: PLR0913
         self,
@@ -961,6 +1013,7 @@ def dotplot(  # noqa: PLR0913
     categories_order: Sequence[str] | None = None,
     expression_cutoff: float = 0.0,
     mean_only_expressed: bool = False,
+    min_cells: int = 0,
     standard_scale: Literal["var", "group"] | None = None,
     title: str | None = None,
     colorbar_title: str | None = DotPlot.DEFAULT_COLOR_LEGEND_TITLE,
@@ -1023,6 +1076,12 @@ def dotplot(  # noqa: PLR0913
     mean_only_expressed
         If True, gene expression is averaged only over the cells
         expressing the given genes.
+    min_cells
+        Minimum number of cells (observations) a ``groupby`` combination must
+        contain to be shown. Combinations with fewer than ``min_cells`` cells are
+        removed before computing the fraction and mean statistics. The default of
+        ``0`` disables filtering. Useful when ``groupby`` is a sequence and some
+        combinations contain too few cells for robust summary statistics.
     group_colors
         A mapping of group names to colors.
         e.g. `{{'T-cell': 'blue', 'B-cell': '#aa40fc'}}`.
@@ -1116,6 +1175,7 @@ def dotplot(  # noqa: PLR0913
         categories_order=categories_order,
         expression_cutoff=expression_cutoff,
         mean_only_expressed=mean_only_expressed,
+        min_cells=min_cells,
         standard_scale=standard_scale,
         title=title,
         figsize=figsize,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -427,6 +427,197 @@ def test_dotplot_add_totals(image_comparer):
     save_and_compare_images("dotplot_totals")
 
 
+def _dotplot_min_cells_adata() -> AnnData:
+    """Tiny deterministic AnnData with known per-group cell counts."""
+    group_sizes = {"A": 10, "B": 6, "C": 3, "D": 1}
+    groups = list(chain.from_iterable(repeat(g, n) for g, n in group_sizes.items()))
+    rng = np.random.default_rng(0)
+    obs = pd.DataFrame(
+        {"group": pd.Categorical(groups)},
+        index=[f"cell{i}" for i in range(len(groups))],
+    )
+    return AnnData(
+        rng.random((len(groups), 3), dtype=np.float32),
+        obs=obs,
+        var=pd.DataFrame(index=["g1", "g2", "g3"]),
+    )
+
+
+@pytest.mark.parametrize(
+    ("min_cells", "expected"),
+    [
+        pytest.param(2, {"A", "B", "C"}, id="drop-smallest"),
+        pytest.param(4, {"A", "B"}, id="drop-two"),
+        pytest.param(7, {"A"}, id="keep-one"),
+    ],
+)
+def test_dotplot_min_cells_filters_small_groups(
+    min_cells: int, expected: set[str]
+) -> None:
+    # groups have sizes A=10, B=6, C=3, D=1
+    adata = _dotplot_min_cells_adata()
+    dp = sc.pl.dotplot(
+        adata,
+        ["g1", "g2", "g3"],
+        groupby="group",
+        min_cells=min_cells,
+        return_fig=True,
+    )
+    assert set(dp.dot_size_df.index) == expected
+    assert set(dp.dot_color_df.index) == expected
+    assert set(dp.categories) == expected
+
+
+def test_dotplot_min_cells_zero_is_noop() -> None:
+    adata = _dotplot_min_cells_adata()
+    genes = ["g1", "g2", "g3"]
+    default = sc.pl.dotplot(adata, genes, groupby="group", return_fig=True)
+    explicit = sc.pl.dotplot(
+        adata, genes, groupby="group", min_cells=0, return_fig=True
+    )
+    # min_cells=0 keeps every group (no filtering at all) ...
+    assert set(default.dot_size_df.index) == {"A", "B", "C", "D"}
+    # ... and is identical to omitting the parameter
+    pd.testing.assert_frame_equal(default.dot_size_df, explicit.dot_size_df)
+    pd.testing.assert_frame_equal(default.dot_color_df, explicit.dot_color_df)
+
+
+def test_dotplot_min_cells_raises_when_all_filtered() -> None:
+    adata = _dotplot_min_cells_adata()
+    with pytest.raises(ValueError, match="min_cells"):
+        sc.pl.dotplot(
+            adata,
+            ["g1", "g2", "g3"],
+            groupby="group",
+            min_cells=10**9,
+            return_fig=True,
+        )
+
+
+def test_dotplot_min_cells_sequence_groupby() -> None:
+    # combination sizes: A_x=10, A_y=5, B_x=4, B_y=1, C_x=2
+    combos = {
+        ("A", "x"): 10,
+        ("A", "y"): 5,
+        ("B", "x"): 4,
+        ("B", "y"): 1,
+        ("C", "x"): 2,
+    }
+    rows = list(chain.from_iterable(repeat(k, n) for k, n in combos.items()))
+    rng = np.random.default_rng(1)
+    obs = pd.DataFrame(
+        {
+            "l1": pd.Categorical([a for a, _ in rows]),
+            "l2": pd.Categorical([b for _, b in rows]),
+        },
+        index=[f"cell{i}" for i in range(len(rows))],
+    )
+    adata = AnnData(
+        rng.random((len(rows), 3), dtype=np.float32),
+        obs=obs,
+        var=pd.DataFrame(index=["g1", "g2", "g3"]),
+    )
+    dp = sc.pl.dotplot(
+        adata,
+        ["g1", "g2", "g3"],
+        groupby=["l1", "l2"],
+        min_cells=4,
+        return_fig=True,
+    )
+    # only combinations with >= 4 cells survive
+    assert set(dp.dot_size_df.index) == {"A_x", "A_y", "B_x"}
+
+
+def test_dotplot_min_cells_respects_categories_order() -> None:
+    adata = _dotplot_min_cells_adata()
+    dp = sc.pl.dotplot(
+        adata,
+        ["g1", "g2", "g3"],
+        groupby="group",
+        categories_order=["D", "C", "B", "A"],
+        min_cells=4,
+        return_fig=True,
+    )
+    # surviving groups keep the user-provided order, minus the dropped ones
+    assert list(dp.dot_size_df.index) == ["B", "A"]
+
+
+def test_dotplot_min_cells_with_precomputed_dataframes() -> None:
+    # `min_cells` must filter the user-supplied dot_color_df / dot_size_df path
+    # coherently (consistent shapes, surviving groups only).
+    adata = _dotplot_min_cells_adata()
+    genes = ["g1", "g2", "g3"]
+    full = sc.pl.dotplot(adata, genes, groupby="group", return_fig=True)
+    dp = sc.pl.DotPlot(
+        adata,
+        genes,
+        "group",
+        min_cells=4,
+        dot_color_df=full.dot_color_df.copy(),
+        dot_size_df=full.dot_size_df.copy(),
+    )
+    assert set(dp.dot_color_df.index) == {"A", "B"}
+    assert set(dp.dot_size_df.index) == {"A", "B"}
+    assert dp.dot_color_df.shape == dp.dot_size_df.shape
+
+
+def test_dotplot_min_cells_with_dendrogram() -> None:
+    pbmc = pbmc68k_reduced()
+    genes = ["CD79A", "MS4A1", "CD3D", "CD8A", "LYZ", "NKG7"]
+    min_cells = 20
+    counts = pbmc.obs["bulk_labels"].value_counts()
+    expected = set(counts.index[counts >= min_cells])
+    assert len(expected) > 2  # sanity: a dendrogram needs more than 2 groups
+
+    n_obs_before = pbmc.n_obs
+    uns_before = set(pbmc.uns)
+    dp = sc.pl.dotplot(
+        pbmc,
+        genes,
+        groupby="bulk_labels",
+        min_cells=min_cells,
+        dendrogram=True,
+        return_fig=True,
+    )
+    dp.make_figure()  # exercises drawing the dendrogram over the subset
+
+    # the caller's adata is untouched: no cells dropped, no dendrogram cached
+    assert pbmc.n_obs == n_obs_before
+    assert set(pbmc.uns) == uns_before
+
+    assert set(dp.dot_size_df.index) == expected
+    assert set(dp.categories) == expected
+
+    # the dendrogram is actually computed/reordered over the surviving groups:
+    # it must match a dendrogram computed independently on the same subset
+    sub = pbmc[pbmc.obs["bulk_labels"].isin(expected)].copy()
+    sub.obs["bulk_labels"] = sub.obs["bulk_labels"].cat.remove_unused_categories()
+    sc.tl.dendrogram(sub, "bulk_labels")
+    expected_order = list(sub.uns["dendrogram_bulk_labels"]["categories_ordered"])
+    assert list(dp.categories_order) == expected_order
+
+
+def test_dotplot_min_cells_dendrogram_keeps_unused_categories(monkeypatch) -> None:
+    # the dendrogram + min_cells path must recompute over the surviving groups
+    # even when anndata does not implicitly drop unused categories on subsetting
+    monkeypatch.setattr("anndata.settings.remove_unused_categories", False)
+    pbmc = pbmc68k_reduced()
+    genes = ["CD79A", "MS4A1", "CD3D", "CD8A", "LYZ", "NKG7"]
+    min_cells = 20
+    counts = pbmc.obs["bulk_labels"].value_counts()
+    expected = set(counts.index[counts >= min_cells])
+    dp = sc.pl.dotplot(
+        pbmc,
+        genes,
+        groupby="bulk_labels",
+        min_cells=min_cells,
+        dendrogram=True,
+        return_fig=True,
+    )
+    dp.make_figure()
+    assert set(dp.dot_size_df.index) == expected
+
+
 def test_matrixplot_obj(image_comparer):
     save_and_compare_images = partial(image_comparer, ROOT, tol=15)
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -6,6 +6,7 @@ from itertools import chain, combinations, repeat
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import anndata
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
@@ -600,7 +601,9 @@ def test_dotplot_min_cells_with_dendrogram() -> None:
 def test_dotplot_min_cells_dendrogram_keeps_unused_categories(monkeypatch) -> None:
     # the dendrogram + min_cells path must recompute over the surviving groups
     # even when anndata does not implicitly drop unused categories on subsetting
-    monkeypatch.setattr("anndata.settings.remove_unused_categories", False)
+    if not hasattr(anndata.settings, "remove_unused_categories"):
+        pytest.skip("anndata.settings.remove_unused_categories is unavailable")
+    monkeypatch.setattr(anndata.settings, "remove_unused_categories", False)
     pbmc = pbmc68k_reduced()
     genes = ["CD79A", "MS4A1", "CD3D", "CD8A", "LYZ", "NKG7"]
     min_cells = 20


### PR DESCRIPTION
## Summary
Adds a `min_cells` parameter to `sc.pl.dotplot` (and the `DotPlot` class) that
hides `groupby` combinations containing fewer than `min_cells` cells, so that
the fraction/mean statistics are only shown for sufficiently populated groups.

Closes #1829.

## Behaviour
- `min_cells=0` (default) is a no-op — existing behaviour is unchanged.
- With a sequence `groupby`, combinations below the threshold are dropped before
  the fraction and mean are computed.
- Raises `ValueError` if every group is filtered out.
- Works together with `dendrogram`, `categories_order`, and `swap_axes`, and with
  a user-supplied `dot_color_df`/`dot_size_df`.
- The caller's `adata` is left untouched (no cells dropped, no dendrogram cached
  on the user's object).

## Tests
- Surviving-group membership for several `min_cells` thresholds (single and
  sequence `groupby`)
- `min_cells=0` keeps every group and equals omitting the parameter
- `ValueError` when all groups are filtered
- `categories_order` is respected (surviving order preserved)
- `min_cells` + `dendrogram=True`: reordering matches an independently computed
  dendrogram over the survivors, works regardless of
  `anndata.settings.remove_unused_categories`, and the caller's `adata` is not
  mutated
- User-supplied precomputed `dot_color_df`/`dot_size_df` path stays consistent

## Notes
Scoped to `dotplot` per the issue. `matrixplot`/`stacked_violin` are out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
