### PR TITLE
chore: use frozendict on 3.15

### DIFF
--- a/docs/extensions/myst_ignore_mime_types.py
+++ b/docs/extensions/myst_ignore_mime_types.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import sys
 from importlib.abc import MetaPathFinder
 from importlib.metadata import Distribution, EntryPoint, EntryPoints
-from types import MappingProxyType
 from typing import TYPE_CHECKING, override
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 from myst_nb.core.render import MimeRenderPlugin
 from sphinx.util.typing import ExtensionMetadata
@@ -38,7 +40,7 @@ class _Ignore(MimeRenderPlugin):
 
 
 class _IgnoreMimeDist(Distribution):
-    metadata = MappingProxyType(dict(Name=__name__, Version="0.0.0"))
+    metadata = frozendict(dict(Name=__name__, Version="0.0.0"))
 
     @override
     def read_text(self, filename: str) -> str | None:

--- a/src/scanpy/experimental/pp/_normalization.py
+++ b/src/scanpy/experimental/pp/_normalization.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from types import MappingProxyType
+import sys
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 from anndata import AnnData
@@ -172,7 +175,7 @@ def normalize_pearson_residuals_pca(
     clip: float | None = None,
     n_comps: int | None = 50,
     rng: SeedLike | RNGLike | None = None,
-    kwargs_pca: Mapping[str, Any] = MappingProxyType({}),
+    kwargs_pca: Mapping[str, Any] = frozendict({}),
     mask_var: np.ndarray | str | Default | None = Default(
         "adata.var.get('highly_variable')"
     ),

--- a/src/scanpy/experimental/pp/_recipes.py
+++ b/src/scanpy/experimental/pp/_recipes.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from types import MappingProxyType
+import sys
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 
@@ -48,7 +51,7 @@ def recipe_pearson_residuals(  # noqa: PLR0913
     chunksize: int = 1000,
     n_comps: int | None = 50,
     rng: SeedLike | RNGLike | None = None,
-    kwargs_pca: Mapping[str, Any] = MappingProxyType({}),
+    kwargs_pca: Mapping[str, Any] = frozendict({}),
     check_values: bool = True,
     inplace: bool = True,
 ) -> tuple[AnnData, pd.DataFrame] | None:

--- a/src/scanpy/neighbors/__init__.py
+++ b/src/scanpy/neighbors/__init__.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import contextlib
+import sys
 from inspect import signature
 from textwrap import indent
-from types import MappingProxyType
 from typing import TYPE_CHECKING, NamedTuple, TypedDict
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 import scipy
@@ -96,7 +99,7 @@ def neighbors(  # noqa: PLR0913
     method: _Method = "umap",
     transformer: KnnTransformerLike | _KnownTransformer | None = None,
     metric: _Metric | _MetricFn | None = None,
-    metric_kwds: Mapping[str, Any] = MappingProxyType({}),
+    metric_kwds: Mapping[str, Any] = frozendict({}),
     rng: SeedLike | RNGLike | None = None,
     key_added: str | None = None,
     copy: bool = False,
@@ -585,7 +588,7 @@ class Neighbors:
         method: _Method | None = "umap",
         transformer: KnnTransformerLike | _KnownTransformer | None = None,
         metric: _Metric | _MetricFn = "euclidean",
-        metric_kwds: Mapping[str, Any] = MappingProxyType({}),
+        metric_kwds: Mapping[str, Any] = frozendict({}),
         rng: SeedLike | RNGLike | None = None,
     ) -> None:
         """Compute distances and connectivities of neighbors.

--- a/src/scanpy/plotting/_v2/_core.py
+++ b/src/scanpy/plotting/_v2/_core.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import inspect
+import sys
 from collections.abc import Collection
 from functools import partial, reduce, update_wrapper
-from types import MappingProxyType
 from typing import TYPE_CHECKING, assert_never, overload
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import holoviews as hv
 import numpy as np
@@ -583,9 +586,7 @@ def dotplot(
     /,
     group_by: AdDim,
     *,
-    funcs: Mapping[str, AggType] = MappingProxyType(
-        dict(color="mean", size="count_nonzero")
-    ),
+    funcs: Mapping[str, AggType] = frozendict(dict(color="mean", size="count_nonzero")),
 ) -> hv.Points:
     """Dot plot of marker expression per group.
 

--- a/src/scanpy/plotting/legacy/_tools/paga.py
+++ b/src/scanpy/plotting/legacy/_tools/paga.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import sys
 import warnings
 from collections.abc import Collection, Mapping, Sequence
 from contextlib import nullcontext
 from pathlib import Path
-from types import MappingProxyType
 from typing import TYPE_CHECKING, TypedDict
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 import pandas as pd
@@ -210,7 +213,7 @@ def _compute_pos(  # noqa: PLR0912
     init_pos: np.ndarray | None,
     adj_tree,
     root: int,
-    layout_kwds: Mapping[str, Any] = MappingProxyType({}),
+    layout_kwds: Mapping[str, Any] = frozendict({}),
 ) -> NDArray[np.float64]:
     import random
 
@@ -354,7 +357,7 @@ def paga(  # noqa: PLR0912, PLR0913, PLR0915
     threshold: float | None = None,
     color: str | Mapping[str | int, Mapping[Any, float]] | None = None,
     layout: _Layout | None = None,
-    layout_kwds: Mapping[str, Any] = MappingProxyType({}),
+    layout_kwds: Mapping[str, Any] = frozendict({}),
     init_pos: np.ndarray | None = None,
     root: int | str | Sequence[int] | None = 0,
     labels: str | Sequence[str] | Mapping[str, str] | None = None,
@@ -365,7 +368,7 @@ def paga(  # noqa: PLR0912, PLR0913, PLR0915
     fontsize: int | None = None,
     fontweight: str = "bold",
     fontoutline: int | None = None,
-    text_kwds: Mapping[str, Any] = MappingProxyType({}),
+    text_kwds: Mapping[str, Any] = frozendict({}),
     node_size_scale: float = 1.0,
     node_size_power: float = 0.5,
     edge_width_scale: float = 1.0,
@@ -380,7 +383,7 @@ def paga(  # noqa: PLR0912, PLR0913, PLR0915
     cmap: str | Colormap | None = None,
     cax: Axes | None = None,
     colorbar=None,  # TODO: this seems to be unused
-    cb_kwds: Mapping[str, Any] = MappingProxyType({}),
+    cb_kwds: Mapping[str, Any] = frozendict({}),
     frameon: bool | None = None,
     add_pos: bool = True,
     export_to_gexf: bool = False,
@@ -721,7 +724,7 @@ def _paga_graph(  # noqa: PLR0912, PLR0913, PLR0915
     fontsize=None,
     fontweight=None,
     fontoutline=None,
-    text_kwds: Mapping[str, Any] = MappingProxyType({}),
+    text_kwds: Mapping[str, Any] = frozendict({}),
     node_size_scale=1.0,
     node_size_power=0.5,
     edge_width_scale=1.0,
@@ -735,7 +738,7 @@ def _paga_graph(  # noqa: PLR0912, PLR0913, PLR0915
     export_to_gexf=False,
     colorbar=None,
     use_raw=True,
-    cb_kwds: Mapping[str, Any] = MappingProxyType({}),
+    cb_kwds: Mapping[str, Any] = frozendict({}),
     single_component=False,
     arrowsize=30,
 ):
@@ -1070,7 +1073,7 @@ def paga_path(  # noqa: PLR0912, PLR0913, PLR0915
     use_raw: bool = True,
     annotations: Sequence[str] = ("dpt_pseudotime",),
     color_map: str | Colormap | None = None,
-    color_maps_annotations: Mapping[str, str | Colormap] = MappingProxyType(
+    color_maps_annotations: Mapping[str, str | Colormap] = frozendict(
         dict(dpt_pseudotime="Greys")
     ),
     palette_groups: Sequence[str] | None = None,

--- a/src/scanpy/queries/_queries.py
+++ b/src/scanpy/queries/_queries.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterable
 from functools import singledispatch
-from types import MappingProxyType
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 from anndata import AnnData
 
@@ -215,7 +218,7 @@ def enrich(
     container: Iterable[str] | Mapping[str, Iterable[str]],
     *,
     org: str = "hsapiens",
-    gprofiler_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    gprofiler_kwargs: Mapping[str, Any] = frozendict({}),
 ) -> pd.DataFrame:
     """Get enrichment for DE results.
 
@@ -303,7 +306,7 @@ def _enrich_anndata(
     log2fc_min: float | None = None,
     log2fc_max: float | None = None,
     gene_symbols: str | None = None,
-    gprofiler_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    gprofiler_kwargs: Mapping[str, Any] = frozendict({}),
 ) -> pd.DataFrame:
     de = rank_genes_groups_df(
         adata,

--- a/src/scanpy/tools/_louvain.py
+++ b/src/scanpy/tools/_louvain.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
-from types import MappingProxyType
+import sys
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 import pandas as pd
@@ -58,7 +61,7 @@ def louvain(  # noqa: PLR0912, PLR0913, PLR0915
     directed: bool = True,
     use_weights: bool = False,
     partition_type: type[MutableVertexPartition] | None = None,
-    partition_kwargs: Mapping[str, Any] = MappingProxyType({}),
+    partition_kwargs: Mapping[str, Any] = frozendict({}),
     neighbors_key: str | None = None,
     obsp: str | None = None,
     copy: bool = False,

--- a/src/scanpy/tools/_sim.py
+++ b/src/scanpy/tools/_sim.py
@@ -13,9 +13,12 @@ Beta Version. The code will be reorganized soon.
 from __future__ import annotations
 
 import itertools
+import sys
 from pathlib import Path
-from types import MappingProxyType
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict
 
 import numpy as np
 import scipy as sp
@@ -294,10 +297,10 @@ def write_data(  # noqa: PLR0912, PLR0913
     *,
     append=False,
     header="",
-    varNames: Mapping[str, int] = MappingProxyType({}),
+    varNames: Mapping[str, int] = frozendict({}),
     Adj: np.ndarray | None = None,
     Coupl: np.ndarray | None = None,
-    boolRules: Mapping[str, str] = MappingProxyType({}),
+    boolRules: Mapping[str, str] = frozendict({}),
     model="",
     modelType="",
     invTimeStep=1,
@@ -404,7 +407,7 @@ class GRNsim:
         show=False,
         verbosity=0,
         Coupl=None,
-        params=MappingProxyType({}),
+        params=frozendict({}),
     ):
         """Initialize.
 

--- a/src/testing/scanpy/_helpers/__init__.py
+++ b/src/testing/scanpy/_helpers/__init__.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import sys
 import warnings
 from contextlib import contextmanager
 from importlib.util import find_spec
 from itertools import permutations
-from types import MappingProxyType
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import numpy as np
 from anndata import AnnData
@@ -98,7 +101,7 @@ def check_rep_results(func, x, *, fields: Iterable[str] = ("layer", "obsm"), **k
 
 
 def _check_check_values_warnings(
-    function, adata: AnnData, expected_warning: str, kwargs=MappingProxyType({})
+    function, adata: AnnData, expected_warning: str, kwargs=frozendict({})
 ):
     """Run `function` on `adata` with provided arguments `kwargs` twice.
 

--- a/src/testing/scanpy/_pytest/__init__.py
+++ b/src/testing/scanpy/_pytest/__init__.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import os
 import sys
 from importlib.util import find_spec
-from types import MappingProxyType
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 15):
+    from types import MappingProxyType as frozendict  # noqa: N813
 
 import pooch
 import pytest
@@ -50,7 +52,7 @@ def original_settings(
     global _original_settings  # noqa: PLW0603
     if _original_settings is None:
         # can’t use `model_dump` here because of https://github.com/pydantic/pydantic/issues/8907
-        _original_settings = MappingProxyType({
+        _original_settings = frozendict({
             s: getattr(sc.settings, s)
             for s in (
                 type(sc.settings).model_fields | type(sc.settings).model_computed_fields


### PR DESCRIPTION
Not adding `__lazy_imports__` yet, will do that once numba actually supports Python 3.15

- [x] [Release notes][] not necessary because: dev only change

[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs
