### PR TITLE
docs: generate 1.12.3 release notes

### DIFF
--- a/docs/release-notes/1.12.3.md
+++ b/docs/release-notes/1.12.3.md
@@ -1,0 +1,17 @@
+(v1.12.3)=
+### 1.12.3 {small}`2026-07-24`
+
+#### Documentation
+
+- Document that {func}`~scanpy.pp.scale` computes variance/std with Bessel's correction (`ddof=1`) {smaller}`A McKenna` ({pr}`4196`)
+
+#### Bug fixes
+
+- Fix {func}`scanpy.get.aggregate` on `dask` arrays when `func` is a list containing `count_nonzero` or `sum` {smaller}`Z Boldyga` ({pr}`4192`)
+- Fix {func}`~scanpy.tl.ingest` PCA projection to center query data with the reference mean {smaller}`S Dicks` ({pr}`4208`)
+
+#### Performance
+
+- Speed up {func}`scanpy.tl.rank_genes_groups` `vs_rest` statistics via a single {func}`scanpy.get.aggregate` pass with [Chan's][] cancellation-free leave-one-out variance {smaller}`Z Boldyga`
+
+  [Chan's]: https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm ({pr}`4204`)

--- a/docs/release-notes/4192.fix.md
+++ b/docs/release-notes/4192.fix.md
@@ -1,1 +1,0 @@
-Fix {func}`scanpy.get.aggregate` on `dask` arrays when `func` is a list containing `count_nonzero` or `sum` {smaller}`Z Boldyga`

--- a/docs/release-notes/4196.docs.md
+++ b/docs/release-notes/4196.docs.md
@@ -1,1 +1,0 @@
-Document that {func}`~scanpy.pp.scale` computes variance/std with Bessel's correction (`ddof=1`) {smaller}`A McKenna`

--- a/docs/release-notes/4204.perf.md
+++ b/docs/release-notes/4204.perf.md
@@ -1,3 +1,0 @@
-Speed up {func}`scanpy.tl.rank_genes_groups` `vs_rest` statistics via a single {func}`scanpy.get.aggregate` pass with [Chan's][] cancellation-free leave-one-out variance {smaller}`Z Boldyga`
-
-[Chan's]: https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Parallel_algorithm

--- a/docs/release-notes/4208.fix.md
+++ b/docs/release-notes/4208.fix.md
@@ -1,1 +1,0 @@
-Fix {func}`~scanpy.tl.ingest` PCA projection to center query data with the reference mean {smaller}`S Dicks`


### PR DESCRIPTION
- [x] Release notes not necessary because: compiles release notes

@meeseeksdev backport to main