### PR TITLE
docs: document norm parameter for embedding scatter plots

### DIFF
--- a/docs/release-notes/4297.fix.md
+++ b/docs/release-notes/4297.fix.md
@@ -1,0 +1,1 @@
+Document the `norm` parameter for {func}`~scanpy.pl.embedding` and related scatter plotting functions {smaller}`L Heumos`

--- a/docs/release-notes/4297.fix.md
+++ b/docs/release-notes/4297.fix.md
@@ -1,1 +1,1 @@
-Document the `norm` parameter for {func}`~scanpy.pl.embedding` and related scatter plotting functions {smaller}`L Heumos`
+Document the `norm` parameter for {func}`~scanpy.pl.embedding` and related scatter plotting functions {smaller}`zethson`

--- a/src/scanpy/plotting/legacy/_docs.py
+++ b/src/scanpy/plotting/legacy/_docs.py
@@ -116,7 +116,9 @@ vmax
 vcenter
     The value representing the center of the color scale. Useful for diverging colormaps.
     The format is the same as for `vmin`.
-    Example: ``sc.pl.umap(adata, color='TREM2', vcenter='p50', cmap='RdBu_r')``\
+    Example: ``sc.pl.umap(adata, color='TREM2', vcenter='p50', cmap='RdBu_r')``
+norm
+    Custom color normalization object from matplotlib. See :ref:`colormapnorms` for details.\
 """
 
 doc_vboundnorm = """\


### PR DESCRIPTION
## Summary
- `norm` was missing from the docstrings of `sc.pl.embedding` and related functions (`umap`, `pca`, `tsne`, `embedding_density`, ...) even though it's an accepted parameter, since `doc_vbound_percentile` (used by these functions) didn't document it while the separate `doc_vboundnorm` (used elsewhere) did.
- Added the `norm` entry to `doc_vbound_percentile`.

Closes #2116