### PR TITLE
docs: generate 1.12.4 release notes

### DIFF
--- a/docs/release-notes/1.12.4.md
+++ b/docs/release-notes/1.12.4.md
@@ -1,0 +1,10 @@
+(v1.12.4)=
+### 1.12.4 {small}`2026-08-27`
+
+#### Bug fixes
+
+- Fix {func}`~scanpy.pp.normalize_total` raising `UnboundLocalError` for `CSR` matrices when `exclude_highly_expressed=False` and Numba JIT is disabled {smaller}`S Dicks` ({pr}`4231`)
+- Keep list-based boolean categorical colors stable after subsetting by storing colors for both boolean values. ({pr}`4252`)
+- Fix {func}`~scanpy.pp.normalize_total` computing a different `target_sum` for sparse and dense input when `target_sum=None`, so matrices containing zero-count cells normalized inconsistently {smaller}`JOhnsonKC201` ({pr}`4256`)
+- Fix {func}`~scanpy.pp.scrublet` failing with non-unique {attr}`~anndata.AnnData.obs_names`, and with cells dropped by its internal filtering when `batch_key` is used {smaller}`P Angerer` ({pr}`4260`)
+- Make {func}`~scanpy.tl.sim` raise instead of silently returning a truncated data matrix when it can’t simulate the requested number of branching realizations {smaller}`P Angerer` ({pr}`4263`)

--- a/docs/release-notes/4231.fix.md
+++ b/docs/release-notes/4231.fix.md
@@ -1,1 +1,0 @@
-Fix {func}`~scanpy.pp.normalize_total` raising `UnboundLocalError` for `CSR` matrices when `exclude_highly_expressed=False` and Numba JIT is disabled {smaller}`S Dicks`

--- a/docs/release-notes/4252.fix.md
+++ b/docs/release-notes/4252.fix.md
@@ -1,1 +1,0 @@
-Keep list-based boolean categorical colors stable after subsetting by storing colors for both boolean values.

--- a/docs/release-notes/4256.fix.md
+++ b/docs/release-notes/4256.fix.md
@@ -1,1 +1,0 @@
-Fix {func}`~scanpy.pp.normalize_total` computing a different `target_sum` for sparse and dense input when `target_sum=None`, so matrices containing zero-count cells normalized inconsistently {smaller}`JOhnsonKC201`

--- a/docs/release-notes/4260.fix.md
+++ b/docs/release-notes/4260.fix.md
@@ -1,1 +1,0 @@
-Fix {func}`~scanpy.pp.scrublet` failing with non-unique {attr}`~anndata.AnnData.obs_names`, and with cells dropped by its internal filtering when `batch_key` is used {smaller}`P Angerer`

--- a/docs/release-notes/4263.fix.md
+++ b/docs/release-notes/4263.fix.md
@@ -1,1 +1,0 @@
-Make {func}`~scanpy.tl.sim` raise instead of silently returning a truncated data matrix when it can’t simulate the requested number of branching realizations {smaller}`P Angerer`


### PR DESCRIPTION
- [x] Release notes not necessary because: compiles release notes

@meeseeksdev backport to main