### PR TITLE
Backport PR #4260 on branch 1.12.x (fix: allow scrublet to deal with dublicated obs_names)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@
 
 # Environment management
 /Pipfile
-/Pipfile.lock
+/*.lock
 /requirements*.lock
 
 # always-ignore extensions

--- a/docs/release-notes/4260.fix.md
+++ b/docs/release-notes/4260.fix.md
@@ -1,0 +1,1 @@
+Fix {func}`~scanpy.pp.scrublet` failing with non-unique {attr}`~anndata.AnnData.obs_names`, and with cells dropped by its internal filtering when `batch_key` is used {smaller}`P Angerer`

--- a/src/scanpy/preprocessing/_scrublet/__init__.py
+++ b/src/scanpy/preprocessing/_scrublet/__init__.py
@@ -193,6 +193,10 @@ def scrublet(  # noqa: PLR0913
     start = logg.info("Running Scrublet")
 
     adata_obs = adata.copy()
+    # `adata.obs_names` may contain duplicates, and cells may get filtered out below,
+    # so use unique positional labels to map results back onto `adata` unambiguously.
+    positions = pd.RangeIndex(adata.n_obs).astype(str)
+    adata_obs.obs_names = positions
 
     def _run_scrublet(ad_obs: AnnData, ad_sim: AnnData | None = None):
         # With no adata_sim we assume the regular use case, starting with raw
@@ -278,7 +282,7 @@ def scrublet(  # noqa: PLR0913
         )
 
         # Now reset the obs to get the scrublet scores
-        adata.obs = scrubbed_obs.loc[adata.obs_names.values]
+        adata.obs = scrubbed_obs.reindex(positions).set_axis(adata.obs_names)
 
         # Save the .uns from each batch separately
         adata.uns["scrublet"] = {}
@@ -292,10 +296,11 @@ def scrublet(  # noqa: PLR0913
 
     else:
         scrubbed = _run_scrublet(adata_obs, adata_sim)
+        scrubbed_obs = scrubbed["obs"].reindex(positions)
 
         # Copy outcomes to input object from our processed version
-        adata.obs["doublet_score"] = scrubbed["obs"]["doublet_score"]
-        adata.obs["predicted_doublet"] = scrubbed["obs"]["predicted_doublet"]
+        adata.obs["doublet_score"] = scrubbed_obs["doublet_score"].to_numpy()
+        adata.obs["predicted_doublet"] = scrubbed_obs["predicted_doublet"].to_numpy()
         adata.uns["scrublet"] = scrubbed["uns"]
 
     logg.info("    Scrublet finished", time=start)

--- a/tests/test_scrublet.py
+++ b/tests/test_scrublet.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import numpy as np
 import pandas as pd
@@ -16,6 +16,8 @@ from testing.scanpy._pytest.marks import needs
 if TYPE_CHECKING:
     from collections.abc import Callable
     from typing import Any
+
+    from scanpy._compat import CSBase
 
 pytestmark = [needs.skimage]
 
@@ -86,6 +88,59 @@ def test_scrublet_batched():
     merged = concat(split)
 
     pd.testing.assert_frame_equal(adata.obs[merged.obs.columns], merged.obs)
+
+
+def _n_genes(adata: AnnData) -> np.ndarray:
+    """`n_genes` as Scrublet’s internal preprocessing computes it."""
+    adata = adata.copy()
+    sc.pp.filter_genes(adata, min_cells=3)
+    sc.pp.filter_cells(adata, min_genes=3)
+    return adata.obs["n_genes"].to_numpy()
+
+
+@pytest.mark.filterwarnings("ignore:Observation names are not unique:UserWarning")
+@pytest.mark.parametrize("batch_key", [None, "batch"], ids=["unbatched", "batched"])
+def test_scrublet_duplicate_obs_names(batch_key: str | None):
+    """Duplicate `obs_names` must not break mapping results back (see #4098)."""
+    adata = pbmc200()
+    adata.obs["batch"] = 100 * ["a"] + 100 * ["b"]
+    # the batches now consist of different cells sharing the same names
+    obs_names = [*adata.obs_names[:100]] * 2
+    adata.obs_names = obs_names
+    assert not adata.obs_names.is_unique
+
+    sc.pp.scrublet(adata, use_approx_neighbors=False, batch_key=batch_key)
+
+    assert_array_equal(adata.obs_names, obs_names)  # left untouched
+    assert adata.obs["doublet_score"].notna().all()
+    assert adata.obs["predicted_doublet"].dtype == bool
+    if batch_key is not None:
+        # The batched path rebuilds all of `.obs`, so check that the rows line up.
+        # Use `n_genes`: unlike the scores, it’s reproducible across runs.
+        expected = np.concatenate([
+            _n_genes(adata[adata.obs["batch"] == batch]) for batch in "ab"
+        ])
+        assert_array_equal(adata.obs["n_genes"], expected)
+
+
+@pytest.mark.parametrize("batch_key", [None, "batch"], ids=["unbatched", "batched"])
+def test_scrublet_filtered_cells(batch_key: str | None):
+    """Cells dropped by Scrublet’s internal filtering get missing scores, not an error."""
+    adata = pbmc200()
+    adata.obs["batch"] = 100 * ["a"] + 100 * ["b"]
+    # make these too sparse to survive `pp.filter_cells(min_genes=3)`, one per batch
+    dropped = [5, 105]
+    x = cast("CSBase", adata.X).tolil()
+    x[dropped, :] = 0
+    adata.X = x.tocsr()
+
+    sc.pp.scrublet(adata, use_approx_neighbors=False, batch_key=batch_key)
+
+    assert_array_equal(
+        np.flatnonzero(adata.obs["doublet_score"].isna()),
+        dropped,
+    )
+    assert adata.obs["predicted_doublet"].isna().sum() == len(dropped)
 
 
 def _preprocess_for_scrublet(adata: AnnData) -> AnnData:


### PR DESCRIPTION
Backport of #4260 to `1.12.x`