### PR TITLE
fix: handle scalar string groups in ranked-gene plots

### DIFF
--- a/src/scanpy/plotting/legacy/_tools/__init__.py
+++ b/src/scanpy/plotting/legacy/_tools/__init__.py
@@ -406,6 +406,8 @@ def rank_genes_groups(  # noqa: PLR0912, PLR0913, PLR0915
 
     reference = str(adata.uns[key]["params"]["reference"])
     group_names = adata.uns[key]["names"].dtype.names if groups is None else groups
+    if isinstance(group_names, str):
+        group_names = [group_names]
     # one panel for each group
     # set up the figure
     n_panels_x = min(n_panels_per_row, len(group_names))
@@ -544,6 +546,8 @@ def _rank_genes_groups_plot(  # noqa: PLR0912, PLR0913, PLR0915
     if groupby is None:
         groupby = str(adata.uns[key]["params"]["groupby"])
     group_names = adata.uns[key]["names"].dtype.names if groups is None else groups
+    if isinstance(group_names, str):
+        group_names = [group_names]
 
     if var_names is not None:
         if isinstance(var_names, Mapping):

--- a/tests/plotting/legacy/test_plotting.py
+++ b/tests/plotting/legacy/test_plotting.py
@@ -926,6 +926,29 @@ def test_rank_genes_group_axes(plot_cmp):
     plt.close()
 
 
+@pytest.mark.parametrize(
+    ("plot_func", "kwargs"),
+    [
+        pytest.param(sc.pl.rank_genes_groups, {}, id="rank_genes_groups"),
+        pytest.param(
+            sc.pl.rank_genes_groups_dotplot,
+            {"dendrogram": False},
+            id="shared-rank-genes-groups-plots",
+        ),
+    ],
+)
+def test_rank_genes_groups_single_group_string(
+    plot_func: Callable[..., Any], kwargs: dict[str, Any]
+) -> None:
+    adata = pbmc68k_reduced()
+    sc.tl.rank_genes_groups(adata, "bulk_labels")
+
+    result = plot_func(adata, groups="Dendritic", n_genes=2, show=False, **kwargs)
+
+    assert result is not None
+    plt.close("all")
+
+
 @pytest.fixture(scope="session")
 def gene_symbols_adatas_session() -> tuple[AnnData, AnnData]:
     """Create two anndata objects which are equivalent except for var_names.


### PR DESCRIPTION
<!--
Thanks for opening a PR to scanpy!
Please be sure to follow the guidelines in our contribution guide (https://scanpy.readthedocs.io/en/latest/dev/index.html) to familiarize yourself with our workflow and speed up review.
-->

## Description

`groups` accepts either a single string or a sequence of strings in the ranked-gene plotting APIs. However, `sc.pl.rank_genes_groups` and the shared plotting path iterated a scalar string character by character.

For example, passing `groups="Dendritic"` attempted to look up the group `"D"` and raised an error instead of plotting `"Dendritic"`.

This PR normalizes scalar string group names to one-element lists before iteration, consistent with the existing behavior in `sc.pl.rank_genes_groups_violin` and `sc.get.rank_genes_groups_df`.

<!-- Please check (“- [x]”) and fill in the following boxes -->
- [ ] Closes # — no existing issue
- [x] [Tests][] included: added regression coverage for both the standalone and shared plotting paths
<!-- Only check the following box if you did not include release notes -->
- [ ] [Release notes][] not necessary because: it's just a simple fix.

## Tests

- add related test.

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs