### PR TITLE
docs: generate 1.13.0a2 release notes

### DIFF
--- a/docs/release-notes/1.13.0a2.md
+++ b/docs/release-notes/1.13.0a2.md
@@ -1,0 +1,24 @@
+(v1.13.0a2)=
+### 1.13.0a2 {small}`2026-08-28`
+
+#### Miscellaneous changes
+
+- Deprecate {mod}`scanpy.external` and each of its functions. Each function’s deprecation message names its replacement: an upstream package, a successor project, or the scanpy function it will move to. See also the [scverse ecosystem](https://scverse.org/packages/#ecosystem) {smaller}`P Angerer` ({pr}`3645`)
+- Create {mod}`scanpy.io` and move `scanpy.{read*,write*}` into it.
+  Deprecate `scanpy.read_loom` and `sc.external.exporting.*` {smaller}`P Angerer` ({pr}`4299`)
+- Fetch the bundled datasets through {func}`scverse_misc.datasets.fetch`, adding hash verification, retries, and fall back to their pre-S3 upstream URLs.
+  {func}`~scanpy.io.read_10x_mtx` and friends now use `pooch` for downloading, also gaining retries {smaller}`P Angerer` ({pr}`4310`)
+
+#### Features
+
+- Fix multi-key {func}`scanpy.pp.harmony_integrate`, remove its legacy correction path, and speed up large integrations {smaller}`S Dicks` ({pr}`4232`)
+- Add exact raw counts for {func}`~scanpy.datasets.pbmc68k_reduced` and clarify its docstring on how the dataset was derived {smaller}`P Angerer` ({pr}`4269`)
+- Move {func}`scanpy.external.pp.hashsolo` into scanpy’s main API as {func}`scanpy.pp.hashsolo` and deprecate the old location.
+  The new function takes {mod}`anndata.acc` references, so the hashing counts can live in {attr}`~anndata.AnnData.obs`, in the data matrix (e.g. `A.X[:, ["Hash1", "Hash2"]]`), or all together in {attr}`~anndata.AnnData.obsm` (e.g. `A.obsm["hto"]`),
+  and writes its results to `.obs[key_added]` and `.obsm[key_added]` instead of six unnamespaced `.obs` columns {smaller}`P Angerer` ({pr}`4303`)
+- Add {func}`scanpy.pp.bbknn`, a native implementation of batch balanced kNN :cite:p:`Polanski2019` {smaller}`S Dicks` ({pr}`4306`)
+- The `use_rep` parameter of {func}`scanpy.pp.neighbors`, {func}`scanpy.tl.tsne`, and {func}`scanpy.tl.dendrogram` now accepts {mod}`anndata.acc` accessors such as `A.X`, `A.layers["scaled"]`, or `A.obsm["pca"]`, and resolves strings into them if {attr}`scanpy.settings.preset` is {attr}`~scanpy.Preset.ScanpyV2Preview` {smaller}`P Angerer` ({pr}`4315`)
+
+#### Performance
+
+- Derive unset {func}`scanpy.pp.harmony_integrate` stopping rules from `flavor`, speeding up `harmony2` considerably: it now follows the Harmony2 defaults, while `harmony1` still follows harmony-pytorch {smaller}`S Dicks` ({pr}`4290`)

--- a/docs/release-notes/3645.chore.md
+++ b/docs/release-notes/3645.chore.md
@@ -1,1 +1,0 @@
-Deprecate {mod}`scanpy.external` and each of its functions. Each function’s deprecation message names its replacement: an upstream package, a successor project, or the scanpy function it will move to. See also the [scverse ecosystem](https://scverse.org/packages/#ecosystem) {smaller}`P Angerer`

--- a/docs/release-notes/4232.feat.md
+++ b/docs/release-notes/4232.feat.md
@@ -1,1 +1,0 @@
-Fix multi-key {func}`scanpy.pp.harmony_integrate`, remove its legacy correction path, and speed up large integrations {smaller}`S Dicks`

--- a/docs/release-notes/4269.feat.md
+++ b/docs/release-notes/4269.feat.md
@@ -1,1 +1,0 @@
-Add exact raw counts for {func}`~scanpy.datasets.pbmc68k_reduced` and clarify its docstring on how the dataset was derived {smaller}`P Angerer`

--- a/docs/release-notes/4290.perf.md
+++ b/docs/release-notes/4290.perf.md
@@ -1,1 +1,0 @@
-Derive unset {func}`scanpy.pp.harmony_integrate` stopping rules from `flavor`, speeding up `harmony2` considerably: it now follows the Harmony2 defaults, while `harmony1` still follows harmony-pytorch {smaller}`S Dicks`

--- a/docs/release-notes/4299.chore.md
+++ b/docs/release-notes/4299.chore.md
@@ -1,2 +1,0 @@
-Create {mod}`scanpy.io` and move `scanpy.{read*,write*}` into it.
-Deprecate `scanpy.read_loom` and `sc.external.exporting.*` {smaller}`P Angerer`

--- a/docs/release-notes/4303.feat.md
+++ b/docs/release-notes/4303.feat.md
@@ -1,3 +1,0 @@
-Move {func}`scanpy.external.pp.hashsolo` into scanpy’s main API as {func}`scanpy.pp.hashsolo` and deprecate the old location.
-The new function takes {mod}`anndata.acc` references, so the hashing counts can live in {attr}`~anndata.AnnData.obs`, in the data matrix (e.g. `A.X[:, ["Hash1", "Hash2"]]`), or all together in {attr}`~anndata.AnnData.obsm` (e.g. `A.obsm["hto"]`),
-and writes its results to `.obs[key_added]` and `.obsm[key_added]` instead of six unnamespaced `.obs` columns {smaller}`P Angerer`

--- a/docs/release-notes/4306.feat.md
+++ b/docs/release-notes/4306.feat.md
@@ -1,1 +1,0 @@
-Add {func}`scanpy.pp.bbknn`, a native implementation of batch balanced kNN :cite:p:`Polanski2019` {smaller}`S Dicks`

--- a/docs/release-notes/4310.chore.md
+++ b/docs/release-notes/4310.chore.md
@@ -1,2 +1,0 @@
-Fetch the bundled datasets through {func}`scverse_misc.datasets.fetch`, adding hash verification, retries, and fall back to their pre-S3 upstream URLs.
-{func}`~scanpy.io.read_10x_mtx` and friends now use `pooch` for downloading, also gaining retries {smaller}`P Angerer`

--- a/docs/release-notes/4315.feat.md
+++ b/docs/release-notes/4315.feat.md
@@ -1,1 +1,0 @@
-The `use_rep` parameter of {func}`scanpy.pp.neighbors`, {func}`scanpy.tl.tsne`, and {func}`scanpy.tl.dendrogram` now accepts {mod}`anndata.acc` accessors such as `A.X`, `A.layers["scaled"]`, or `A.obsm["pca"]`, and resolves strings into them if {attr}`scanpy.settings.preset` is {attr}`~scanpy.Preset.ScanpyV2Preview` {smaller}`P Angerer`


### PR DESCRIPTION
- [x] Release notes not necessary because: compiles release notes