### PR TITLE
feat: pp.scale allow selecting correction

### DIFF
--- a/docs/release-notes/4220.feat.md
+++ b/docs/release-notes/4220.feat.md
@@ -1,0 +1,1 @@
+Allow selecting the delta degrees of freedom used by {func}`scanpy.pp.scale` through the new `ddof` parameter {smaller}`A McKenna`

--- a/docs/release-notes/4220.feat.md
+++ b/docs/release-notes/4220.feat.md
@@ -1,1 +1,1 @@
-Allow selecting the delta degrees of freedom used by {func}`scanpy.pp.scale` through the new `ddof` parameter {smaller}`A McKenna`
+Allow selecting the degrees of freedom adjustment used by {func}`scanpy.pp.scale` through the new `correction` parameter {smaller}`A McKenna`

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -78,16 +78,17 @@ def scale[A: _Array](
     layer: str | None = None,
     obsm: str | None = None,
     mask_obs: NDArray[np.bool] | str | None = None,
+    ddof: int = 1,
 ) -> AnnData | A | None:
     """Scale data to unit variance and zero mean.
 
     .. note::
-        Variance and standard deviation are computed with Bessel's correction,
-        i.e. dividing by ``n_obs - 1`` (``ddof=1``), matching :func:`numpy.std`
-        with ``ddof=1`` rather than the numpy default of ``ddof=0`` (population
-        variance). The difference is negligible for large `n_obs` but can matter for
-        small datasets, where it also slightly shifts where `max_value`
-        clipping takes effect.
+        By default, variance and standard deviation are computed with Bessel's
+        correction, i.e. dividing by ``n_obs - 1`` (``ddof=1``), matching
+        :func:`numpy.std` with ``ddof=1`` rather than the numpy default of
+        ``ddof=0`` (population variance). The difference is negligible for large
+        `n_obs` but can matter for small datasets, where it also slightly shifts
+        where `max_value` clipping takes effect.
 
     .. note::
         Variables (genes) that do not display any variation (are constant across
@@ -119,6 +120,10 @@ def scale[A: _Array](
         to a certain set of observations. The mask is specified as a boolean array
         or a string referring to an array in :attr:`~anndata.AnnData.obs`.
         This will transform data from csc to csr format if `issparse(data)`.
+    ddof
+        Delta degrees of freedom. The divisor used to compute variance is
+        ``N - ddof``, where ``N`` is the number of observations used to calculate
+        the scaling parameters. Defaults to ``1``.
 
     Returns
     -------
@@ -142,7 +147,12 @@ def scale[A: _Array](
         msg = f"`obsm` argument inappropriate for value of type {type(data)}"
         raise ValueError(msg)
     return scale_array(
-        data, zero_center=zero_center, max_value=max_value, copy=copy, mask_obs=mask_obs
+        data,
+        zero_center=zero_center,
+        max_value=max_value,
+        copy=copy,
+        mask_obs=mask_obs,
+        ddof=ddof,
     )
 
 
@@ -157,6 +167,7 @@ def scale_array[A: _Array](
     copy: bool = False,
     return_mean_std: bool = False,
     mask_obs: NDArray[np.bool] | None = None,
+    ddof: int = 1,
 ) -> (
     A
     | tuple[
@@ -199,9 +210,10 @@ def scale_array[A: _Array](
             zero_center=zero_center,
             max_value=max_value,
             return_mean_std=return_mean_std,
+            ddof=ddof,
         )
 
-    mean, var = mean_var(x, axis=0, correction=1)
+    mean, var = mean_var(x, axis=0, correction=ddof)
     std = np.sqrt(var)
     std[std == 0] = 1
     if zero_center:
@@ -237,6 +249,7 @@ def scale_array_masked[A: _Array](
     zero_center: bool = True,
     max_value: float | None = None,
     return_mean_std: bool = False,
+    ddof: int = 1,
 ) -> (
     A
     | tuple[
@@ -248,7 +261,7 @@ def scale_array_masked[A: _Array](
     if isinstance(x, CSBase) and not zero_center:
         if isinstance(x, CSCBase):
             x = x.tocsr()
-        mean, var = mean_var(x[mask_obs, :], axis=0, correction=1)
+        mean, var = mean_var(x[mask_obs, :], axis=0, correction=ddof)
         std = np.sqrt(var)
         std[std == 0] = 1
 
@@ -266,6 +279,7 @@ def scale_array_masked[A: _Array](
             zero_center=zero_center,
             max_value=max_value,
             return_mean_std=True,
+            ddof=ddof,
         )
 
     if return_mean_std:
@@ -303,6 +317,7 @@ def scale_anndata(
     layer: str | None = None,
     obsm: str | None = None,
     mask_obs: NDArray[np.bool] | str | None = None,
+    ddof: int = 1,
 ) -> AnnData | None:
     adata = adata.copy() if copy else adata
     str_mean_std = ("mean", "std")
@@ -322,6 +337,7 @@ def scale_anndata(
         copy=False,  # because a copy has already been made, if it were to be made
         return_mean_std=True,
         mask_obs=mask_obs,
+        ddof=ddof,
     )
     _set_obs_rep(adata, x, layer=layer, obsm=obsm)
     return adata if copy else None

--- a/src/scanpy/preprocessing/_scale.py
+++ b/src/scanpy/preprocessing/_scale.py
@@ -78,17 +78,17 @@ def scale[A: _Array](
     layer: str | None = None,
     obsm: str | None = None,
     mask_obs: NDArray[np.bool] | str | None = None,
-    ddof: int = 1,
+    correction: float = 1,
 ) -> AnnData | A | None:
     """Scale data to unit variance and zero mean.
 
     .. note::
         By default, variance and standard deviation are computed with Bessel's
-        correction, i.e. dividing by ``n_obs - 1`` (``ddof=1``), matching
-        :func:`numpy.std` with ``ddof=1`` rather than the numpy default of
-        ``ddof=0`` (population variance). The difference is negligible for large
-        `n_obs` but can matter for small datasets, where it also slightly shifts
-        where `max_value` clipping takes effect.
+        correction (``correction=1``), i.e. dividing by ``n_obs - 1``. This
+        matches :func:`numpy.std` with ``ddof=1`` rather than the numpy default
+        of ``ddof=0`` (population variance). The difference is negligible for
+        large `n_obs` but can matter for small datasets, where it also slightly
+        shifts where `max_value` clipping takes effect.
 
     .. note::
         Variables (genes) that do not display any variation (are constant across
@@ -120,10 +120,10 @@ def scale[A: _Array](
         to a certain set of observations. The mask is specified as a boolean array
         or a string referring to an array in :attr:`~anndata.AnnData.obs`.
         This will transform data from csc to csr format if `issparse(data)`.
-    ddof
-        Delta degrees of freedom. The divisor used to compute variance is
-        ``N - ddof``, where ``N`` is the number of observations used to calculate
-        the scaling parameters. Defaults to ``1``.
+    correction
+        Degrees of freedom adjustment. The divisor used to compute variance is
+        ``M - correction``, where ``M`` is the number of observations used to
+        calculate the scaling parameters. Defaults to ``1``.
 
     Returns
     -------
@@ -152,7 +152,7 @@ def scale[A: _Array](
         max_value=max_value,
         copy=copy,
         mask_obs=mask_obs,
-        ddof=ddof,
+        correction=correction,
     )
 
 
@@ -167,7 +167,7 @@ def scale_array[A: _Array](
     copy: bool = False,
     return_mean_std: bool = False,
     mask_obs: NDArray[np.bool] | None = None,
-    ddof: int = 1,
+    correction: float = 1,
 ) -> (
     A
     | tuple[
@@ -210,10 +210,10 @@ def scale_array[A: _Array](
             zero_center=zero_center,
             max_value=max_value,
             return_mean_std=return_mean_std,
-            ddof=ddof,
+            correction=correction,
         )
 
-    mean, var = mean_var(x, axis=0, correction=ddof)
+    mean, var = mean_var(x, axis=0, correction=correction)
     std = np.sqrt(var)
     std[std == 0] = 1
     if zero_center:
@@ -249,7 +249,7 @@ def scale_array_masked[A: _Array](
     zero_center: bool = True,
     max_value: float | None = None,
     return_mean_std: bool = False,
-    ddof: int = 1,
+    correction: float = 1,
 ) -> (
     A
     | tuple[
@@ -261,7 +261,7 @@ def scale_array_masked[A: _Array](
     if isinstance(x, CSBase) and not zero_center:
         if isinstance(x, CSCBase):
             x = x.tocsr()
-        mean, var = mean_var(x[mask_obs, :], axis=0, correction=ddof)
+        mean, var = mean_var(x[mask_obs, :], axis=0, correction=correction)
         std = np.sqrt(var)
         std[std == 0] = 1
 
@@ -279,7 +279,7 @@ def scale_array_masked[A: _Array](
             zero_center=zero_center,
             max_value=max_value,
             return_mean_std=True,
-            ddof=ddof,
+            correction=correction,
         )
 
     if return_mean_std:
@@ -317,7 +317,7 @@ def scale_anndata(
     layer: str | None = None,
     obsm: str | None = None,
     mask_obs: NDArray[np.bool] | str | None = None,
-    ddof: int = 1,
+    correction: float = 1,
 ) -> AnnData | None:
     adata = adata.copy() if copy else adata
     str_mean_std = ("mean", "std")
@@ -337,7 +337,7 @@ def scale_anndata(
         copy=False,  # because a copy has already been made, if it were to be made
         return_mean_std=True,
         mask_obs=mask_obs,
-        ddof=ddof,
+        correction=correction,
     )
     _set_obs_rep(adata, x, layer=layer, obsm=obsm)
     return adata if copy else None

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -79,7 +79,7 @@ X_scaled_for_mask_clipped = [
 @pytest.mark.parametrize("container", ["anndata", "array"])
 @pytest.mark.parametrize("dtype", [np.float32, np.int64])
 @pytest.mark.parametrize("zero_center", [True, False], ids=["center", "no_center"])
-@pytest.mark.parametrize("ddof", [0, 1])
+@pytest.mark.parametrize("correction", [0, 0.5, 1])
 @pytest.mark.parametrize(
     ("mask_obs", "x", "x_centered", "x_scaled"),
     [
@@ -96,12 +96,21 @@ X_scaled_for_mask_clipped = [
     ],
 )
 def test_scale(
-    *, typ, container, zero_center, dtype, ddof, mask_obs, x, x_centered, x_scaled
+    *,
+    typ,
+    container,
+    zero_center,
+    dtype,
+    correction,
+    mask_obs,
+    x,
+    x_centered,
+    x_scaled,
 ):
     values = np.asarray(x, dtype=np.float64)
     selected = slice(None) if mask_obs is None else mask_obs
     mean = values[selected].mean(axis=0)
-    std = values[selected].std(axis=0, ddof=ddof)
+    std = values[selected].std(axis=0, ddof=correction)
     std[std == 0] = 1
 
     expected = values.copy()
@@ -110,7 +119,7 @@ def test_scale(
     else:
         expected[selected] /= std
 
-    if ddof == 1:
+    if correction == 1:
         expected_original = x_centered if zero_center else x_scaled
         assert np.allclose(expected, expected_original)
 
@@ -129,7 +138,7 @@ def test_scale(
                 zero_center=zero_center,
                 copy=container == "array",
                 mask_obs=mask_obs,
-                ddof=ddof,
+                correction=correction,
             )
     received = sparse.csr_matrix(  # noqa: TID251
         x.X if scaled is None else scaled

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -79,6 +79,7 @@ X_scaled_for_mask_clipped = [
 @pytest.mark.parametrize("container", ["anndata", "array"])
 @pytest.mark.parametrize("dtype", [np.float32, np.int64])
 @pytest.mark.parametrize("zero_center", [True, False], ids=["center", "no_center"])
+@pytest.mark.parametrize("ddof", [0, 1])
 @pytest.mark.parametrize(
     ("mask_obs", "x", "x_centered", "x_scaled"),
     [
@@ -95,8 +96,24 @@ X_scaled_for_mask_clipped = [
     ],
 )
 def test_scale(
-    *, typ, container, zero_center, dtype, mask_obs, x, x_centered, x_scaled
+    *, typ, container, zero_center, dtype, ddof, mask_obs, x, x_centered, x_scaled
 ):
+    values = np.asarray(x, dtype=np.float64)
+    selected = slice(None) if mask_obs is None else mask_obs
+    mean = values[selected].mean(axis=0)
+    std = values[selected].std(axis=0, ddof=ddof)
+    std[std == 0] = 1
+
+    expected = values.copy()
+    if zero_center:
+        expected[selected] = (expected[selected] - mean) / std
+    else:
+        expected[selected] /= std
+
+    if ddof == 1:
+        expected_original = x_centered if zero_center else x_scaled
+        assert np.allclose(expected, expected_original)
+
     x = AnnData(typ(x, dtype=dtype)) if container == "anndata" else typ(x, dtype=dtype)
     with warnings.catch_warnings():
         # TODO: fix setting slices of sparse matrices in scale()
@@ -108,13 +125,19 @@ def test_scale(
             else nullcontext()
         ):
             scaled = sc.pp.scale(
-                x, zero_center=zero_center, copy=container == "array", mask_obs=mask_obs
+                x,
+                zero_center=zero_center,
+                copy=container == "array",
+                mask_obs=mask_obs,
+                ddof=ddof,
             )
     received = sparse.csr_matrix(  # noqa: TID251
         x.X if scaled is None else scaled
     ).toarray()
-    expected = x_centered if zero_center else x_scaled
     assert np.allclose(received, expected)
+    if container == "anndata":
+        std_key = "std" if mask_obs is None else "std with mask"
+        assert np.allclose(x.var[std_key], std)
 
 
 def test_mask_string():


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

Follow-up to #4196.

This adds a selectable `correction` parameter to `sc.pp.scale`. The default remains `correction=1`, so existing behaviour is unchanged.

The parameter is propagated through array, masked-array, sparse, and `AnnData` scaling paths. The documentation now explains how the variance divisor is calculated.

  - [x] Tests included for `correction=0` and `correction=1`, covering dense, CSR, and CSC inputs; direct arrays and `AnnData`; masked and unmasked observations; and centered and non-centered scaling.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [x] [Tests][] included or not required because:
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because:

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
