### PR TITLE
docs: document the `adata.uns['hvg']` output of `pp.highly_variable_genes`

### DIFF
--- a/src/scanpy/preprocessing/_highly_variable_genes.py
+++ b/src/scanpy/preprocessing/_highly_variable_genes.py
@@ -757,6 +757,10 @@ def highly_variable_genes(  # noqa: PLR0913
         If `batch_key` is given, this denotes in how many batches genes are detected as HVG
     `adata.var['highly_variable_intersection']` : :class:`pandas.Series` (dtype `bool`)
         If `batch_key` is given, this denotes the genes that are highly variable in all batches
+    `adata.uns['hvg']` : :class:`dict`
+        Dictionary with a `'flavor'` entry recording the `flavor` used.
+        :func:`scanpy.pl.highly_variable_genes` reads it to decide whether to plot
+        dispersions or variances
 
     """
     if isinstance(flavor, Default):


### PR DESCRIPTION
- [x] Closes #4341
- [x] [Tests][] included or not required because: docstring-only change, no behaviour is added or modified
<!-- Only check the following box if you did not include release notes -->
- [x] [Release notes][] not necessary because: documentation-only change to an existing docstring

[tests]: https://scanpy.readthedocs.io/en/stable/dev/testing.html#writing-tests
[release notes]: https://scanpy.readthedocs.io/en/stable/dev/documentation.html#adding-to-the-docs

---

`pp.highly_variable_genes` writes `adata.uns['hvg'] = {'flavor': flavor}` when `inplace=True`, but the `Returns` section documents only the `adata.var` columns. `pl.highly_variable_genes` reads that entry to pick which metrics to plot, so deleting it raises `KeyError: 'hvg'`.

Adds one entry to `Returns`. No behaviour change.
